### PR TITLE
[MFT] Switch to MFT ASync QC task

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -48,7 +48,7 @@ def include_all_QC_finalization(ntimeframes, standalone, run):
   #add_QC_finalization('mftDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-digit.json', MFTDigitsQCneeds)
   add_QC_finalization('mftDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-digit.json')
   add_QC_finalization('mftClustersQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-cluster.json')
-  add_QC_finalization('mftTracksQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-track.json')
+  add_QC_finalization('mftAsyncQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-async.json')
   #add_QC_finalization('tpcTrackingQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-tracking-direct.json')
   add_QC_finalization('trdDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/trd-digits-task.json')
   add_QC_finalization('vertexQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/vertexing-qc-direct-mc.json')

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -474,7 +474,7 @@ for tf in range(1, NTIMEFRAMES + 1):
       # for pp we adjust the strobe lengths to
       # These numbers must be a divisor of 3564 (orbit duration in BCs)
       AlpideConfig.update({"ITSAlpideParam.roFrameLengthInBC" : 198,
-                           "MFTAlpideParam.roFrameLengthInBC" : 297})
+                           "MFTAlpideParam.roFrameLengthInBC" : 198})
 
 
    def putConfigValues(localCF = {}):
@@ -767,12 +767,12 @@ for tf in range(1, NTIMEFRAMES + 1):
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-digit.json')
      addQCPerTF(taskName='mftClustersQC',
                 needs=[MFTRECOtask['name']],
-                readerCommand='o2-qc-mft-clusters-root-file-reader --mft-cluster-infile=mftclusters.root',
+                readerCommand='o2-global-track-cluster-reader --track-types none --cluster-types MFT',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-cluster.json')
-     addQCPerTF(taskName='mftTracksQC',
+     addQCPerTF(taskName='mftAsyncQC',
                 needs=[MFTRECOtask['name']],
-                readerCommand='o2-qc-mft-tracks-root-file-reader --mft-track-infile=mfttracks.root',
-                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-track.json')
+                readerCommand='o2-global-track-cluster-reader --track-types MFT --cluster-types MFT',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-async.json')
 
      ### TPC
      # addQCPerTF(taskName='tpcTrackingQC',

--- a/MC/config/QC/json/qc-mft-async.json
+++ b/MC/config/QC/json/qc-mft-async.json
@@ -26,38 +26,29 @@
       }
     },
     "tasks": {
-      "QcMFTTrackTask": {
+      "QcMFTAsync": {
         "active": "true",
-        "className": "o2::quality_control_modules::mft::QcMFTTrackTask",
+        "className": "o2::quality_control_modules::mft::QcMFTAsyncTask",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
         "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",
-          "query": "randomtrack:MFT/TRACKS/0;tracksrof:MFT/MFTTrackROF/0"
+          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clusters:MFT/COMPCLUSTERS/0;clustersrofs:MFT/CLUSTERSROF/0"
         },
         "taskParameters": {
-          "myOwnKey": "myOwnValue"
+          "ROFLengthInBC": "198",
+          "MaxTrackROFSize": "1000",
+          "MaxClusterROFSize": "5000",
+          "MaxDuration": "60000",
+          "TimeBinSize": "0.1",
+          "RefOrbit": "0"
         },
         "location": "remote"
       }
     },
-    "checks": {
-      "QcMFTTrackCheck": {
-        "active": "false",
-        "dataSource": [{
-          "type": "Task",
-          "name": "QcMFTTrackTask",
-          "MOs": ["mMFTTrackCharge"]
-        }],
-        "className": "o2::quality_control_modules::mft::QcMFTTrackCheck",
-        "moduleName": "QcMFT",
-        "detectorName": "MFT",
-        "policy": "OnAny"
-      }
-    }    
+    "checks": {}    
   },
   "dataSamplingPolicies": [
   ]


### PR DESCRIPTION
MFT Async QC task is used in central reconstruction and should also be used in official productions.
Also changed `MFTAlpideParam.roFrameLengthInBC` to our lucky number.