### PR TITLE
take out fairmq-ipc-prefix

### DIFF
--- a/MC/analysis_testing/analysis_test.sh
+++ b/MC/analysis_testing/analysis_test.sh
@@ -16,7 +16,7 @@ testanalysis=$1 # o2-analysistutorial-mc-histograms o2-analysis-spectra-tof-tiny
 NTF=$(find ./ -name "tf*" -type d | wc | awk '//{print $1}')
 #
 
-commonDPL="-b --run --driver-client-backend ws:// --fairmq-ipc-prefix ${FAIRMQ_IPC_PREFIX:-./.tmp}"
+commonDPL="-b --run --driver-client-backend ws://"
 annaCMD="RC=0; if [ -f AO2D.root ]; then timeout 600s ${testanalysis} ${commonDPL} --aod-file AO2D.root; RC=\$?; fi; [ -f AnalysisResults.root ] && mv AnalysisResults.root AnalysisResults_${testanalysis}.root; [ -f QAResult.root ] && mv QAResults.root QAResults_${testanalysis}.root; [ \${RC} -eq 0 ]"
 
 rm workflow_ana.json

--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -20,7 +20,7 @@ sys.path.append(join(dirname(__file__), '.', 'o2dpg_workflow_utils'))
 from o2dpg_workflow_utils import createTask, dump_workflow
 
 def getDPL_global_options(bigshm=False, noIPC=None):
-   common="-b --run --fairmq-ipc-prefix ${FAIRMQ_IPC_PREFIX:-./} --driver-client-backend ws:// "
+   common="-b --run --driver-client-backend ws:// "
    if noIPC != None:
       return common + " --no-IPC "
    if bigshm:

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -140,7 +140,7 @@ workflow['stages'] = []
 
 
 def getDPL_global_options(bigshm=False):
-   common="-b --run --fairmq-ipc-prefix ${FAIRMQ_IPC_PREFIX:-./} --driver-client-backend ws:// "
+   common="-b --run --driver-client-backend ws:// "
    if args.noIPC!=None:
       return common + " --no-IPC "
    if bigshm:


### PR DESCRIPTION
This seems no longer necessary. Sockets will be anonymous
and not populate /tmp or other visible directories anymore