### PR TITLE
Update GH action for new release convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         
     - name: Trigger release in jenkins
       run: |
-       echo ${{github.event.release.tag_name}} | grep -e "prod-20[0-9][0-9][0-1][0-9]-[0-9][0-9]"
+       echo ${{github.event.release.tag_name}} | grep -e 'prod-20[0-9][0-9][0-1][0-9]-[0-9][0-9][a-z]\?'
        echo ${{secrets.JENKINS_BOT_PASS}} | kinit ${{secrets.PRINCIPAL}}
        curl -X POST -k --negotiate -u : ${{secrets.API_URL}} -H 'Content-Type: application/x-www-form-urlencoded' -d 'O2DPG_TAG=${{github.event.release.tag_name}}'
        klist


### PR DESCRIPTION
This allows an optional trailing letter on the version, for multiple releases in a day.