### PR TITLE
o2dpg_sim_workflow.py: options to enable forward assessment

### DIFF
--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp_assessment.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp_assessment.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV()"  \
+        -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full
+
+
+# run workflow
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Add options to enable assessment workflows to `o2dpg_sim_workflow.py`

* `--mft-assessment-full` enables MFT standalone assessment workflow, produces `MFTAssessment.root`
*  `--fwdmatching-assessment-full` enables global forward matching assessment workflow, produces `GlobalForwardAssessment.root`

Working example on `MC/run/PWGDQ/runPromptCharmonia_fwdy_pp_assessment.sh`