### PR TITLE
Initial integration with QC Tasks

### DIFF
--- a/MC/bin/O2DPG_pp_minbias.sh
+++ b/MC/bin/O2DPG_pp_minbias.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# A example workflow MC->RECO->AOD for a simple pp min bias 
+# production
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh
+
+# ----------- START ACTUAL JOB  ----------------------------- 
+
+NWORKERS=${NWORKERS:-8}
+MODULES="--skipModules ZDC"
+SIMENGINE=${SIMENGINE:-TGeant4}
+
+# create workflow
+./o2dpg_sim_workflow.py -eCM 14000  -col pp -gen pythia8 -proc inel -tf 1    \
+                                                       -ns 20 -e ${SIMENGINE}                   \
+                                                       -j ${NWORKERS} -interactionRate 500000
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt vertexQC
+
+# publish the current dir to ALIEN
+# copy_ALIEN
+

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -75,6 +75,9 @@ parser.add_argument('--early-tf-cleanup',action='store_true', help='whether to c
 parser.add_argument('--combine-smaller-digi', action='store_true', help=argparse.SUPPRESS)
 parser.add_argument('--combine-tpc-clusterization', action='store_true', help=argparse.SUPPRESS) #<--- useful for small productions (pp, low interaction rate, small number of events)
 
+# QC related arguments
+parser.add_argument('--include-qc', action='store_true', help='a flag to include QC in the workflow')
+
 args = parser.parse_args()
 print (args)
 
@@ -115,6 +118,7 @@ def getDPL_global_options(bigshm=False,nosmallrate=False):
 
 doembedding=True if args.embedding=='True' or args.embedding==True else False
 usebkgcache=args.use_bkg_from!=None
+includeQC=True if args.include_qc=='True' or args.include_qc==True else False
 
 if doembedding:
     if not usebkgcache:
@@ -499,12 +503,53 @@ for tf in range(1, NTIMEFRAMES + 1):
    PVFINDERtask['cmd'] = 'o2-primary-vertexing-workflow ' + getDPL_global_options(nosmallrate=False)
    # PVFINDERtask['cmd'] += ' --vertexing-sources "ITS,ITS-TPC,ITS-TPC-TOF" --vetex-track-matching-sources "ITS,ITS-TPC,ITS-TPC-TOF"'
    workflow['stages'].append(PVFINDERtask)
- 
-   vertexQCneeds = [PVFINDERtask['name']]
-   vertexQCtask = createTask(name='vertexQC_'+str(tf), needs=vertexQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
-   vertexQCtask['cmd'] = 'o2-primary-vertex-reader-workflow | o2-qc --config json:///home/pkonopka/alice/vertexing-qc-direct-mc.json ' + getDPL_global_options(nosmallrate=False)
-   workflow['stages'].append(vertexQCtask)
- 
+
+   if includeQC:
+
+     ### ITS
+     # fixme: not working yet, ITS will prepare a way to read clusters and tracks. Also ITSDictionary will be needed. 
+     # ITSClustersTracksQCneeds = [ITSRECOtask['name']] 
+     # ITSClustersTracksQCtask = createTask(name='itsClustersTracksQC_'+str(tf), needs=ITSClustersTracksQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     # ITSClustersTracksQCtask['cmd'] = 'o2-missing-reader | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/its-clusters-tracks-qc.json ' + getDPL_global_options(nosmallrate=False)
+     # workflow['stages'].append(ITSClustersTracksQCtask)
+
+     ### MFT
+     # fixme: there is a bug in Check which causes a segfault, uncomment when the fix is merged
+     # MFTDigitsQCneeds = [det_to_digitask["MFT"]['name']]
+     # MFTDigitsQCtask = createTask(name='mftDigitsQC_'+str(tf), needs=MFTDigitsQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     # MFTDigitsQCtask['cmd'] = 'o2-qc-mft-digits-root-file-reader --mft-digit-infile=mftdigits.root | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-digit.json ' + getDPL_global_options(nosmallrate=False)
+     # workflow['stages'].append(MFTDigitsQCtask)
+
+     MFTClustersQCneeds = [MFTRECOtask['name']]
+     MFTClustersQCtask = createTask(name='mftClustersQC_'+str(tf), needs=MFTClustersQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     MFTClustersQCtask['cmd'] = 'o2-qc-mft-clusters-root-file-reader --mft-cluster-infile=mftclusters.root | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-cluster.json ' + getDPL_global_options(nosmallrate=False)
+     workflow['stages'].append(MFTClustersQCtask)
+
+     MFTTracksQCneeds = [MFTRECOtask['name']]
+     MFTTracksQCtask = createTask(name='mftTracksQC_'+str(tf), needs=MFTTracksQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     MFTTracksQCtask['cmd'] = 'o2-qc-mft-tracks-root-file-reader --mft-track-infile=mfttracks.root | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-track.json ' + getDPL_global_options(nosmallrate=False)
+     workflow['stages'].append(MFTTracksQCtask)
+
+     ### TPC
+     TPCTrackingQCneeds = [TPCRECOtask['name']]
+     TPCTrackingQCtask = createTask(name='tpcTrackingQC_'+str(tf), needs=TPCTrackingQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=2, mem='2000')
+     TPCTrackingQCtask['cmd'] = 'o2-tpc-track-reader | o2-tpc-reco-workflow --input-type clusters --infile tpc-native-clusters.root --output-type disable-writer | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-tracking-direct.json ' + getDPL_global_options(nosmallrate=False)
+     workflow['stages'].append(TPCTrackingQCtask)
+
+     ### TRD
+     TRDDigitsQCneeds = [TRDDigitask['name']]
+     TRDDigitsQCtask = createTask(name='trdDigitsQC_'+str(tf), needs=TRDDigitsQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     TRDDigitsQCtask['cmd'] = 'o2-trd-trap-sim | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/trd-digits-task.json ' + getDPL_global_options(nosmallrate=False)
+     workflow['stages'].append(TRDDigitsQCtask)
+
+     ### RECO
+     vertexQCneeds = [PVFINDERtask['name']]
+     vertexQCtask = createTask(name='vertexQC_'+str(tf), needs=vertexQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     vertexQCtask['cmd'] = 'o2-primary-vertex-reader-workflow | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/vertexing-qc-direct-mc.json ' + getDPL_global_options(nosmallrate=False)
+     workflow['stages'].append(vertexQCtask)
+
+     
+
   # -----------
   # produce AOD
   # -----------

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -500,6 +500,11 @@ for tf in range(1, NTIMEFRAMES + 1):
    # PVFINDERtask['cmd'] += ' --vertexing-sources "ITS,ITS-TPC,ITS-TPC-TOF" --vetex-track-matching-sources "ITS,ITS-TPC,ITS-TPC-TOF"'
    workflow['stages'].append(PVFINDERtask)
  
+   vertexQCneeds = [PVFINDERtask['name']]
+   vertexQCtask = createTask(name='vertexQC_'+str(tf), needs=vertexQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+   vertexQCtask['cmd'] = 'o2-primary-vertex-reader-workflow | o2-qc --config json:///home/pkonopka/alice/vertexing-qc-direct-mc.json ' + getDPL_global_options(nosmallrate=False)
+   workflow['stages'].append(vertexQCtask)
+ 
   # -----------
   # produce AOD
   # -----------

--- a/MC/config/QC/json/dpl-config.json
+++ b/MC/config/QC/json/dpl-config.json
@@ -1,0 +1,19 @@
+{
+    "internal-dpl-clock": "",
+    "digits-root-file-reader-mft": {
+        "mft-digit-infile": "mftdigits2.root",
+        "orbit-offset-enumeration": "0",
+        "orbit-multiplier-enumeration": "0",
+        "start-value-enumeration": "0",
+        "end-value-enumeration": "-1",
+        "step-value-enumeration": "1"
+    },
+    "Dispatcher": {
+        "period-timer-stats": "10000000"
+    },
+    "QC-TASK-RUNNER-QcMFTDigitTask": {
+        "period-timer-cycle": "60000000"
+    },
+    "QC-CHECK-RUNNER-QcMFTDigitCheck": "",
+    "internal-dpl-injected-dummy-sink": ""
+}

--- a/MC/config/QC/json/its-clusters-tracks-qc.json
+++ b/MC/config/QC/json/its-clusters-tracks-qc.json
@@ -1,0 +1,93 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "ITSClusterTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSClusterTask",
+        "moduleName": "QcITS",
+	"detectorName": "ITS",	
+        "cycleDurationSeconds": "180",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0"
+        },
+        "location": "remote",
+        "taskParameters": {
+                    "layer": "1111111",
+                    "clusterDictionaryPath": "/home/epn/odc/files/ITSdictionary.bin",
+                    "runNumberPath": "/home/its/QC/workdir/infiles/RunNumber.dat",
+                    "geomPath": "./o2sim_geometry.root",
+                    "nThreads": "4"  					
+        }
+
+      },
+      "ITSTrackTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSTrackTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "tracks:ITS/TRACKS/0;rofs:ITS/ITSTrackROF/0;compclus:ITS/COMPCLUSTERS/0"
+        },
+        "location": "remote"
+      }
+
+    },
+    "checks": {
+      "ITSClusterCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSClusterCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [{
+          "type": "Task",
+          "name": "ITSClusterTask",
+          "MOs": ["Layer0/AverageClusterSize"]
+          }]
+        },
+      "ITSTrackCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSTrackCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [{
+          "type": "Task",
+          "name": "ITSTrackTask",
+          "MOs": ["NClusters"]
+          }]
+        }
+    }
+   },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/config/QC/json/qc-mft-cluster.json
+++ b/MC/config/QC/json/qc-mft-cluster.json
@@ -1,0 +1,61 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "QcMFTClusterTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::QcMFTClusterTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcMFTClusterCheck": {
+        "active": "true",
+        "dataSource": [{
+          "type": "Task",
+          "name": "QcMFTClusterTask",
+          "MOs": ["mMFTClusterSensorIndex"]
+        }],
+        "className": "o2::quality_control_modules::mft::QcMFTClusterCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnAny"
+      }
+    }    
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/config/QC/json/qc-mft-digit.json
+++ b/MC/config/QC/json/qc-mft-digit.json
@@ -1,0 +1,61 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "QcMFTDigitTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::QcMFTDigitTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "randomdigit:MFT/DIGITS/0;digitsrof:MFT/DIGITSROF/0"
+        },
+        "taskParameters": {
+          "FLP": "0",
+          "TaskLevel": "4"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcMFTDigitCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::QcMFTDigitCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnEachSeparately",
+        "dataSource": [{
+          "type": "Task",
+          "name": "QcMFTDigitTask"
+        }]
+      }
+    }    
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/config/QC/json/qc-mft-track.json
+++ b/MC/config/QC/json/qc-mft-track.json
@@ -1,0 +1,61 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "QcMFTTrackTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::QcMFTTrackTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "randomtrack:MFT/TRACKS/0;tracksrof:MFT/MFTTrackROF/0"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcMFTTrackCheck": {
+        "active": "false",
+        "dataSource": [{
+          "type": "Task",
+          "name": "QcMFTTrackTask",
+          "MOs": ["mMFTTrackCharge"]
+        }],
+        "className": "o2::quality_control_modules::mft::QcMFTTrackCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnAny"
+      }
+    }    
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/config/QC/json/tpc-qc-tracking-direct.json
+++ b/MC/config/QC/json/tpc-qc-tracking-direct.json
@@ -1,0 +1,48 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "TPCTrackingQA": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::Tracking",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+            "type": "direct",
+            "query": "inputTracks:TPC/TRACKS/0;inputTrackLabels:TPC/TRACKSMCLBL/0;inputClusRefs:TPC/CLUSREFS/0;inputClusters:TPC/CLUSTERNATIVE/0;inputClusterLabels:TPC/CLNATIVEMCLBL/0"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+    }
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/config/QC/json/trd-digits-task.json
+++ b/MC/config/QC/json/trd-digits-task.json
@@ -1,0 +1,75 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://localhost:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "QcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::DigitsTask",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tst-raw"
+        },
+        "taskParameters": {
+          "trdDigits": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::DigitsCheck",
+        "moduleName": "QcTRD",
+        "policy": "OnAny",
+        "detectorName": "TRD",
+        "dataSource": [{
+          "type": "Task",
+          "name": "QcTask",
+          "MOs": ["mADC"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "tst-raw",
+      "active": "true",
+      "machines": [],
+      "query": "random:TRD/DIGITS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+   ]
+  }

--- a/MC/config/QC/json/vertexing-qc-direct-mc.json
+++ b/MC/config/QC/json/vertexing-qc-direct-mc.json
@@ -1,0 +1,67 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      },
+      "infologger": {                     "": "Configuration of the Infologger (optional).",
+        "filterDiscardDebug": "false",    "": "Set to true to discard debug and trace messages (default: false)",
+        "filterDiscardLevel": "21",       "": "Message at this level or above are discarded (default: 21 - Trace)"
+      }
+    },
+    "tasks": {
+      "Vertexing_MC": {
+        "active": "true",
+        "className": "o2::quality_control_modules::rec::VertexingQcTask",
+        "moduleName": "QcREC",
+        "detectorName": "REC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+            "type": "direct",
+            "query_comment": "checking every vertex, in MC",
+	    "query": "pvtx:GLO/PVTX/0;pvtxLbl:GLO/PVTX_MCTR/0"
+        },
+        "taskParameters": {
+          "isMC": "true"
+        },
+        "location": "remote",
+        "saveObjectsToFile": "testVertexingQC_MC.root",      "": "For debugging, path to the file where to save. If empty or missing it won't save."
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "detectorName": "REC",
+        "dataSource": [{
+          "type": "Task",
+          "name": "Vertexing_MC",
+          "MOs": ["example"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/MC/run/examples/O2DPG_pp_minbias_one_tf_qc.sh
+++ b/MC/run/examples/O2DPG_pp_minbias_one_tf_qc.sh
@@ -18,12 +18,14 @@ MODULES="--skipModules ZDC"
 SIMENGINE=${SIMENGINE:-TGeant4}
 
 # create workflow
-./o2dpg_sim_workflow.py -eCM 14000  -col pp -gen pythia8 -proc inel -tf 1    \
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 14000  -col pp -gen pythia8 -proc inel -tf 1    \
                                                        -ns 20 -e ${SIMENGINE}                   \
-                                                       -j ${NWORKERS} -interactionRate 500000
+                                                       -j ${NWORKERS} -interactionRate 500000   \
+                                                       --include-qc
 
 # run workflow
-${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt vertexQC
+# ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt vertexQC
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json
 
 # publish the current dir to ALIEN
 # copy_ALIEN


### PR DESCRIPTION
This adds 5 QC Tasks, which can be enabled with --include-qc flag passed to o2dpg_sim_workflow.py. In this iteration they publish results directly to QCDB (at ccdb-test) and results from many TFs and sub-jobs are not merged.

More Tasks to come, also merging will be done in future PRs.

An example to run it can be found in `MC/run/examples/O2DPG_pp_minbias_one_tf_qc.sh`