### PR TITLE
update for LMee (LMuu) HF cocktail simulations

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
@@ -1,0 +1,45 @@
+// 
+//o2-sim -j 1 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHFbb_lowMassEE.ini (GeneratorHFbb_lowMassMuMu.ini)  -> bb -> e+e- (bb -> mu+mu-)
+//o2-sim -j 1 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHFcc_lowMassEE.ini (GeneratorHFbb_lowMassMuMu.ini) -> cc -> e+e- (cc -> mu+mu-)
+//o2-sim -j 1 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHFbtoc_lowMassEE.ini (GeneratorHFbtoc_lowMassMuMu.ini) -> b->e, b->c->e (b->mu, b->c->mu) 
+//
+
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
+#include "GeneratorHF.C"
+
+enum LMeeType { kBBtoLL=0, kCCtoLL, kBandCToLL}; 
+
+FairGenerator*
+GeneratorHF_LowMassLeptonLepton(Int_t kTypeLowMassHF = kBBtoLL, Bool_t isDielectron = kTRUE, double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false)
+{
+
+  //
+  // generate LMee and LMmumu cocktails from HF. Different sources can be generated:
+  // 1) kBBtoLL -> unlike sign lepton pairs from bb ( -> lepton^+ lepton^-)
+  // 2) kCCtoLL -> unlike sign lepton pairs from cc ( -> lepton^+ lepton^-)
+  // 3) kBandCToLL -> like / unlike sign lepton pairs from b->lepton + b->c->lepton
+  // 
+  auto gen = new o2::eventgen::GeneratorHF();
+  
+  if(kTypeLowMassHF == kBBtoLL || kTypeLowMassHF == kBandCToLL) gen->setPDG(5);
+  else if(kTypeLowMassHF == kCCtoLL) gen->setPDG(4);
+  else { printf("unknow case, please check! \n"); return 0x0; }
+  
+  gen->setRapidity(rapidityMin,rapidityMax);
+  gen->setVerbose(verbose);
+
+  TString pathO2 = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer");
+
+  TString decayTableType = "Muonic"; 
+  if(isDielectron) decayTableType = "Electronic";
+
+  if(kTypeLowMassHF == kBBtoLL) gen->readFile(Form("%s/force_semi%sB.cfg",pathO2.Data(),decayTableType.Data()));
+  else if(kTypeLowMassHF == kCCtoLL) gen->readFile(Form("%s/force_semi%sC.cfg",pathO2.Data(),decayTableType.Data()));
+
+  if(ispp) gen->setFormula("1");
+  else gen->setFormula("max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.))");
+  
+  return gen;
+}
+
+

--- a/MC/config/PWGDQ/ini/GeneratorHFbb_lowMassEE.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFbb_lowMassEE.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kBBtoLL,kTRUE,-1.5,1.5)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.5,1.5)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHFbb_lowMassMuMu.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFbb_lowMassMuMu.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kBBtoLL,kFALSE,-4.3,-2.3)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(13,kFALSE,-4.3,-2.3)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHFbtoc_lowMassEE.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFbtoc_lowMassEE.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kBandCToLL,kTRUE,-1.5,1.5)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C 
+funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.5,1.5)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHFbtoc_lowMassMuMu.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFbtoc_lowMassMuMu.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kBandCToLL,kFALSE,-4.3,-2.3)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHFcc_lowMassEE.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFcc_lowMassEE.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kCCtoLL,kTRUE,-1.5,1.5)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.5,1.5)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHFcc_lowMassMuMu.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHFcc_lowMassMuMu.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorHF_LowMassLeptonLepton.C
+funcName = GeneratorHF_LowMassLeptonLepton(kCCtoLL,kFALSE,-4.3,-2.3)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(13,kFALSE,-4.3,-2.3)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/pythia8/decayer/force_semiElectronicB.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/force_semiElectronicB.cfg
@@ -1,0 +1,15 @@
+######################
+511:onMode = off
+511:onIfAny = 11
+521:onMode = off
+521:onIfAny = 11
+531:onMode = off
+531:onIfAny = 11
+5122:onMode = off
+5122:onIfAny = 11
+5132:onMode = off
+5132:onIfAny = 11
+5232:onMode = off
+5232:onIfAny = 11
+5332:onMode = off
+5332:onIfAny = 11

--- a/MC/config/PWGDQ/pythia8/decayer/force_semiElectronicC.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/force_semiElectronicC.cfg
@@ -1,0 +1,15 @@
+######################
+411:onMode = off
+411:onIfAny = 11
+421:onMode = off
+421:onIfAny = 11
+431:onMode = off
+431:onIfAny = 11
+4122:onMode = off
+4122:onIfAny = 11
+4132:onMode = off
+4132:onIfAny = 11
+4232:onMode = off
+4232:onIfAny = 11
+4332:onMode = off
+4332:onIfAny = 11

--- a/MC/config/PWGDQ/pythia8/decayer/force_semiMuonicB.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/force_semiMuonicB.cfg
@@ -1,0 +1,15 @@
+######################
+511:onMode = off
+511:onIfAny = 13
+521:onMode = off
+521:onIfAny = 13
+531:onMode = off
+531:onIfAny = 13
+5122:onMode = off
+5122:onIfAny = 13
+5132:onMode = off
+5132:onIfAny = 13
+5232:onMode = off
+5232:onIfAny = 13
+5332:onMode = off
+5332:onIfAny = 13

--- a/MC/config/PWGDQ/pythia8/decayer/force_semiMuonicC.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/force_semiMuonicC.cfg
@@ -1,0 +1,15 @@
+######################
+411:onMode = off
+411:onIfAny = 13
+421:onMode = off
+421:onIfAny = 13
+431:onMode = off
+431:onIfAny = 13
+4122:onMode = off
+4122:onIfAny = 13
+4132:onMode = off
+4132:onIfAny = 13
+4232:onMode = off
+4232:onIfAny = 13
+4332:onMode = off
+4332:onIfAny = 13

--- a/MC/run/PWGDQ/runLMeeHFCocktail_midy_pp.sh
+++ b/MC/run/PWGDQ/runLMeeHFCocktail_midy_pp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+#generate random number
+RNDSIG=$((1 + $RANDOM % 100))
+
+if [[ $RNDSIG -ge 0 && $RNDSIG -lt 10 ]];
+then
+        CONFIGNAME="GeneratorHFcc_lowMassEE.ini"
+elif [[ $RNDSIG -ge 10 && $RNDSIG -lt 20 ]];
+then
+        CONFIGNAME="GeneratorHFbb_lowMassEE.ini"
+elif [[ $RNDSIG -ge 20 && $RNDSIG -le 100 ]];
+then
+        CONFIGNAME="GeneratorHFbtoc_lowMassEE.ini"
+fi
+
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/$CONFIGNAME  \
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} 
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runLMmumuHFCocktail_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runLMmumuHFCocktail_fwdy_pp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+#generate random number
+RNDSIG=$((1 + $RANDOM % 100))
+
+if [[ $RNDSIG -ge 0 && $RNDSIG -lt 10 ]];
+then
+        CONFIGNAME="GeneratorHFcc_lowMassMuMu.ini"
+elif [[ $RNDSIG -ge 10 && $RNDSIG -lt 20 ]];
+then
+        CONFIGNAME="GeneratorHFbb_lowMassMuMu.ini"
+elif [[ $RNDSIG -ge 20 && $RNDSIG -le 100 ]];
+then
+        CONFIGNAME="GeneratorHFbtoc_lowMassMuMu.ini"
+fi
+
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/$CONFIGNAME  \
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} 
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
The commit includes:
- generation config macro for LMee (LMmumu) simulations at mid (forward) rapidity
- files file.ini related to the specific HF signal to be injected (namely, cc -> ee / bb -> ee / b,c->e
and similar for the forward rapidity with muons).
- pythia8 decay files for forcing the electronic / muonic decay modes 
- running scripts for generating HF cocktails 

Regarding the last point, I have a question for @sawenzel  and Catalin-Lucian Ristea: we would like to inject
one signal per event randomly (as done in current simulations in AliDPG, see 
https://github.com/alisw/AliDPG/blob/master/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_HFdielectrons002.C). 
Do you think the strategy in the running scripts above would work for nightlies and grid
productions ? 
Thanks a lot!  