### PR TITLE
Some changes on workflow generation

### DIFF
--- a/MC/run/PWGHF/create_embedding_workflow.py
+++ b/MC/run/PWGHF/create_embedding_workflow.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 # we simply delegate to main script with some PWGHF settings
-command='${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13000 -col pp -proc ccbar '
+command='${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13000 -col pp -proc ccbar --embedding '
 
 # and add given user options
 for i in range(1, len(sys.argv)):

--- a/MC/utils/merge_TTrees.C
+++ b/MC/utils/merge_TTrees.C
@@ -1,0 +1,12 @@
+// A helper to "vertically" merge the set of (distinct) branches of 2 trees
+// into a single common (non-friended) tree in a new file.
+//
+// This is using RDataFrame mechanics as suggested by the ROOT team.
+// TODO: generalize to abirtrary list of files.
+void merge_TTrees(std::string f1, std::string f2, std::string treename, std::string outname) {
+  TFile file(f1.c_str(), "OPEN");
+  auto t1=(TTree*)file.Get(treename.c_str());
+  t1->AddFriend(treename.c_str(), f2.c_str());
+  ROOT::RDataFrame df(*t1);
+  df.Snapshot(treename.c_str(), outname.c_str(), ".*");
+}


### PR DESCRIPTION
... Mainly geared to being able to process 100PbPb within 16GB.

 Changes to workflow generator
    
    * Split TPC clusterization into 2 stages
      so that we can fit into 16GB for ~100PbPb.
    * Introduce additional cluster merging step
      to prepare one file for TPC reco
    * Add ROOT macro helper for the merge step
      (to be generalized later)
    * Adjust some memory/cpu resource estimates
      (based on ~100PbPb dataframes)
    * Don't use --rate 1 for TOF reco workflow.
      Now terminates much faster.