### PR TITLE
Modifications

### DIFF
--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOJPSITOELE.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOJPSITOELE.DEC
@@ -184,6 +184,34 @@ Decay anti-Omega_b+
   0.00047    anti-Omega+        J/psi                     PHSP;
 Enddecay
 
+Decay B_c-
+#                  SemiLeptonic Decays
+0.01900    J/psi      e-      anti-nu_e         PHOTOS  PHSP;
+#                  Hadronic Decays
+0.00130    J/psi      pi-                   SVS;
+0.00400    J/psi      rho-                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K-                    SVS;
+0.00022    J/psi      K*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00170    J/psi      D_s-                  SVS;
+0.00670    J/psi      D_s*-                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D-                    SVS;
+0.00028    J/psi      D*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+Enddecay
+
+Decay B_c+
+#                  SemiLeptonic Decays
+0.01900    J/psi      e+          nu_e         PHOTOS  PHSP;
+#                  Hadronic Decays
+0.00130    J/psi      pi+                   SVS;
+0.00400    J/psi      rho+                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K+                    SVS;
+0.00022    J/psi      K*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00170    J/psi      D_s+                  SVS;
+0.00670    J/psi      D_s*+                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D+                    SVS;
+0.00028    J/psi      D*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+Enddecay
+
 Decay J/psi
 1.000 e+   e-                PHOTOS VLL;
 Enddecay

--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOJPSITOMU.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOJPSITOMU.DEC
@@ -121,7 +121,7 @@ Decay B_s0
 0.0002    J/psi   pi+      pi-       PHSP;
 0.0002    J/psi   pi0      pi0       PHSP;
 # PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
-0.0000023   phi    e+     e-                   BTOSLLALI;
+0.0000023   phi    mu+    mu-                  BTOSLLALI;
 Enddecay
 
 Decay anti-B_s0
@@ -146,7 +146,7 @@ Decay anti-B_s0
 0.0002    J/psi   pi+      pi-       PHSP;
 0.0002    J/psi   pi0      pi0       PHSP;
 # PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
-0.0000023   phi    e-     e+                   BTOSLLALI;
+0.0000023   phi    mu+    mu-                  BTOSLLALI;
 
 Enddecay
 
@@ -184,9 +184,36 @@ Decay anti-Omega_b+
   0.00047    anti-Omega+        J/psi                     PHSP;
 Enddecay
 
+Decay B_c-
+#                  SemiLeptonic Decays
+0.01900    J/psi      mu-     anti-nu_mu        PHOTOS  PHSP;
+#                  Hadronic Decays
+0.00130    J/psi      pi-                   SVS;
+0.00400    J/psi      rho-                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K-                    SVS;
+0.00022    J/psi      K*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00170    J/psi      D_s-                  SVS;
+0.00670    J/psi      D_s*-                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D-                    SVS;
+0.00028    J/psi      D*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+Enddecay
+
+Decay B_c+
+#                  SemiLeptonic Decays
+0.01900    J/psi      mu+         nu_mu        PHOTOS  PHSP;
+#                  Hadronic Decays
+0.00130    J/psi      pi+                   SVS;
+0.00400    J/psi      rho+                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K+                    SVS;
+0.00022    J/psi      K*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00170    J/psi      D_s+                  SVS;
+0.00670    J/psi      D_s*+                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D+                    SVS;
+0.00028    J/psi      D*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+Enddecay
+
 Decay J/psi
 1.000 mu+   mu-                PHOTOS VLL;
 Enddecay
-
 
 End

--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOELE.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOELE.DEC
@@ -133,11 +133,9 @@ Decay Xi_b-
   0.00038    Xi-        psi(2S)                           PHSP;
 Enddecay
 
-
 Decay anti-Xi_b+
   0.00038    anti-Xi+        psi(2S)                      PHSP;
 Enddecay
-
 
 Decay Omega_b-
   0.00038    Omega-        psi(2S)                        PHSP;
@@ -145,6 +143,16 @@ Enddecay
 
 Decay anti-Omega_b+
   0.00038    anti-Omega+        psi(2S)                   PHSP;
+Enddecay
+
+Decay B_c-
+#                  SemiLeptonic Decays
+0.00094    psi(2S)    e-      anti-nu_e         PHOTOS  PHSP;
+Enddecay
+
+Decay B_c+
+#                  SemiLeptonic Decays
+0.00094    psi(2S)    e+          nu_e         PHOTOS  PHSP;
 Enddecay
 
 Decay psi(2S)

--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOMU.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSITOMU.DEC
@@ -93,7 +93,7 @@ Decay B_s0
 0.0002    psi(2S) pi0      pi0       PHSP;
 #
 # PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
-0.0000023   phi    e+     e-                   BTOSLLALI;
+0.0000023   phi    mu+    mu-                  BTOSLLALI;
 Enddecay
 
 Decay anti-B_s0
@@ -117,7 +117,7 @@ Decay anti-B_s0
 0.0002    psi(2S) pi0      pi0       PHSP;
 #
 # PR LHCb 04/08/2004 : add Bs -> phi mu mu, phi e e
-0.0000023   phi    e-     e+                   BTOSLLALI;
+0.0000023   phi    mu+    mu-                  BTOSLLALI;
 
 Enddecay
 
@@ -133,11 +133,9 @@ Decay Xi_b-
   0.00038    Xi-        psi(2S)                           PHSP;
 Enddecay
 
-
 Decay anti-Xi_b+
   0.00038    anti-Xi+        psi(2S)                      PHSP;
 Enddecay
-
 
 Decay Omega_b-
   0.00038    Omega-        psi(2S)                        PHSP;
@@ -145,6 +143,16 @@ Enddecay
 
 Decay anti-Omega_b+
   0.00038    anti-Omega+        psi(2S)                   PHSP;
+Enddecay
+
+Decay B_c-
+#                  SemiLeptonic Decays
+0.00094    psi(2S)    mu-     anti-nu_mu        PHOTOS  PHSP;
+Enddecay
+
+Decay B_c+
+#                  SemiLeptonic Decays
+0.00094    psi(2S)    mu+         nu_mu        PHOTOS  PHSP;
 Enddecay
 
 Decay psi(2S)

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
@@ -10,7 +10,7 @@ R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
 #include "GeneratorHF.C"
 
 FairGenerator*
-GeneratorBeautyToJpsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+GeneratorBeautyToJpsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;541;5112;5122;5232;5132;5332")
 {
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>(); 
   gen->setRapidity(rapidityMin,rapidityMax);
@@ -38,7 +38,7 @@ GeneratorBeautyToJpsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax =
 }
 
 FairGenerator*
-GeneratorBeautyToJpsi_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2.2, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+GeneratorBeautyToJpsi_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2.2, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;541;5112;5122;5232;5132;5332")
 {
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin,rapidityMax);

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
@@ -10,7 +10,7 @@ R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
 #include "GeneratorHF.C"
 
 FairGenerator*
-GeneratorBeautyToPsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+GeneratorBeautyToPsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 1.5, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;541;5112;5122;5132;5332")
 {
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>(); 
   gen->setRapidity(rapidityMin,rapidityMax);
@@ -38,7 +38,7 @@ GeneratorBeautyToPsi_EvtGenMidY(double rapidityMin = -1.5, double rapidityMax = 
 }
 
 FairGenerator*
-GeneratorBeautyToPsi_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2.2, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;5112;5122;5232;5132")
+GeneratorBeautyToPsi_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2.2, bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;541;5112;5122;5132;5332")
 {
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin,rapidityMax);


### PR DESCRIPTION
Dear Experts,

I would like to summarize some of the changes we want to make for Non-Prompt MC simulations.

- B_c- and B_c+ Semileptonic decays added to all decay files related to Non-Prompt J/psi and Non-Prompt Psi(2S).
- B_c- and B_c+ Hadronic Decays added to all decay files related to Non-Prompt J/psi.
- phi + dilepton decays fixed for dimuon decays in decay files.
- For Non-Prompt J/psi Generator config macro (GeneratorBeautyToJpsi_EvtGen.C) , added pdg code for B_c (541) and for Omega_b- (5332). These changes both for Mid and Forward Rapidity.
- For Non-Prompt Psi(2S) Generator config macro (GeneratorBeautyToPsi_EvtGen.C), added pdg code for B_c (541) and for Omega_b- (5332). Also I delete Xi_b0 (5232) because Xi_b0  doesn't have decay mode to Psi(2S). These changes both for Mid and Forward Rapidity.

Kind Regards
