### PR TITLE
Make sure that module loading during workflow generation does not change the O2DPG_ROOT of the current O2DPG that executes the job

### DIFF
--- a/DATA/tools/parse
+++ b/DATA/tools/parse
@@ -65,6 +65,9 @@ for line in f:
         calibworkflows = []
         print("Found topology", sys.argv[2], "-", args)
         if 'EPNSYNCMODE' in os.environ and int(os.environ['EPNSYNCMODE']) and (not 'GEN_TOPO_RUN_HOME' in os.environ or not int(os.environ['GEN_TOPO_RUN_HOME'])):
+            restore_O2DPG_ROOT = 'O2DPG_ROOT' in os.environ
+            if restore_O2DPG_ROOT:
+                restore_O2DPG_ROOT_val = os.environ['O2DPG_ROOT']
             if 'OVERRIDE_PDPSUITE_VERSION' in os.environ and os.environ['OVERRIDE_PDPSUITE_VERSION'] != "":
                 args[1] = os.environ['OVERRIDE_PDPSUITE_VERSION']
             for i in args[1].split():
@@ -74,6 +77,8 @@ for line in f:
                         raise
                 print("Loading module", i)
                 mod.module('load', i)
+            if restore_O2DPG_ROOT:
+                os.environ['O2DPG_ROOT'] = restore_O2DPG_ROOT_val
         if len(args) > 2 and not 'O2_ROOT' in os.environ:
             print("O2 not loaded")
             raise


### PR DESCRIPTION
Thx @aphecetche for reporting.
The problem is: The workflow generation loads the O2DPG module once at the beginning, to have access to the general scripts.
Then it goes to the O2DPG folder specified (either by hash or path), and executes the workflow generation there.
Now, that workflow generation loads an O2PDPSuite, which contains O2DPG in itself.
If that O2DPG version differs from the one that was initially loaded, it loads the other version as well, and that overrides the $O2DPG_ROOT env variable.
This should not happen after we have already explicitly cd'ed to the correct folder, and made that our O2DPG_ROOT.
This is kind of a hack to maintain the env variable, but I see no better solution unfortunately.