### PR TITLE
Adding TOF matching QC

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -645,12 +645,20 @@ for tf in range(1, NTIMEFRAMES + 1):
      workflow['stages'].append(TRDDigitsQCtask)
 
      ### RECO
+     ### Primary vertex
      vertexQCneeds = [PVFINDERtask['name']]
      vertexQCtask = createTask(name='vertexQC_local'+str(tf), needs=vertexQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
      vertexQCtask['cmd'] = 'o2-primary-vertex-reader-workflow | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/vertexing-qc-direct-mc.json --local-batch ../' + qcdir + '/vertexQC.root ' + getDPL_global_options()
      vertexQCtask['semaphore'] = 'vertexQC'
      workflow['stages'].append(vertexQCtask)
-     
+
+     ### TOF matching
+     TOFMatchQCneeds = [TOFTPCMATCHERtask['name']]
+     TOFMatchQCtask = createTask(name='TOFMatchQC_local'+str(tf), needs=TOFMatchQCneeds, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+     TOFMatchQCtask['cmd'] = 'o2-global-track-cluster-reader --track-types "ITS-TPC-TOF,TPC-TOF,TPC" --cluster-types none | o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json --local-batch ../' + qcdir + '/TOFMatchQC.root ' + getDPL_global_options()
+     TOFMatchQCtask['semaphore'] = 'TOFMatchQC'
+     workflow['stages'].append(TOFMatchQCtask)
+
  
    #secondary vertexer
    SVFINDERtask = createTask(name='svfinder_'+str(tf), needs=[PVFINDERtask['name']], tf=tf, cwd=timeframeworkdir, lab=["RECO"], cpu=1, mem='2000')
@@ -729,6 +737,11 @@ if includeQC:
   vertexQCtask = createTask(name='vertexQC_finalize', needs=vertexQCneeds, cwd=qcdir, lab=["QC"], cpu=1, mem='2000')
   vertexQCtask['cmd'] = 'o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/vertexing-qc-direct-mc.json --remote-batch vertexQC.root ' + getDPL_global_options()
   workflow['stages'].append(vertexQCtask)
+
+  TOFMatchQCneeds = ['TOFMatchQC_local'+str(tf) for tf in range(1, NTIMEFRAMES + 1)]
+  TOFMatchQCtask = createTask(name='TOFMatchQC_finalize', needs=TOFMatchQCneeds, cwd=qcdir, lab=["QC"], cpu=1, mem='2000')
+  TOFMatchQCtask['cmd'] = 'o2-qc --config json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json --remote-batch TOFMatchQC.root ' + getDPL_global_options()
+  workflow['stages'].append(TOFMatchQCtask)
 
 
 dump_workflow(workflow["stages"], args.o)

--- a/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
+++ b/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
@@ -1,0 +1,69 @@
+{
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ccdb-test.cern.ch:8080",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
+      },
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
+      },
+      "monitoring" : {
+        "url" : "infologger:///debug?qc"
+      },
+      "consul" : {
+        "url" : ""
+      },
+      "conditionDB" : {
+        "url" : "ccdb-test.cern.ch:8080"
+      },
+      "infologger" : { "" : "Configuration of the Infologger (optional).",
+                       "filterDiscardDebug" : "false",
+                       "" : "Set to true to discard debug and trace messages (default: false)",
+                       "filterDiscardLevel" : "21",
+                       "" : "Message at this level or above are discarded (default: 21 - Trace)" }
+    },
+    "tasks" : {
+      "MatchedTracksITSTPCTOF_TPCTOF" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::TOFMatchedTracks",
+        "moduleName" : "QcTOF",
+        "detectorName" : "TOF",
+        "cycleDurationSeconds" : "10",
+        "maxNumberCycles" : "-1",
+        "dataSource" : {
+          "type" : "direct",
+          "query_comment" : "checking every matched track",
+          "query" : "matchITSTPCTOF:TOF/MTC_ITSTPC/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;tofcluster:TOF/CLUSTERS/0"
+        },
+        "taskParameters" : {
+          "GID" : "ITS-TPC,TPC,ITS-TPC-TOF,TPC-TOF",
+          "verbose" : "false"
+        },
+        "location" : "remote",
+        "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF.root",
+        "" : "For debugging, path to the file where to save. If empty or missing it won't save."
+      }
+    },
+    "checks" : {
+      "QcCheck" : {
+        "active" : "false",
+        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName" : "QcSkeleton",
+        "policy" : "OnAny",
+        "detectorName" : "TOF",
+        "dataSource" : [ {
+          "type" : "Task",
+          "name" : "QcTask",
+          "MOs" : ["example"]
+        } ]
+      }
+    }
+  },
+         "dataSamplingPolicies" : [
+         ]
+}


### PR DESCRIPTION
@knopers8 , @sawenzel , @noferini , this is to add the TOF QC to the simulation processing. The QCG shows the plots correctly. I tried reading the object from the file, but for that I had issues, but probably I am doing it in the wrong way, see below for reference. 
Despite this, if you think the PR is ok, we could merge it. 
One more think: the json is copied from QualityControl, isn't it better to find another way?

Chiara


```
Attaching file TOFMatchQC.root as _file0...
(TFile *) 0x3316260
root [1] .ls
TFile**		TOFMatchQC.root	
 TFile*		TOFMatchQC.root	
  KEY: o2::quality_control::core::MonitorObjectCollection	MatchedTracksITSTPCTOF_TPCTOF;1	object title
root [2] o2::quality_control::core::MonitorObjectCollection* c = (o2::quality_control::core::MonitorObjectCollection*)_file0->Get("MatchedTracksITSTPCTOF_TPCTOF")
#0  0x00007f92cc427dba in wait4 () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f92cc3970e7 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f92ccba211c in TUnixSystem::Exec (shellcmd=<optimized out>, this=0x17e0800) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/unix/src/TUnixSystem.cxx:2120
#3  TUnixSystem::StackTrace (this=0x17e0800) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/unix/src/TUnixSystem.cxx:2411
#4  0x00007f92c79bfeb8 in cling::MultiplexInterpreterCallbacks::PrintStackTrace() () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#5  0x00007f92c79b4b9f in cling_runtime_internal_throwIfInvalidPointer () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#6  0x00007f92afc316e7 in ?? ()
#7  0x00007ffc2c91ed60 in ?? ()
#8  0x00007f92afc31890 in ?? ()
#9  0x0000000000000002 in ?? ()
#10 0x00007f92c7a43beb in cling::IncrementalExecutor::runStaticInitializersOnce(cling::Transaction&) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#11 0x00007f92c79ba714 in cling::Interpreter::executeTransaction(cling::Transaction&) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#12 0x00007f92c7a561f7 in cling::IncrementalParser::commitTransaction(llvm::PointerIntPair<cling::Transaction*, 2u, cling::IncrementalParser::EParseResult, llvm::PointerLikeTypeTraits<cling::Transaction*>, llvm::PointerIntPairInfo<cling::Transaction*, 2u, llvm::PointerLikeTypeTraits<cling::Transaction*> > >&, bool) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#13 0x00007f92c7a581f9 in cling::IncrementalParser::Compile(llvm::StringRef, cling::CompilationOptions const&) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#14 0x00007f92c79b83a8 in cling::Interpreter::EvaluateInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cling::CompilationOptions, cling::Value*, cling::Transaction**, unsigned long) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#15 0x00007f92c79b8741 in cling::Interpreter::process(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cling::Value*, cling::Transaction**, bool) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#16 0x00007f92c7aa2a67 in cling::MetaProcessor::process(llvm::StringRef, cling::Interpreter::CompilationResult&, cling::Value*, bool) () from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/ROOT/v6-24-06-local1/lib/libCling.so
#17 0x00007f92c78de25c in HandleInterpreterException (metaProcessor=0x237d760, input_line=0x34bd890 "#line 1 \"ROOT_prompt_2\"\no2::quality_control::core::MonitorObjectCollection* c = (o2::quality_control::core::MonitorObjectCollection*)_file0->Get(\"MatchedTracksITSTPCTOF_TPCTOF\")", compRes=
0x7ffc2c91f12c: cling::Interpreter::kSuccess, result=0x7ffc2c91f260) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/metacling/src/TCling.cxx:2427
#18 0x00007f92c78f56ca in TCling::ProcessLine (this=0x1853130, line=<optimized out>, error=0x7ffc2c91f4fc) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/GCC-Toolchain/v10.2.0-alice2-local1/include/c++/10.2.0/bits/unique_ptr.h:173
#19 0x00007f92cce0b022 in TRint::ProcessLineNr (this=0x1839c40, filestem=<optimized out>, line=0x3e3d990 "o2::quality_control::core::MonitorObjectCollection* c = (o2::quality_control::core::MonitorObjectCollection*)_file0->Get(\"MatchedTracksITSTPCTOF_TPCTOF\")", error=0x7ffc2c91f4fc) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/rint/src/TRint.cxx:751
#20 0x00007f92cce0b388 in TRint::HandleTermInput (this=0x1839c40) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/base/inc/TString.h:244
#21 0x00007f92ccb9e93c in TUnixSystem::CheckDescriptors (this=this
entry=0x17e0800) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/unix/src/TUnixSystem.cxx:1322
#22 0x00007f92ccba03a8 in TUnixSystem::DispatchOneEvent (this=0x17e0800, pendingOnly=<optimized out>) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/unix/src/TUnixSystem.cxx:1077
#23 0x00007f92ccab8569 in TSystem::InnerLoop (this=0x17e0800) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/base/src/TSystem.cxx:404
#24 TSystem::Run (this=0x17e0800) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/base/src/TSystem.cxx:354
#25 0x00007f92cca54eaf in TApplication::Run (this=this
entry=0x1839c40, retrn=retrn
entry=false) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/base/src/TApplication.cxx:1623
#26 0x00007f92cce0c8f6 in TRint::Run (this=this
entry=0x1839c40, retrn=retrn
entry=false) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/core/rint/src/TRint.cxx:463
#27 0x000000000040110a in main (argc=<optimized out>, argv=0x7ffc2c921928) at /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/SOURCES/ROOT/v6-24-06/v6-24-06/main/src/rmain.cxx:30
Error in <HandleInterpreterException>: Trying to access a pointer that points to an invalid memory address..
Execution of your code was aborted.
In file included from G__O2QualityControl dictionary payload:377:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/O2/dev-local1/include/Framework/ServiceRegistry.h:15:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/O2/dev-local1/include/Framework/ServiceSpec.h:16:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/O2/dev-local1/include/Framework/DeviceInfo.h:16:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/O2/dev-local1/include/Framework/DeviceState.h:14:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/O2/dev-local1/include/Framework/ChannelInfo.h:15:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/FairMQ/v1.4.40-local1/include/fairmq/FairMQParts.h:12:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/FairMQ/v1.4.40-local1/include/fairmq/FairMQTransportFactory.h:16:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/FairMQ/v1.4.40-local1/include/fairmq/MemoryResources.h:22:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/boost/v1.75.0-local1/include/boost/container/flat_map.hpp:29:
In file included from /home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/boost/v1.75.0-local1/include/boost/container/detail/flat_tree.hpp:29:
/home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/boost/v1.75.0-local1/include/boost/container/detail/pair.hpp:133:89: warning: invalid memory pointer passed to a callee:
static piecewise_construct_t piecewise_construct = BOOST_CONTAINER_DOC1ST(unspecified, *std_piecewise_construct_holder<>::dummy);
                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zampolli/SOFT/alibuild/ali-o2-QC/sw/ubuntu2004_x86-64/boost/v1.75.0-local1/include/boost/container/detail/workaround.hpp:71:46: note: expanded from macro 'BOOST_CONTAINER_DOC1ST'
#define BOOST_CONTAINER_DOC1ST(TYPE1, TYPE2) TYPE2
                                             ^~~~~
root [3] 
root [3] 

```