### PR TITLE
Add env.vars to set nthreads and lanes of ITS decoder in noise processing

### DIFF
--- a/DATA/production/calib/its-noise-aggregator.sh
+++ b/DATA/production/calib/its-noise-aggregator.sh
@@ -25,7 +25,7 @@ fi
 
 if [[ -z $NTHREADS ]] ; then NTHREADS=1; fi
 
-WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-noise-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-noise-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
+WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-noise-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-noise-input-proxy,method=bind,type=pull,rateLogging=1,transport=zeromq\" | "
 WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-5 --nthreads ${NTHREADS} ${INPTYPE} | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://ccdb-test.cern.ch:8080\" | "
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"

--- a/DATA/production/calib/its-noise-processing.sh
+++ b/DATA/production/calib/its-noise-processing.sh
@@ -24,9 +24,12 @@ if [[ -z $USECLUSTERS ]]; then
 else
   PROXY_OUTSPEC="downstreamA:ITS/COMPCLUSTERS/0;downstreamB:ITS/PATTERNS/0;downstreamC:ITS/CLUSTERSROF/0"
 fi
+
+[[ -z $NITSDECTHREADS ]] && NITSDECTHREADS=4
+[[ -z $NITSDECTPIPELINES ]] && NITSDECTPIPELINES=6
   
 WORKFLOW="o2-dpl-raw-proxy ${ARGS_ALL} --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=0\" | "
-WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} ${OUTTYPE} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 4 | "
+WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} ${OUTTYPE} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads ${NITSDECTHREADS} --pipeline its-stf-decoder:${NITSDECTPIPELINES} | "
 WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-noise-input-proxy --channel-config \"name=its-noise-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=0\" | "
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/calib/its-noise-processing.sh
+++ b/DATA/production/calib/its-noise-processing.sh
@@ -28,9 +28,9 @@ fi
 [[ -z $NITSDECTHREADS ]] && NITSDECTHREADS=4
 [[ -z $NITSDECTPIPELINES ]] && NITSDECTPIPELINES=6
   
-WORKFLOW="o2-dpl-raw-proxy ${ARGS_ALL} --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=0\" | "
+WORKFLOW="o2-dpl-raw-proxy ${ARGS_ALL} --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=1\" | "
 WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} ${OUTTYPE} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads ${NITSDECTHREADS} --pipeline its-stf-decoder:${NITSDECTPIPELINES} | "
-WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-noise-input-proxy --channel-config \"name=its-noise-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=0\" | "
+WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-noise-input-proxy --channel-config \"name=its-noise-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=1\" | "
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 
 if [ $WORKFLOWMODE == "print" ]; then

--- a/DATA/production/standalone-calibration.desc
+++ b/DATA/production/standalone-calibration.desc
@@ -1,6 +1,6 @@
-ITS-noise-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-noise-processing.sh" calib,20,"NTHREADS=32 production/calib/its-noise-aggregator.sh"
+ITS-noise-calibration: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELINES=6 production/calib/its-noise-processing.sh" calib,20,"NTHREADS=32 production/calib/its-noise-aggregator.sh"
 
-ITS-noise-calibration-clusters: "O2PDPSuite" reco,20,20,"USECLUSTERS=1 production/calib/its-noise-processing.sh" calib,20,"USECLUSTERS=1 NTHREADS=32 production/calib/its-noise-aggregator.sh"
+ITS-noise-calibration-clusters: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELINES=6 USECLUSTERS=1 production/calib/its-noise-processing.sh" calib,20,"USECLUSTERS=1 NTHREADS=32 production/calib/its-noise-aggregator.sh"
 
 ITS-thr-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-threshold-processing.sh" calib,20,"production/calib/its-threshold-aggregator.sh"
 


### PR DESCRIPTION
Defaults are set to 4 and 6 respectively, can be modified by NITSDECTHREADS=2 NITSDECTPIPELINES=4 ...