### PR TITLE
Generator Config Macro for PWG-DQ Pb-pb Quarkonia Forward Y and Update run script

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C
@@ -1,0 +1,190 @@
+// usage
+// o2-sim -j 4 -n 10 -g external  -o sgn  --configKeyValues "GeneratorExternal.fileName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV()"
+//
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/PromptQuarkonia)
+#include "GeneratorCocktail.C"
+#include "GeneratorEvtGen.C"
+
+namespace o2 {
+namespace eventgen {
+
+class O2_GeneratorParamJpsi : public GeneratorTGenerator
+{
+
+public:
+
+  O2_GeneratorParamJpsi() : GeneratorTGenerator("ParamJpsi") {
+    paramJpsi = new GeneratorParam(1, -1, PtJPsiPbPb5TeV, YJPsiPbPb5TeV, V2JPsiPbPb5TeV, IpJPsiPbPb5TeV);
+    paramJpsi->SetMomentumRange(0., 1.e6);
+    paramJpsi->SetPtRange(0, 999.);
+    paramJpsi->SetYRange(-4.2, -2.3);
+    paramJpsi->SetPhiRange(0., 360.);
+    paramJpsi->SetDecayer(new TPythia6Decayer());
+    paramJpsi->SetForceDecay(kNoDecay); // particle left undecayed
+    // - - paramJpsi->SetTrackingFlag(1);  // (from AliGenParam) -> check this
+    setTGenerator(paramJpsi);
+  };
+
+
+  ~O2_GeneratorParamJpsi() {
+    delete paramJpsi;
+  };
+
+  Bool_t Init() override {
+    GeneratorTGenerator::Init();
+    paramJpsi->Init();
+    return true;
+  }
+
+  void SetNSignalPerEvent(Int_t nsig){paramJpsi->SetNumberParticles(nsig);}
+
+  //-------------------------------------------------------------------------//
+  static Double_t PtJPsiPbPb5TeV(const Double_t *px, const Double_t * /*dummy*/)
+  {
+  	// jpsi pT in PbPb, tuned on data (2015) -> Castillo embedding https://alice.its.cern.ch/jira/browse/ALIROOT-8174?jql=text%20~%20%22LHC19a2%22
+	Double_t x=*px;
+	Float_t p0,p1,p2,p3;
+	p0 = 1.00715e6;
+	p1 = 3.50274;
+	p2 = 1.93403;
+	p3 = 3.96363;
+	return p0 *x / TMath::Power( 1. + TMath::Power(x/p1,p2), p3 );
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t YJPsiPbPb5TeV(const Double_t *py, const Double_t * /*dummy*/)
+  {
+  	// jpsi y in PbPb, tuned on data (2015) -> Castillo embedding https://alice.its.cern.ch/jira/browse/ALIROOT-8174?jql=text%20~%20%22LHC19a2%22
+	Double_t y = *py;
+	Float_t p0,p1,p2;
+	p0 = 1.09886e6;
+	p1 = 0;
+	p2 = 2.12568;
+	return p0*TMath::Exp(-(1./2.)*TMath::Power(((y-p1)/p2),2));
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t V2JPsiPbPb5TeV(const Double_t * /*dummy*/, const Double_t * /*dummy*/)
+  {
+        //jpsi v2
+        return 0.;
+  }
+
+  //-------------------------------------------------------------------------//
+  static Int_t IpJPsiPbPb5TeV(TRandom *)
+  {
+        return 443;
+  }
+
+
+private:
+
+  GeneratorParam *paramJpsi = nullptr;
+
+};
+
+class O2_GeneratorParamPsi : public GeneratorTGenerator
+{
+
+public:
+
+  O2_GeneratorParamPsi() : GeneratorTGenerator("ParamPsi") {
+    paramPsi = new GeneratorParam(1, -1, PtPsiPbPb5TeV, YPsiPbPb5TeV, V2PsiPbPb5TeV, IpPsiPbPb5TeV);
+    paramPsi->SetMomentumRange(0., 1.e6);
+    paramPsi->SetPtRange(0, 999.);
+    paramPsi->SetYRange(-4.2, -2.3);
+    paramPsi->SetPhiRange(0., 360.);
+    paramPsi->SetDecayer(new TPythia6Decayer());
+    paramPsi->SetForceDecay(kNoDecay); // particle left undecayed
+    // - - paramJpsi->SetTrackingFlag(1);  // check this
+    setTGenerator(paramPsi);
+  };
+
+  ~O2_GeneratorParamPsi() {
+    delete paramPsi;
+  };
+
+  Bool_t Init() override {
+    GeneratorTGenerator::Init();
+    paramPsi->Init();
+    return true;
+  }
+
+  void SetNSignalPerEvent(Int_t nsig){paramPsi->SetNumberParticles(nsig);}
+
+  //-------------------------------------------------------------------------//
+  static Double_t PtPsiPbPb5TeV(const Double_t *px, const Double_t * /*dummy*/)
+  {
+  	// jpsi pT in PbPb, tuned on data (2015) -> Castillo embedding https://alice.its.cern.ch/jira/browse/ALIROOT-8174?jql=text%20~%20%22LHC19a2%22
+	Double_t x=*px;
+	Float_t p0,p1,p2,p3;
+	p0 = 1.00715e6;
+	p1 = 3.50274;
+	p2 = 1.93403;
+	p3 = 3.96363;
+	return p0 *x / TMath::Power( 1. + TMath::Power(x/p1,p2), p3 );
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t YPsiPbPb5TeV(const Double_t *py, const Double_t * /*dummy*/)
+  {
+  	// jpsi y in PbPb, tuned on data (2015) -> Castillo embedding https://alice.its.cern.ch/jira/browse/ALIROOT-8174?jql=text%20~%20%22LHC19a2%22
+	Double_t y = *py;
+	Float_t p0,p1,p2;
+	p0 = 1.09886e6;
+	p1 = 0;
+	p2 = 2.12568;
+	return p0*TMath::Exp(-(1./2.)*TMath::Power(((y-p1)/p2),2));
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t V2PsiPbPb5TeV(const Double_t * /*dummy*/, const Double_t * /*dummy*/)
+  {
+        //jpsi v2
+        return 0.;
+  }
+
+  //-------------------------------------------------------------------------//
+  static Int_t IpPsiPbPb5TeV(TRandom *)
+  {
+        return 100443;
+  }
+
+
+private:
+
+  GeneratorParam *paramPsi = nullptr;
+
+};
+
+
+}}
+
+
+FairGenerator* GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV()
+{
+
+  auto genCocktailEvtGen = new o2::eventgen::GeneratorEvtGen<GeneratorCocktail_class>();
+
+  auto genJpsi = new o2::eventgen::O2_GeneratorParamJpsi;
+  genJpsi->SetNSignalPerEvent(4); // 4 J/psi generated per event by GeneratorParam
+  auto genPsi = new o2::eventgen::O2_GeneratorParamPsi;
+  genPsi->SetNSignalPerEvent(2);  // 2 Psi(2S) generated per event by GeneratorParam
+  genCocktailEvtGen->AddGenerator(genJpsi,1); // 2/3 J/psi
+  genCocktailEvtGen->AddGenerator(genPsi,1);  // 1/3 Psi(2S)
+
+
+  TString pdgs = "443;100443";
+  std::string spdg;
+  TObjArray *obj = pdgs.Tokenize(";");
+  genCocktailEvtGen->SetSizePdg(obj->GetEntriesFast());
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   genCocktailEvtGen->AddPdg(std::stoi(spdg),i);
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  genCocktailEvtGen->SetForceDecay(kEvtDiMuon);
+
+  return genCocktailEvtGen;
+}

--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
@@ -15,8 +15,8 @@ NWORKERS=${NWORKERS:-8}
 NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
-	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV()"  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV()"  \
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV()"  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Dear Experts,

p_T distributions and Rapidity shapes (parameters) are different for Proton - Proton and Pb-Pb collisions system (For Monte Carlo Simulations).

According to AliDPG Generator Config Macro for J/psi --> Dimuon for Pb-Pb Collision system, I prepared a new generator config macro for Quarkonia Fwdy Pb-Pb MC (PWG-DQ).

You can check reference generator config macro in below:

`https://github.com/alisw/AliDPG/blob/master/MC/CustomGenerators/PWGDQ/Muon_GenParamJpsi_PbPb5TeV_1.C`

Best Regards

