### PR TITLE
Do not leak FairMQ socket files

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -938,6 +938,17 @@ class WorkflowExecutor:
     def execute(self):
         psutil.cpu_percent(interval=None)
         os.environ['JOBUTILS_SKIPDONE'] = "ON"
+
+        # we make our own "tmp" folder
+        # where we can put stuff such as tmp socket files etc (for instance DPL FAIR-MQ sockets)
+        # (In case of running within docker/singularity, this may not be so important)
+        if not os.path.isdir("./.tmp"):
+          os.mkdir("./.tmp")
+        if os.environ.get('FAIRMQ_IPC_PREFIX')==None:
+          socketpath = os.getcwd() + "/.tmp"
+          actionlogger.info("Setting FAIRMQ socket path to " + socketpath)
+          os.environ['FAIRMQ_IPC_PREFIX'] = socketpath
+
         # some maintenance / init work
         if args.list_tasks:
           print ('List of tasks in this workflow:')

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -109,12 +109,13 @@ def createTask(name='', needs=[], tf=-1, cwd='./', lab=[], cpu=1, relative_cpu=N
     return { 'name': name, 'cmd':'', 'needs': needs, 'resources': { 'cpu': cpu , 'mem': mem }, 'timeframe' : tf, 'labels' : lab, 'cwd' : cwd }
 
 def getDPL_global_options(bigshm=False,nosmallrate=False):
+   common="-b --run --fairmq-ipc-prefix ${FAIRMQ_IPC_PREFIX:-./} --driver-client-backend ws:// " + ('--rate 1000','')[nosmallrate]
    if args.noIPC!=None:
-      return "-b --run --no-IPC " + ('--rate 1000','')[nosmallrate]
+      return common + " --no-IPC "
    if bigshm:
-      return "-b --run --shm-segment-size ${SHMSIZE:-50000000000} --driver-client-backend ws://" + (' --rate 1000','')[nosmallrate]
+      return common + " --shm-segment-size ${SHMSIZE:-50000000000} "
    else:
-      return "-b --run " + ' --driver-client-backend ws://' + (' --rate 1000','')[nosmallrate]
+      return common
 
 doembedding=True if args.embedding=='True' or args.embedding==True else False
 usebkgcache=args.use_bkg_from!=None


### PR DESCRIPTION
* do not use default /tmp dir for socket files,
  as they may leak and pose a problem in the long run

* offer configurability of fairmq-ipc-prefix

* the pipeline runner set this to a new local .tmp
  folder