### PR TITLE
Modifications

### DIFF
--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOELE.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOELE.DEC
@@ -1,0 +1,155 @@
+####
+Decay B0
+#       B -> cc= s
+0.000310000 psi(2S) K_S0                                    SVS; #[Reconstructed PDG2011]
+0.000310000 psi(2S) K_L0                                    SVS; #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K+  pi-          PHSP;
+0.0002     psi(2S)  K0  pi0          PHSP;
+0.0002     psi(2S)  K0  pi-  pi+     PHSP;
+0.0001     psi(2S)  K0  pi0  pi0     PHSP;
+0.0001     psi(2S)  K+  pi-  pi0     PHSP;
+0.0004     psi(2S)  K_10              PHSP;
+#
+####
+0.000620000 psi(2S) K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay anti-B0
+#
+0.000310000 psi(2S) K_S0                                    SVS; #[Reconstructed PDG2011]
+0.000310000 psi(2S) K_L0                                    SVS; #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K-  pi+          PHSP;
+0.0002     psi(2S)  anti-K0   pi0          PHSP;
+0.0002     psi(2S)  anti-K0   pi+  pi-     PHSP;
+0.0001     psi(2S)  anti-K0   pi0  pi0     PHSP;
+0.0001     psi(2S)  K-  pi+  pi0     PHSP;
+0.0004     psi(2S)  anti-K_10              PHSP;
+#
+0.000620000 psi(2S) anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+####
+Enddecay
+
+Decay B-
+#
+#   B -> cc= s          sum = 1.92%
+#
+0.000646000 psi(2S) K-                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0004   psi(2S) anti-K0   pi-                   PHSP;
+0.0002   psi(2S) K-  pi0                   PHSP;
+0.001900000 psi(2S) K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K-  pi0  pi0              PHSP;
+0.0001   psi(2S) anti-K0   pi-  pi0              PHSP;
+0.0004     psi(2S)  K_1-              PHSP;
+#
+0.000025800 psi(2S) pi-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay B+
+#
+#   B -> cc= s          sum = 1.92%
+#
+0.000646000 psi(2S) K+                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0004   psi(2S) K0  pi+                   PHSP;
+0.0002   psi(2S) K+  pi0                   PHSP;
+0.001900000 psi(2S) K+      pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K+  pi0  pi0              PHSP;
+0.0001   psi(2S) K0  pi+  pi0              PHSP;
+0.0004   psi(2S)  K_1+                     PHSP;
+#
+####
+0.000025800 psi(2S) pi+                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay B_s0
+#					psi' = 0.34%  CLNS 94/1315
+0.000465    psi(2S)     eta'	                           SVS;
+0.000235    psi(2S)     eta                                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003      psi(2S)     K-          K+                     PHSP;
+0.0003      psi(2S)     anti-K0     K0                     PHSP;
+0.0003      psi(2S)     K0          K-         pi+         PHSP;
+0.0003      psi(2S)     anti-K0     K0         pi0         PHSP;
+0.0003      psi(2S)     K-          K+         pi0         PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+# PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
+0.0000023   phi    e+     e-                   BTOSLLALI;
+Enddecay
+
+Decay anti-B_s0
+#					psi' = 0.34%  CLNS 94/1315
+#
+0.000465  psi(2S) eta'               SVS;
+0.000235  psi(2S) eta                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003    psi(2S) K-       K+        PHSP;
+0.0003    psi(2S) anti-K0  K0        PHSP;
+0.0003    psi(2S) anti-K0  K+    pi- PHSP;
+0.0003    psi(2S) anti-K0  K0    pi0 PHSP;
+0.0003    psi(2S) K-       K+    pi0 PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+# PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
+0.0000023   phi    e-     e+                   BTOSLLALI;
+
+Enddecay
+
+Decay Lambda_b0
+  0.00038    Lambda0         psi(2S)                      PHSP;
+Enddecay
+
+Decay anti-Lambda_b0
+  0.00038    anti-Lambda0    psi(2S)                      PHSP;
+Enddecay
+
+Decay Xi_b-
+  0.00038    Xi-        psi(2S)                           PHSP;
+Enddecay
+
+
+Decay anti-Xi_b+
+  0.00038    anti-Xi+        psi(2S)                      PHSP;
+Enddecay
+
+
+Decay Omega_b-
+  0.00038    Omega-        psi(2S)                        PHSP;
+Enddecay
+
+Decay anti-Omega_b+
+  0.00038    anti-Omega+        psi(2S)                   PHSP;
+Enddecay
+
+Decay psi(2S)
+### from DECAY.DEC
+1.000 e+   e-                PHOTOS VLL;
+Enddecay
+
+End

--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOMU.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOMU.DEC
@@ -1,0 +1,155 @@
+####
+Decay B0
+#       B -> cc= s
+0.000310000 psi(2S) K_S0                                    SVS; #[Reconstructed PDG2011]
+0.000310000 psi(2S) K_L0                                    SVS; #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K+  pi-          PHSP;
+0.0002     psi(2S)  K0  pi0          PHSP;
+0.0002     psi(2S)  K0  pi-  pi+     PHSP;
+0.0001     psi(2S)  K0  pi0  pi0     PHSP;
+0.0001     psi(2S)  K+  pi-  pi0     PHSP;
+0.0004     psi(2S)  K_10              PHSP;
+#
+####
+0.000620000 psi(2S) K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay anti-B0
+#
+0.000310000 psi(2S) K_S0                                    SVS; #[Reconstructed PDG2011]
+0.000310000 psi(2S) K_L0                                    SVS; #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K-  pi+          PHSP;
+0.0002     psi(2S)  anti-K0   pi0          PHSP;
+0.0002     psi(2S)  anti-K0   pi+  pi-     PHSP;
+0.0001     psi(2S)  anti-K0   pi0  pi0     PHSP;
+0.0001     psi(2S)  K-  pi+  pi0     PHSP;
+0.0004     psi(2S)  anti-K_10              PHSP;
+#
+0.000620000 psi(2S) anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+####
+Enddecay
+
+Decay B-
+#
+#   B -> cc= s          sum = 1.92%
+#
+0.000646000 psi(2S) K-                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0004   psi(2S) anti-K0   pi-                   PHSP;
+0.0002   psi(2S) K-  pi0                   PHSP;
+0.001900000 psi(2S) K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K-  pi0  pi0              PHSP;
+0.0001   psi(2S) anti-K0   pi-  pi0              PHSP;
+0.0004     psi(2S)  K_1-              PHSP;
+#
+0.000025800 psi(2S) pi-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay B+
+#
+#   B -> cc= s          sum = 1.92%
+#
+0.000646000 psi(2S) K+                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0004   psi(2S) K0  pi+                   PHSP;
+0.0002   psi(2S) K+  pi0                   PHSP;
+0.001900000 psi(2S) K+      pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K+  pi0  pi0              PHSP;
+0.0001   psi(2S) K0  pi+  pi0              PHSP;
+0.0004   psi(2S)  K_1+                     PHSP;
+#
+####
+0.000025800 psi(2S) pi+                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+
+Enddecay
+
+Decay B_s0
+#					psi' = 0.34%  CLNS 94/1315
+0.000465    psi(2S)     eta'	                           SVS;
+0.000235    psi(2S)     eta                                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003      psi(2S)     K-          K+                     PHSP;
+0.0003      psi(2S)     anti-K0     K0                     PHSP;
+0.0003      psi(2S)     K0          K-         pi+         PHSP;
+0.0003      psi(2S)     anti-K0     K0         pi0         PHSP;
+0.0003      psi(2S)     K-          K+         pi0         PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+# PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
+0.0000023   phi    e+     e-                   BTOSLLALI;
+Enddecay
+
+Decay anti-B_s0
+#					psi' = 0.34%  CLNS 94/1315
+#
+0.000465  psi(2S) eta'               SVS;
+0.000235  psi(2S) eta                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003    psi(2S) K-       K+        PHSP;
+0.0003    psi(2S) anti-K0  K0        PHSP;
+0.0003    psi(2S) anti-K0  K+    pi- PHSP;
+0.0003    psi(2S) anti-K0  K0    pi0 PHSP;
+0.0003    psi(2S) K-       K+    pi0 PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+# PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
+0.0000023   phi    e-     e+                   BTOSLLALI;
+
+Enddecay
+
+Decay Lambda_b0
+  0.00038    Lambda0         psi(2S)                      PHSP;
+Enddecay
+
+Decay anti-Lambda_b0
+  0.00038    anti-Lambda0    psi(2S)                      PHSP;
+Enddecay
+
+Decay Xi_b-
+  0.00038    Xi-        psi(2S)                           PHSP;
+Enddecay
+
+
+Decay anti-Xi_b+
+  0.00038    anti-Xi+        psi(2S)                      PHSP;
+Enddecay
+
+
+Decay Omega_b-
+  0.00038    Omega-        psi(2S)                        PHSP;
+Enddecay
+
+Decay anti-Omega_b+
+  0.00038    anti-Omega+        psi(2S)                   PHSP;
+Enddecay
+
+Decay psi(2S)
+### from DECAY.DEC
+1.000 mu+   mu-                PHOTOS VLL;
+Enddecay
+
+End

--- a/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
+++ b/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
@@ -243,6 +243,12 @@ void ForceDecay()
      case kEvtBJpsiDiMuon:
       SetDecayTable(Form("%s/BTOJPSITOMU.DEC",pathO2.Data()));
       break;
+     case kEvtBPsiDiElectron:
+      SetDecayTable(Form("%s/BTOPSITOELE.DEC",pathO2.Data()));
+      break;
+     case kEvtBPsiDiMuon:
+      SetDecayTable(Form("%s/BTOPSITOMU.DEC",pathO2.Data()));
+      break;
      case kEvtBSemiElectronic:
       SetDecayTable(Form("%s/BTOELE.DEC",pathO2.Data()));
       break;

--- a/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
+++ b/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
@@ -16,7 +16,7 @@ R__ADD_INCLUDE_PATH($EVTGEN_ROOT/include)
 #include "EvtGenBase/EvtReport.hh"
 #include "EvtGenExternal/EvtExternalGenList.hh"
 
-enum DecayModeEvt {kEvtAll=0, kEvtBJpsiDiElectron, kEvtBJpsi, kEvtBJpsiDiMuon, kEvtBSemiElectronic, kEvtHadronicD, kEvtHadronicDWithout4Bodies, kEvtChiToJpsiGammaToElectronElectron, kEvtChiToJpsiGammaToMuonMuon, kEvtSemiElectronic, kEvtBSemiMuonic, kEvtSemiMuonic, kEvtDiElectron, kEvtDiMuon, kEvtBPsiPrimeDiMuon, kEvtBPsiPrimeDiElectron, kEvtJpsiDiMuon, kEvtPsiPrimeJpsiDiElectron, kEvtPhiKK, kEvtOmega, kEvtLambda, kEvtHardMuons, kEvtElectronEM, kEvtDiElectronEM, kEvtGammaEM, kEvtBeautyUpgrade};
+enum DecayModeEvt {kEvtAll=0, kEvtBJpsiDiElectron, kEvtBJpsi, kEvtBJpsiDiMuon, kEvtBPsiDiElectron, kEvtBPsiDiMuon, kEvtBSemiElectronic, kEvtHadronicD, kEvtHadronicDWithout4Bodies, kEvtChiToJpsiGammaToElectronElectron, kEvtChiToJpsiGammaToMuonMuon, kEvtSemiElectronic, kEvtBSemiMuonic, kEvtSemiMuonic, kEvtDiElectron, kEvtDiMuon, kEvtBPsiPrimeDiMuon, kEvtBPsiPrimeDiElectron, kEvtJpsiDiMuon, kEvtPsiPrimeJpsiDiElectron, kEvtPhiKK, kEvtOmega, kEvtLambda, kEvtHardMuons, kEvtElectronEM, kEvtDiElectronEM, kEvtGammaEM, kEvtBeautyUpgrade};
 
 
 namespace o2 {

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
@@ -1,0 +1,61 @@
+// usage (fwdy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_fwdy.ini 
+// usage (midy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_midy.ini 
+//
+//
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
+#include "GeneratorEvtGen.C"
+#include "GeneratorHF.C"
+
+FairGenerator*
+GeneratorBeautyToPsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+{
+  auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>(); 
+  gen->setRapidity(rapidityMin,rapidityMax);
+  gen->setPDG(5);
+
+  gen->setVerbose(verbose);
+  if(ispp) gen->setFormula("1");
+  else gen->setFormula("max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.))");
+  std::string spdg;
+  TObjArray *obj = pdgs.Tokenize(";");
+  gen->SetSizePdg(obj->GetEntriesFast());
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   gen->AddPdg(std::stoi(spdg),i);
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  gen->SetForceDecay(kEvtBPsiDiElectron);
+  // print debug
+  // gen->PrintDebug();
+
+  return gen;
+}
+
+FairGenerator*
+GeneratorBeautyToPsi_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2.2, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+{
+  auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
+  gen->setRapidity(rapidityMin,rapidityMax);
+  gen->setPDG(5);
+
+  gen->setVerbose(verbose);
+  if(ispp) gen->setFormula("1");
+  else gen->setFormula("max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.))");
+  std::string spdg;
+  TObjArray *obj = pdgs.Tokenize(";");
+  gen->SetSizePdg(obj->GetEntriesFast());
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   gen->AddPdg(std::stoi(spdg),i);
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  gen->SetForceDecay(kEvtBPsiDiMuon);
+  // print debug
+  // gen->PrintDebug();
+
+  return gen;
+}
+

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
@@ -1,7 +1,7 @@
 // usage (fwdy) :
-//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_fwdy.ini 
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_Psi2S_fwdy.ini
 // usage (midy) :
-//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_midy.ini 
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_Psi2S_midy.ini
 //
 //
 R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)

--- a/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV.C
@@ -1,0 +1,198 @@
+// usage 
+// o2-sim -j 4 -n 10 -g external  -o sgn  --configKeyValues "GeneratorExternal.fileName=GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV()" 
+//
+
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/PromptQuarkonia)  
+#include "GeneratorCocktail.C"
+#include "GeneratorEvtGen.C"
+
+namespace o2 {
+namespace eventgen {
+
+class O2_GeneratorParamJpsi : public GeneratorTGenerator
+{
+
+public:
+  
+  O2_GeneratorParamJpsi() : GeneratorTGenerator("ParamJpsi") {
+    paramJpsi = new GeneratorParam(1, -1, PtJPsipp13TeV, YJPsipp13TeV, V2JPsipp13TeV, IpJPsipp13TeV);
+    paramJpsi->SetMomentumRange(0., 1.e6);
+    paramJpsi->SetPtRange(0., 1000.); 
+    paramJpsi->SetYRange(-1.0, 1.0);  
+    paramJpsi->SetPhiRange(0., 360.); 
+    paramJpsi->SetDecayer(new TPythia6Decayer()); // Pythia
+    paramJpsi->SetForceDecay(kNoDecay); // particle left undecayed
+    setTGenerator(paramJpsi); 
+  };
+
+
+  ~O2_GeneratorParamJpsi() {
+    delete paramJpsi;
+  };
+
+  Bool_t Init() override {
+    GeneratorTGenerator::Init();
+    paramJpsi->Init();
+    return true;
+  }
+
+  void SetNSignalPerEvent(Int_t nsig){paramJpsi->SetNumberParticles(nsig);}
+
+  //-------------------------------------------------------------------------//
+  static Double_t PtJPsipp13TeV(const Double_t *px, const Double_t * /*dummy*/)
+  {
+  	// prompt J/Psi pT
+  	// pp, 13TeV (tuned on pp 13 TeV, 2016-2018)
+  	//
+  	const Double_t kC    = 2.28550e+00;
+  	const Double_t kpt0  = 3.73619e+00;
+  	const Double_t kn    = 2.81708e+00;
+  	Double_t pt          = px[0];
+
+  	return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t YJPsipp13TeV(const Double_t *py, const Double_t * /*dummy*/)
+  {
+        // jpsi y in pp at 13 TeV, tuned on data, prompt jpsi ALICE+LHCb, 13 TeV
+        Double_t y = *py;
+        Float_t p0, p1, p2;
+        p0 = 7.79382e+00;
+        p1 = 2.87827e-06;
+        p2 = 4.41847e+00;
+        return p0 * TMath::Exp(-(1. / 2.) * TMath::Power(((y - p1) / p2), 2));
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t V2JPsipp13TeV(const Double_t * /*dummy*/, const Double_t * /*dummy*/)
+  {
+        //jpsi v2
+        return 0.;
+  }
+
+  //-------------------------------------------------------------------------//
+  static Int_t IpJPsipp13TeV(TRandom *)
+  {
+        return 443;
+  }
+
+
+private:
+
+  GeneratorParam *paramJpsi = nullptr;
+
+};
+
+
+class O2_GeneratorParamPsi : public GeneratorTGenerator   
+{
+
+public:
+  
+  O2_GeneratorParamPsi() : GeneratorTGenerator("ParamPsi") {
+    paramPsi = new GeneratorParam(1, -1, PtPsipp13TeV, YPsipp13TeV, V2Psipp13TeV, IpPsipp13TeV);
+    paramPsi->SetMomentumRange(0., 1.e6); // Momentum range added from me
+    paramPsi->SetPtRange(0., 1000.); // transverse of momentum range
+    paramPsi->SetYRange(-1.0, 1.0);  // rapidity range
+    paramPsi->SetPhiRange(0., 360.); // phi range
+    paramPsi->SetDecayer(new TPythia6Decayer()); // Pythia decayer
+    paramPsi->SetForceDecay(kNoDecay); // particle left undecayed
+    setTGenerator(paramPsi); // Setting parameters to ParamPsi for Psi(2S)
+  };
+
+
+  ~O2_GeneratorParamPsi() {
+    delete paramPsi;
+  };
+
+  Bool_t Init() override {
+    GeneratorTGenerator::Init();
+    paramPsi->Init();
+    return true;
+  }
+  void SetNSignalPerEvent(Int_t nsig){paramPsi->SetNumberParticles(nsig);}
+
+  //-------------------------------------------------------------------------//
+  static Double_t PtPsipp13TeV(const Double_t *px, const Double_t * /*dummy*/)
+  {
+  	// prompt J/Psi pT
+  	// pp, 13TeV (tuned on pp 13 TeV, 2016-2018)
+  	//
+  	const Double_t kC    = 2.28550e+00;
+  	const Double_t kpt0  = 3.73619e+00;
+  	const Double_t kn    = 2.81708e+00;
+  	Double_t pt          = px[0];
+
+  	return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t YPsipp13TeV(const Double_t *py, const Double_t * /*dummy*/)
+  {
+        // jpsi y in pp at 13 TeV, tuned on data, prompt jpsi ALICE+LHCb, 13 TeV
+        Double_t y = *py;
+        Float_t p0, p1, p2;
+        p0 = 7.79382e+00;
+        p1 = 2.87827e-06;
+        p2 = 4.41847e+00;
+        return p0 * TMath::Exp(-(1. / 2.) * TMath::Power(((y - p1) / p2), 2));
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t V2Psipp13TeV(const Double_t * /*dummy*/, const Double_t * /*dummy*/)
+  {
+        //jpsi v2
+        return 0.;
+  }
+
+  //-------------------------------------------------------------------------//
+  static Int_t IpPsipp13TeV(TRandom *)
+  {
+        return 100443;
+  }
+
+private:
+
+  GeneratorParam *paramPsi = nullptr;
+
+};
+
+
+}}
+
+
+FairGenerator*
+GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV() 
+{
+  auto genCocktailEvtGen = new o2::eventgen::GeneratorEvtGen<GeneratorCocktail_class>();
+  
+  
+  auto genJpsi = new o2::eventgen::O2_GeneratorParamJpsi;
+  genJpsi->SetNSignalPerEvent(1); // signal per event for J/Psi
+  auto genPsi = new o2::eventgen::O2_GeneratorParamPsi;
+  genPsi->SetNSignalPerEvent(1);  // signal per event for Psi(2s)
+  genCocktailEvtGen->AddGenerator(genJpsi,1); // add cocktail --> J/Psi
+  genCocktailEvtGen->AddGenerator(genPsi,1);  // add cocktail --> Psi(2s)
+
+  TString pdgs = "443;100443";
+  std::string spdg; 
+  TObjArray *obj = pdgs.Tokenize(";"); 
+  genCocktailEvtGen->SetSizePdg(obj->GetEntriesFast()); 
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   genCocktailEvtGen->AddPdg(std::stoi(spdg),i); 
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  genCocktailEvtGen->SetForceDecay(kEvtDiElectron); 
+  
+  // print debug
+  genCocktailEvtGen->PrintDebug(); 
+
+  return genCocktailEvtGen;
+}
+
+

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
@@ -20,9 +20,3 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 [TriggerExternal]
 fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-4.3,-2.3)
-
-### The setup inhibits transport of primary particles which are produce at forward rapidity.
-### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
-
-[Stack]
-transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+funcName = GeneratorBeautyToPsi_EvtGenFwdY()
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-4.3,-2.3)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
@@ -1,0 +1,28 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+funcName = GeneratorBeautyToPsi_EvtGenMidY()
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-1.5,1.5)
+
+### The setup inhibits transport of primary particles which are produce at forward rapidity.
+### The settings below only transports particles in the barrel, which is currently defined as |eta| < 2
+
+[Stack]
+transportPrimary = barrel

--- a/MC/run/PWGDQ/runBeautyToPsi_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToPsi_fwdy_pp.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8} 
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini  \
+    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runBeautyToPsi_midy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToPsi_midy_pp.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini  \
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} 
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runPromptCharmonia_midy_pp.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_midy_pp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV()"  \
+    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Dear Experts,

We prepared MC simulation chains for non-prompt Psi(2S) Mid and Forward Y and Prompt Charmonia Mid Y.

Modifications are:

-Added .DEC Fİles h_B to Psi(2S) to Dielectron and Dimuon (for non-prompt Psi(2S) Mid and Forward Y)

-GeneratorEvtgen.C modfied for Non-Prompt Psi(2S) decays.

-Added Generator Config Macros for non-prompt psi(2s) and prompt charmonia mid rapidity.

-Added .ini files for non-prompt Psi(2S) Forward and Mid Y

-Added Run scripts for non-prompt psi(2s) and prompt charmonia mid rapidity