### PR TITLE
[R3C-752] Change ITS noise calib to digit inputs with 32 threads

### DIFF
--- a/DATA/production/calib/its-noise-aggregator.sh
+++ b/DATA/production/calib/its-noise-aggregator.sh
@@ -15,10 +15,18 @@ if [ $NORATELOG == 1 ]; then
 fi
 ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
-PROXY_INSPEC="A:ITS/COMPCLUSTERS/0;B:ITS/PATTERNS/0;C:ITS/CLUSTERSROF/0;eos:***/INFORMATION"
+INPTYPE=""
+if [[ -z $USECLUSTERS ]]; then
+  PROXY_INSPEC="A:ITS/DIGITS/0;B:ITS/DIGITSROF/0;eos:***/INFORMATION"
+else
+  PROXY_INSPEC="A:ITS/COMPCLUSTERS/0;B:ITS/PATTERNS/0;C:ITS/CLUSTERSROF/0;eos:***/INFORMATION"
+  INPTYPE=" --use-clusters "  
+fi
+
+if [[ -z $NTHREADS ]] ; then NTHREADS=1; fi
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-noise-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-noise-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
-WORKFLOW+="o2-calibration-its-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-5 | "
+WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-5 --nthreads ${NTHREADS} ${INPTYPE} | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://ccdb-test.cern.ch:8080\" | "
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 

--- a/DATA/production/calib/its-noise-processing.sh
+++ b/DATA/production/calib/its-noise-processing.sh
@@ -16,10 +16,17 @@ fi
 ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
-PROXY_OUTSPEC="downstreamA:ITS/COMPCLUSTERS/0;downstreamB:ITS/PATTERNS/0;downstreamC:ITS/CLUSTERSROF/0"
 
+OUTTYPE=""
+if [[ -z $USECLUSTERS ]]; then
+  PROXY_OUTSPEC="downstreamA:ITS/DIGITS/0;downstreamB:ITS/DIGITSROF/0"
+  OUTTYPE=" --no-clusters --digits "
+else
+  PROXY_OUTSPEC="downstreamA:ITS/COMPCLUSTERS/0;downstreamB:ITS/PATTERNS/0;downstreamC:ITS/CLUSTERSROF/0"
+fi
+  
 WORKFLOW="o2-dpl-raw-proxy ${ARGS_ALL} --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=0\" | "
-WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 4 | "
+WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} ${OUTTYPE} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 4 | "
 WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-noise-input-proxy --channel-config \"name=its-noise-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=0\" | "
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/standalone-calibration.desc
+++ b/DATA/production/standalone-calibration.desc
@@ -1,4 +1,6 @@
-ITS-noise-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-noise-processing.sh" calib,20,"production/calib/its-noise-aggregator.sh"
+ITS-noise-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-noise-processing.sh" calib,20,"NTHREADS=32 production/calib/its-noise-aggregator.sh"
+
+ITS-noise-calibration-clusters: "O2PDPSuite" reco,20,20,"USECLUSTERS=1 production/calib/its-noise-processing.sh" calib,20,"USECLUSTERS=1 NTHREADS=32 production/calib/its-noise-aggregator.sh"
 
 ITS-thr-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-threshold-processing.sh" calib,20,"production/calib/its-threshold-aggregator.sh"
 


### PR DESCRIPTION
To use clusters input one should select ITS-noise-calibration-clusters from the
`standalone-calibration.desc`

This PR depends on https://github.com/AliceO2Group/AliceO2/pull/8186
