### PR TITLE
running scripts (PWGDQ)

### DIFF
--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV()"  \
+        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runPromptJpsi_midy_pp.sh
+++ b/MC/run/PWGDQ/runPromptJpsi_midy_pp.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=GeneratorParamPromptJpsiToElectronEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorParamPromptJpsiToElectronEvtGen_pp13TeV()"  \
+       	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Running scripts for running PWGDQ simulations (min. bias pythia + prompt charmonium signals, mid / fwd rapidity). 
@sawenzel: these are tested locally at MC truth level. If possible, we would like to include them in one of the nightlies tests for testing the full simulation chain. Thanks a lot in advance for any comment.   