### PR TITLE
updated ITS json for QC async and MC according to QC PR1060

### DIFF
--- a/DATA/production/qc-async/its.json
+++ b/DATA/production/qc-async/its.json
@@ -40,7 +40,8 @@
           "clusterDictionaryPath": "./ITSdictionary.bin",
           "runNumberPath": "",
           "geomPath": "./o2sim_geometry.root",
-          "nThreads": "1"
+          "nThreads": "1",
+	  "nBCbins" : "103"
         }
       },
       "ITSTrackTask": {
@@ -61,7 +62,8 @@
           "vertexZsize": "15",
           "vertexRsize": "0.8",
           "NtracksMAX"  : "100",
-          "doTTree": "0"
+          "doTTree": "0",
+	  "nBCbins" : "103"
         }
       }
     },

--- a/MC/config/QC/json/its-clusters-tracks-qc.json
+++ b/MC/config/QC/json/its-clusters-tracks-qc.json
@@ -43,7 +43,8 @@
           "clusterDictionaryPath": "./ITSdictionary.bin",
           "runNumberPath": "",
           "geomPath": "./o2sim_geometry.root",
-          "nThreads": "1"
+          "nThreads": "1",
+	  "nBCbins" : "103"
         }
       },
       "ITSTrackTask": {
@@ -64,7 +65,8 @@
           "vertexZsize": "15",
           "vertexRsize": "0.8",
           "NtracksMAX"  : "100",
-          "doTTree": "0"
+          "doTTree": "0",
+	  "nBCbins" : "103"
         }
       }
     },


### PR DESCRIPTION
added parameter nBCbins to define the number of bins for plots showing bunch-crossing info. 
(ref: https://github.com/AliceO2Group/QualityControl/pull/1060/files)