### PR TITLE
Putting MFT full reconstruction as an option

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -91,6 +91,9 @@ parser.add_argument('--include-local-qc', action='store_true', help='includes th
 parser.add_argument('--include-analysis', '--include-an', '--analysis',
                     action='store_true', help='a flag to include O2 analysis in the workflow')
 
+# MFT reconstruction configuration
+parser.add_argument('--mft-reco-full', action='store_true', help='enables complete mft reco instead of simplified misaligned version')
+
 args = parser.parse_args()
 print (args)
 
@@ -616,8 +619,12 @@ for tf in range(1, NTIMEFRAMES + 1):
    TOFTPCMATCHERtask['cmd'] = 'o2-tof-matcher-workflow ' + getDPL_global_options() + putConfigValues({"ITSClustererParam.dictFilePath":"../"})
    workflow['stages'].append(TOFTPCMATCHERtask)
 
+   MFTConfig = {"MFTClustererParam.dictFilePath":"../"}
+   if args.mft_reco_full == True:
+      MFTConfig.update({"MFTTracking.forceZeroField" : 0,
+                        "MFTTracking.LTFclsRCut" : 0.0100})
    MFTRECOtask = createTask(name='mftreco_'+str(tf), needs=[det_to_digitask["MFT"]['name'], MFT_DICT_DOWNLOADER_TASK['name']], tf=tf, cwd=timeframeworkdir, lab=["RECO"], mem='1500')
-   MFTRECOtask['cmd'] = 'o2-mft-reco-workflow ' + getDPL_global_options() + putConfigValues({"MFTClustererParam.dictFilePath" : "../", "MFTTracking.forceZeroField": 0, "MFTTracking.LTFclsRCut" : 0.0100})
+   MFTRECOtask['cmd'] = 'o2-mft-reco-workflow ' + getDPL_global_options() + putConfigValues(MFTConfig)
    workflow['stages'].append(MFTRECOtask)
 
    # MCH reco: needing access to kinematics ... so some extra logic needed here

--- a/MC/run/PWGDQ/runBeautyToJpsi_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToJpsi_fwdy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini  \
-        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runBeautyToJpsi_midy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToJpsi_midy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_midy.ini  \
-	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} 
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full 
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runBeautyToPsi_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToPsi_fwdy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini  \
-    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runBeautyToPsi_midy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToPsi_midy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini  \
-	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} 
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV()"  \
-        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 
 # run workflow

--- a/MC/run/PWGDQ/runPromptCharmonia_midy_pp.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_midy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToElectronEvtGen_pp13TeV()"  \
-    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+    -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 
 # run workflow

--- a/MC/run/PWGDQ/runPromptJpsi_midy_pp.sh
+++ b/MC/run/PWGDQ/runPromptJpsi_midy_pp.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToElectronEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorParamPromptJpsiToElectronEvtGen_pp13TeV()"  \
-       	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS}
+       	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Added option `--mft-reco-full` to enable full MFT reconstruction, used by PWGDQ scripts. The default is the simplified tracking for a misaligned detector.