### PR TITLE
added cdiff as python8 process option

### DIFF
--- a/MC/config/common/pythia8/utils/mkpy8cfg.py
+++ b/MC/config/common/pythia8/utils/mkpy8cfg.py
@@ -26,7 +26,7 @@ parser.add_argument('--eB', type=float, default='6499.',
 parser.add_argument('--eCM', type=float, default='-1',
                     help='Centre-of-mass energy (careful!, better use beam energy)')
 
-parser.add_argument('--process', default='inel', choices=['none', 'inel', 'ccbar', 'bbbar', 'heavy', 'jets', 'dirgamma'],
+parser.add_argument('--process', default='inel', choices=['none', 'inel', 'ccbar', 'bbbar', 'heavy', 'jets', 'dirgamma', 'cdiff'],
                     help='Process to switch on')
 
 parser.add_argument('--ptHatMin', type=float,
@@ -105,6 +105,10 @@ if args.process == 'jets':
     fout.write('HardQCD:all = on \n')
 if args.process == 'dirgamma':
     fout.write('PromptPhoton:all = on \n')
+if args.process == 'cdiff':
+    fout.write('SoftQCD:inelastic = on \n')
+    # enable non-zero cross section for CEP
+    fout.write('SigmaTotal:zeroAXB = off \n')
 fout.write('\n')
 
 ### heavy ion  settings (valid for Pb-Pb 5520 only)


### PR DESCRIPTION
cdiff enables non-zero cross section for the central diffractive process
It sets SoftQCD:inelastic = on and  SigmaTotal:zeroAXB = off
See discussion of SigmaTotal:zeroAXB at https://pythia.org/manuals/pythia8306/QCDSoftProcesses.html