### PR TITLE
[EMCAL-524, EMCAL-525] Renaming digits to cell task

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -23,16 +23,16 @@
       }
     },
     "tasks": {
-      "DigitsTask": {
+      "CellTask": {
         "active": "true",
-        "className": "o2::quality_control_modules::emcal::DigitsQcTask",
+        "className": "o2::quality_control_modules::emcal::CellTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",
         "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR"
+          "query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR"
         }
       }
     }

--- a/DATA/production/qc-sync/emc.json
+++ b/DATA/production/qc-sync/emc.json
@@ -47,9 +47,9 @@
 		    "mergingMode": "delta",
 		    "localControl": "odc"
 		},
-		"DigitsTask": {
+		"CellTask": {
 		    "active": "true",
-		    "className": "o2::quality_control_modules::emcal::DigitsQcTask",
+		    "className": "o2::quality_control_modules::emcal::CellTask",
 		    "moduleName": "QcEMCAL",
 		    "detectorName": "EMC",
 		    "cycleDurationSeconds": "60",
@@ -106,18 +106,18 @@
 				}
 			]
 		},
-    		"DigitsCheckAmplitude": {
+    		"CellCheckAmplitude": {
 		    "active": "true",
-		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "className": "o2::quality_control_modules::emcal::CellCheck",
 		    "moduleName": "QcEMCAL",
 		    "policy": "OnEachSeparately",
 		    "detectorName": "EMC",
 		    "dataSource": [
 				{
 				    "type": "Task",
-				    "name": "DigitsTask",
-				    "MOs": ["digitAmplitudeEMCAL_CAL", "digitAmplitudeEMCAL_PHYS", "digitAmplitudeDCAL_CAL", "digitAmplitudeDCAL_PHYS",
-							"digitAmplitude_CAL", "digitAmplitude_PHYS"	
+				    "name": "CellTask",
+				    "MOs": ["cellAmplitudeEMCAL_CAL", "cellAmplitudeEMCAL_PHYS", "cellAmplitudeDCAL_CAL", "cellAmplitudeDCAL_PHYS",
+							"cellAmplitude_CAL", "cellAmplitude_PHYS"	
 				    ]
 				}
 		    ]
@@ -143,7 +143,7 @@
 		"id": "emccells",
 		"active": "true",
 		"machines": ["localhost"],
-		"query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
+		"query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
 		"samplingConditions": [
 		    {
 			"condition": "random",


### PR DESCRIPTION
DigitQcTask has been renamed in
QualityControl v1.46 to CellTask for
consistency with its input source.