### PR TITLE
Update the parameters for the TOF matching QC

### DIFF
--- a/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
+++ b/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
@@ -10,7 +10,10 @@
       },
       "Activity" : {
         "number" : "42",
-        "type" : "2"
+        "type" : "2",
+        "provenance": "qc_mc",
+        "passName": "passMC",
+        "periodName": "SimChallenge"
       },
       "monitoring" : {
         "url" : "infologger:///debug?qc"


### PR DESCRIPTION
Putting the same parameters as in other tasks, mainly to make the results go to "qc_mc" directory.