### PR TITLE
TPC-QC: deactivate Clusters Tasks in MC

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -827,7 +827,8 @@ for tf in range(1, NTIMEFRAMES + 1):
      #           configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-tracking-direct.json')
      addQCPerTF(taskName='tpcStandardQC',
                  needs=[TPCRECOtask['name']],
-                 readerCommand='o2-tpc-file-reader --tpc-track-reader "--infile tpctracks.root" --tpc-native-cluster-reader "--infile tpc-native-clusters.root" --input-type clusters,tracks',
+     #            readerCommand='o2-tpc-file-reader --tpc-track-reader "--infile tpctracks.root" --tpc-native-cluster-reader "--infile tpc-native-clusters.root" --input-type clusters,tracks',
+                 readerCommand='o2-tpc-file-reader --tpc-track-reader "--infile tpctracks.root" --input-type tracks',
                  configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-standard-direct.json')
 
      ### TRD

--- a/MC/config/QC/json/tpc-qc-standard-direct.json
+++ b/MC/config/QC/json/tpc-qc-standard-direct.json
@@ -32,7 +32,7 @@
     },
     "tasks": {
       "Clusters": {
-        "active": "true",
+        "active": "false",
         "className": "o2::quality_control_modules::tpc::Clusters",
         "moduleName": "QcTPC",
         "detectorName": "TPC",


### PR DESCRIPTION
We found an issue with the Clusters task, which will likely lead any MC production to crash. This was not spotted in the small-scale tests done before. For now, it has to be deactivated. Will be reactivated, as soon as the issue could be solved.