### PR TITLE
Add forward box generator for matching studies

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorBoxFwd.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBoxFwd.C
@@ -1,0 +1,57 @@
+#include "FairGenerator.h"
+
+class FwdBoxGenerator : public FairGenerator {
+
+public:
+  FwdBoxGenerator(int nparticles, int pdgcode, float etamin, float etamax,
+                  float ptmin, float ptmax)
+      : FairGenerator(), mPDGCode(pdgcode), mNParticles(nparticles),
+        mEtaMin(etamin), mEtaMax(etamax), mPtMin(ptmin), mPtMax(ptmax){};
+  ~FwdBoxGenerator() = default;
+
+  int mPDGCode;
+  int mNParticles;
+  float mEtaMin;
+  float mEtaMax;
+  float mPtMin;
+  float mPtMax;
+  bool mRandomizeCharge = true;
+  void disableRandomCharge() { mRandomizeCharge = false; }
+
+  Bool_t ReadEvent(FairPrimaryGenerator *primGen) override {
+
+    int iPart = mNParticles;
+    while (iPart) {
+      float pt = gRandom->Uniform(mPtMin, mPtMax);
+      float eta = gRandom->Uniform(mEtaMin, mEtaMax);
+      float phi = gRandom->Uniform(0., TMath::TwoPi());
+      float px = pt * TMath::Cos(phi);
+      float py = pt * TMath::Sin(phi);
+      float tanl = tan(TMath::Pi() / 2 - 2 * atan(exp(-eta)));
+      float pz = tanl * pt;
+      int charge = 1;
+
+      if (mRandomizeCharge && (gRandom->Rndm() < 0.5)) {
+        charge = -1;
+      }
+      primGen->AddTrack(charge * mPDGCode, px, py, pz, 0, 0, 0);
+      printf("Add track %d %.2f %.2f %.2f  \n", charge * mPDGCode, px, py, pz);
+
+      iPart--;
+    }
+    return kTRUE;
+  }
+
+private:
+};
+
+FairGenerator *fwdMuBoxGen(int nParticles = 1, int pdgCode = 13,
+                           float etamin = -3.8f, float etamax = -2.2f,
+                           float ptmin = 0.01f, float ptmax = 20.f) {
+  if (gSystem->Getenv("NMUONS")) {
+    nParticles = atoi(gSystem->Getenv("NMUONS"));
+  }
+  auto gen =
+      new FwdBoxGenerator(nParticles, pdgCode, etamin, etamax, ptmin, ptmax);
+  return gen;
+}

--- a/MC/run/PWGDQ/runFwdMuBoxGen_PbPb.sh
+++ b/MC/run/PWGDQ/runFwdMuBoxGen_PbPb.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+# alienv enter O2/latest-dev-o2 O2DPG/latest-master-o2 AEGIS/latest-o2 EVTGEN/latest-o2
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh 
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+NBOXMUONS=${NBOXMUONS:2}
+
+NMUONS=$NBOXMUONS ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 \
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBoxFwd.C;GeneratorExternal.funcName=fwdMuBoxGen()"  \
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
+
+# run workflow (MFT-related tasks)
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt "(mft.*)" 

--- a/MC/run/PWGDQ/runFwdMuBoxGen_pp.sh
+++ b/MC/run/PWGDQ/runFwdMuBoxGen_pp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# make sure O2DPG + O2 is loaded
+# alienv enter O2/latest-dev-o2 O2DPG/latest-master-o2 AEGIS/latest-o2 EVTGEN/latest-o2
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh
+
+RNDSEED=${RNDSEED:-0}
+NSIGEVENTS=${NSIGEVENTS:-1}
+NBKGEVENTS=${NBKGEVENTS:-1}
+NWORKERS=${NWORKERS:-8}
+NTIMEFRAMES=${NTIMEFRAMES:-1}
+NBOXMUONS=${NBOXMUONS:2}
+
+NMUONS=$NBOXMUONS ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13600 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBoxFwd.C;GeneratorExternal.funcName=fwdMuBoxGen()"  \
+	-genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
+
+# run workflow (MFT-related tasks)
+${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt "(mft.*)"


### PR DESCRIPTION
This PR adds a generator for forward muons. Examples for embedding in pp and PbPb collisions are provided. This is necessary for forward matching performance studies.