### PR TITLE
add TOF digits QC for MC

### DIFF
--- a/MC/config/QC/json/tofdigits.json
+++ b/MC/config/QC/json/tofdigits.json
@@ -1,0 +1,141 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "TaskDigits": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::TaskDigits",
+        "moduleName": "QcTOF",
+        "detectorName": "TOF",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tof-digits"
+        },
+        "taskParameters": {
+          "Diagnostic": "false"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "TOFRawsMulti": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckRawMultiplicity",
+        "moduleName": "QcTOF",
+        "policy": "OnAny",
+        "detectorName": "TOF",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskDigits",
+            "MOs": [
+              "TOFRawsMulti"
+            ]
+          }
+        ]
+      },
+      "TOFRawsTime": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckRawTime",
+        "moduleName": "QcTOF",
+        "policy": "OnAny",
+        "detectorName": "TOF",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskDigits",
+            "MOs": [
+              "TOFRawsTime"
+            ]
+          }
+        ]
+      },
+      "TOFRawsToT": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckRawToT",
+        "moduleName": "QcTOF",
+        "policy": "OnAny",
+        "detectorName": "TOF",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskDigits",
+            "MOs": [
+              "TOFRawsToT"
+            ]
+          }
+        ]
+      },
+      "TOFRawHitMap": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckHitMap",
+        "moduleName": "QcTOF",
+        "policy": "OnAny",
+        "detectorName": "TOF",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskDigits",
+            "MOs": [
+              "TOFRawHitMap"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "tof-digits",
+      "active": "true",
+      "machines": [],
+      "query": "tofdigits:TOF/DIGITS/0;readoutwin:TOF/READOUTWINDOW/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "tof-digits-dia",
+      "active": "true",
+      "machines": [],
+      "query": "tofdigits:TOF/DIGITS/0;readoutwin:TOF/READOUTWINDOW/0;patterns:TOF/PATTERNS",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}


### PR DESCRIPTION
This is the QC digits to be added in MC workflow as for the data (really needed with anchoring!).
The typical workflow is something like

o2-tof-reco-workflow -b --input-type digits --output-type none| o2-qc -b --config json://${O2DPG_ROOT}/MC/config/QC/json/tofdigits.json --local-batch TOFDigitQC.root