### PR TITLE
adding a complete benchmark for embedding

### DIFF
--- a/MC/run/PWGHF/calc_embedding_speedup.sh
+++ b/MC/run/PWGHF/calc_embedding_speedup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# calculate embedding gain
+# for the moment not considering reconstruction
+# (assumes prior running of embedding_benchmark.sh)
+BKGSIMTIME=$(awk '//{print $2}' ${PWD}/bkgsim.log_time)
+SGNTIME=$(awk 'BEGIN{c=0} //{c+=$2} END {print c}' sgnsim*.log_time)
+DIGITIME=$(awk 'BEGIN{c=0} //{c+=$2} END {print c}' *digi*.log_time)
+
+# GAIN = (NTIMEFRAME * BKGSIMTIME + SGNTIME + DIGITIME) / (BKGSIMTIME + SGNTIME + DIGITIME)
+awk -v BT=${BKGSIMTIME} -v ST=${SGNTIME} -v DT=${DIGITIME} -v NTF=${NTIMEFRAMES} 'END {print "SPEEDUP="(NTF*BT + ST + DT)/(BT + ST + DT)}' < /dev/null

--- a/MC/run/PWGHF/embedding_benchmark.sh
+++ b/MC/run/PWGHF/embedding_benchmark.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+#
+# A example workflow doing signal-background embedding, meant
+# to study embedding speedups.
+# Background events are reused across timeframes. 
+# 
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh
+
+# ----------- START ACTUAL JOB  ----------------------------- 
+
+NSIGEVENTS=${NSIGEVENTS:-20}
+NTIMEFRAMES=${NTIMEFRAMES:-5}
+NWORKERS=${NWORKERS:-8}
+NBKGEVENTS=${NBKGEVENTS:-20}
+MODULES="--skipModules ZDC"
+
+
+# background task -------
+taskwrapper bkgsim.log o2-sim -j ${NWORKERS} -n ${NBKGEVENTS} -g pythia8hi ${MODULES} -o bkg \
+            --configFile ${O2DPG_ROOT}/MC/config/common/ini/basic.ini
+
+# loop over timeframes
+for tf in `seq 1 ${NTIMEFRAMES}`; do
+
+  RNDSEED=0
+  PTHATMIN=0.  # [default = 0]
+  PTHATMAX=-1. # [default = -1]
+
+  # produce the signal configuration
+  ${O2DPG_ROOT}/MC/config/common/pythia8/utils/mkpy8cfg.py \
+    	     --output=pythia8.cfg \
+	     --seed=${RNDSEED} \
+	     --idA=2212 \
+	     --idB=2212 \
+	     --eCM=13000. \
+	     --process=ccbar \
+	     --ptHatMin=${PTHATMIN} \
+	     --ptHatMax=${PTHATMAX}
+ 
+  # simulate the signals for this timeframe
+  taskwrapper sgnsim_${tf}.log o2-sim ${MODULES} -n ${NSIGEVENTS} -e TGeant3 -j ${NWORKERS} -g extgen \
+       --configFile ${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF.ini                                 \
+       --configKeyValues "GeneratorPythia8.config=pythia8.cfg"                                        \
+       --embedIntoFile bkg_Kine.root                                                                  \
+       -o sgn${tf}
+
+  CONTEXTFILE=collisioncontext_${tf}.root
+
+  cp sgn${tf}_grp.root o2sim_grp.root
+
+  # now run digitization phase
+  echo "Running digitization for $intRate kHz interaction rate"
+  
+  gloOpt="-b --run --shm-segment-size 10000000000" # TODO: decide shared mem based on event number
+
+  taskwrapper tpcdigi_${tf}.log o2-sim-digitizer-workflow $gloOpt -n ${NSIGEVENTS} --sims bkg,sgn${tf} --onlyDet TPC --interactionRate 50000 --tpc-lanes ${NWORKERS} --outcontext ${CONTEXTFILE}
+  # --> a) random seeding
+  # --> b) propagation of collisioncontext and application in other digitization steps
+
+  echo "Return status of TPC digitization: $?"
+  taskwrapper trddigi_${tf}.log o2-sim-digitizer-workflow $gloOpt -n ${NSIGEVENTS} --sims bkg,sgn${tf} --onlyDet TRD --interactionRate 50000 --configKeyValues "TRDSimParams.digithreads=10" --incontext ${CONTEXTFILE}
+  echo "Return status of TRD digitization: $?"
+
+  taskwrapper restdigi_${tf}.log o2-sim-digitizer-workflow $gloOpt -n ${NSIGEVENTS} --sims bkg,sgn${tf} --skipDet TRD,TPC,FT0 --interactionRate 50000 --incontext ${CONTEXTFILE}
+  echo "Return status of OTHER digitization: $?"
+
+  taskwrapper tpcreco_${tf}.log o2-tpc-reco-workflow $gloOpt --tpc-digit-reader \"--infile tpcdigits.root\" --input-type digits --output-type clusters,tracks  --tpc-track-writer \"--treename events --track-branch-name Tracks --trackmc-branch-name TracksMCTruth\" --configKeyValues \"GPU_global.continuousMaxTimeBin=10000\"
+  echo "Return status of tpcreco: $?"
+
+  # we need to move these products somewhere
+  mv tpctracks.root tpctracks_${tf}.root
+  mv tpcdigits.root tpcdigits_${tf}.root
+done
+
+# We need to exit for the ALIEN JOB HANDLER!
+exit 0


### PR DESCRIPTION
A PWGHF benchmark for embedding that can be run on the GRID or locally (when ALIEN_PROC_ID is set).

Multiple timeframes can be digitized, each reusing the same background events
with different signal.
The goal is to obtain embedding gain numbers as a function
of the number of timeframes, etc.