### PR TITLE
DATA-reco anchoring and improved configurability

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -1,0 +1,77 @@
+def create_sim_config(args):
+    # creates a generic simulation config
+    # based on arguments args (run number, energy, ...) originally passed
+    # to o2dpg_sim_workflow.py
+
+    COLTYPEIR = args.col
+    if args.embedding==True:
+        COLTYPEIR = args.colBkg
+
+    config = {}
+    def add(cfg, flatconfig):
+       for entry in flatconfig:
+           mk = entry.split(".")[0]
+           sk = entry.split(".")[1]
+           d = cfg.get(mk,{})
+           d[sk] = flatconfig[entry]
+           cfg[mk] = d
+
+    # some specific settings for pp productions
+    if COLTYPEIR == 'pp':
+       # Alpide chip settings
+       add(config, {"MFTAlpideParam.roFrameLengthInBC" : 198})
+       if 302000 <= int(args.run) and int(args.run) < 309999:
+           add(config, {"ITSAlpideParam.roFrameLengthInBC" : 198})
+
+       # ITS reco settings
+       add(config, {"ITSVertexerParam.phiCut" : 0.5,
+                    "ITSVertexerParam.clusterContributorsCut" : 3,
+                    "ITSVertexerParam.tanLambdaCut" : 0.2})
+       # primary vertexing settings
+       if 301000 <= int(args.run) and int(args.run) <= 301999:
+          add(config, {"pvertexer.acceptableScale2" : 9,
+                       "pvertexer.minScale2" : 2.,
+                       "pvertexer.nSigmaTimeTrack" : 4.,
+                       "pvertexer.timeMarginTrackTime" : 0.5,
+                       "pvertexer.timeMarginVertexTime" : 7.,
+                       "pvertexer.nSigmaTimeCut" : 10,
+                       "pvertexer.dbscanMaxDist2" : 36,
+                       "pvertexer.dcaTolerance" : 3.,
+                       "pvertexer.pullIniCut" : 100,
+                       "pvertexer.addZSigma2" : 0.1,
+                       "pvertexer.tukey" : 20.,
+                       "pvertexer.addZSigma2Debris" : 0.01,
+                       "pvertexer.addTimeSigma2Debris" : 1.,
+                       "pvertexer.maxChi2Mean" : 30,
+                       "pvertexer.timeMarginReattach" : 3.,
+                       "pvertexer.addTimeSigma2Debris" : 1.,
+                       "pvertexer.dbscanDeltaT" : 24,
+                       "pvertexer.maxChi2TZDebris" : 100,
+                       "pvertexer.maxMultRatDebris" : 1.,
+                       "pvertexer.dbscanAdaptCoef" : 20.})
+       elif 302000 <= int(args.run) and int(args.run) <= 309999:
+          # specific tunes for high pp
+          # run range taken from https://twiki.cern.ch/twiki/bin/viewauth/ALICE/O2DPGMCSamplingSchema
+          # taken from JIRA https://alice.its.cern.ch/jira/browse/O2-2691
+          add(config, {"pvertexer.dbscanDeltaT" : 7,
+                       "pvertexer.maxChi2TZDebris": 50,
+                       "pvertexer.maxMultRatDebris": 1.,
+                       "pvertexer.dbscanAdaptCoef" : 20,
+                       "pvertexer.maxVerticesPerCluster" : 20,
+                       "pvertexer.dbscanMaxDist2" : 36})
+
+       else:
+          # generic pp
+          add(config, {"pvertexer.acceptableScale2" : 9,
+                       "pvertexer.dbscanMaxDist2" : 36,
+                       "pvertexer.dbscanDeltaT" : 24,
+                       "pvertexer.maxChi2TZDebris" : 100,
+                       "pvertexer.maxMultRatDebris" : 1.,
+                       "pvertexer.dbscanAdaptCoef" : 20.})
+
+    # MFT tracking settings
+    if args.mft_reco_full == True:
+        add({"MFTTracking.forceZeroField" : 0,
+             "MFTTracking.LTFclsRCut" : 0.0100})
+
+    return config

--- a/UTILS/parse-async-WorkflowConfig.py
+++ b/UTILS/parse-async-WorkflowConfig.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+# A script helping to parse configuration
+# from a reco workflow, in order to apply the same settings
+# in MC. Spits out a json with the configuration.
+
+# things to parse
+# - detector list
+# - components of reco workflow
+# - vertexing sources etc
+# - config - key params ; per job
+# - we can produce a json or a dict
+
+import re
+import json
+
+def get_topology_cmd(filename):
+   """
+   returns the command for the topology; from a workflow filename
+   """
+   f = open(filename, 'r')
+   lines = f.readlines()
+   output = []
+   for l in lines:
+     if l.count('--session') and l.count("o2-") > 0:
+        output.append(l)
+   return output
+
+
+def extract_detector_list():
+   """
+   extracts list of sensitive detectors used
+   """
+
+def extract_config_key_values(tokenlist):
+   kvconfig = {}
+   for i,t in enumerate(tokenlist):
+     if t == '--configKeyValues':
+         configs = tokenlist[i+1]
+         # individual key-values:
+         if configs[0]=='"':
+           configs = configs[1:]
+         if configs[-1] == '"':
+           configs = configs[:-1]
+         keyvals = configs.split(";")
+         for kv in keyvals:
+            tmp = kv.rstrip().split("=")
+            if len(tmp) > 1:
+              key = tmp[0]
+              value = tmp[1]
+              kvconfig[key]=value
+   return kvconfig
+
+def extract_args(tokens, arg):
+   """
+   extract the value for a given argument from a list of argument tokens
+   """
+   i = 0
+   while i < len(tokens):
+       t = tokens[i]
+       if t == arg:
+          return tokens[i+1] if i+1 < len(tokens) else ""
+       i += 1
+   return ""
+
+def remove_tokens(tokens, argument, stride=1):
+   # take out arguments; that we definitely do not want to take over
+   outtokens = []
+   i = 0
+   while i < len(tokens):
+       t = tokens[i]
+       if t == argument:
+          i += stride
+          continue
+       outtokens.append(t)
+       i += 1
+   return outtokens
+
+
+def flatten_config_values(commandlist):
+   """
+   let's see if we have any duplicates or contradicting things
+   and if we can produce a flat dictionary of config values
+   """
+   main_sub_config = {}
+   for task in commandlist:
+      thisconfig = task.get('configval')
+      if thisconfig:
+         for compoundkey in thisconfig:
+            mainkey = compoundkey.split(".")[0]
+            subkey = compoundkey.split(".")[1]
+            if main_sub_config.get(mainkey) == None:
+               main_sub_config[mainkey] = {}
+            preventry = main_sub_config[mainkey].get(subkey)
+            value = thisconfig[compoundkey]
+            if preventry and preventry != value:
+                  print("Found inconsistent duplicate key .. cannot simply flatten")
+            else:
+               main_sub_config[mainkey][subkey] = value
+   return main_sub_config
+
+# write INI files gives config values
+def configValues_to_ini(flatconfig):
+   """
+   supposedly, there is an INI conversion but not sure where
+   ... so we fake it here
+   """
+   # write ini
+   f = open("ini-file","w")
+   for mainkey in flatconfig:
+      f.write("["+mainkey+"]\n")
+      for subkey in flatconfig[mainkey]:
+         f.write(subkey+"="+flatconfig[mainkey][subkey]+"\n")
+
+def configValues_to_json(flatconfig):
+   """
+   """
+   with open('config-json.json', 'w') as outfile:
+        json.dump(flat_config, outfile, indent=2)
+
+
+def parse_important_DPL_args(cmds, flat_config):
+   """
+   Here we parse important other options that are not part of config-params such --vertexing-sources and --vertex-track-matching sources for various reco tasks.
+   Unfortunately, we cannot just blindly take everything as some of these things are
+   specific to reco, so we need to maintain a list.
+
+   The options are attached to same config as for configurable params ... under
+   specific keys which can be queried during MC workflow creation.
+
+   So this reads cmds dictionary and modifies flat_config dictionary.
+   """
+
+   for tasks in cmds:
+      # we just to it by specific tasks until we have a better way
+      cmd = tasks['cmd']
+      tokens = tasks['remainingargs']
+      # primary vertex finder -- here we need "vertexing sources and vertex-track-matching-sources"
+      if cmd == 'o2-primary-vertexing-workflow':
+         c = {}
+         c['vertexing-sources'] = extract_args(tokens, '--vertexing-sources')
+         c['vertex-track-matching-sources'] = extract_args(tokens, '--vertex-track-matching-sources')
+         flat_config[cmd + '-options'] = c
+
+      # secondary vertex finder
+      if cmd == 'o2-secondary-vertexing-workflow':
+         c = {}
+         c['vertexing-sources'] = extract_args(tokens, '--vertexing-sources')
+         flat_config[cmd + '-options'] = c
+
+      # aod
+      if cmd == 'o2-aod-producer-workflow':
+         c = {}
+         c['info-sources'] = extract_args(tokens, '--info-sources')
+         flat_config[cmd + '-options'] = c
+
+      # its reco
+      if cmd == 'o2-its-reco-workflow':
+         pass
+
+      # trd tracking
+      if cmd == 'o2-trd-global-tracking':
+         c = {}
+         c['track-sources'] = extract_args(tokens, '--track-sources')
+         flat_config[cmd + '-options'] = c
+
+      # tof matching
+      if cmd == 'o2-tof-matcher-workflow':
+         c = {}
+         c['track-sources'] = extract_args(tokens, '--track-sources')
+         flat_config[cmd + '-options'] = c
+
+      # ctf reader workflow (with this we can constrain
+      # sensitive detectors and reduce the overal graph workflow)
+      if cmd == 'o2-ctf-reader-workflow':
+         c = {}
+         c['onlyDet'] = extract_args(tokens, '--onlyDet')
+         flat_config[cmd + '-options'] = c
+
+
+def print_untreated_args(cmds):
+   """
+   let's see the content in remaining_args
+   """
+   for task in cmds:
+      rargs = task.get("remainingargs")
+      if rargs and len(rargs) > 0:
+         print (task["cmd"]," ",rargs)
+
+
+def print_principalconfigkeys_pertask(cmds):
+   """
+   prints list of principal config keys per task
+   """
+   for task in cmds:
+      c = task.get("configval")
+      if c != None:
+         keyset = set()
+         for k in c:
+            keyset.add(k.split(".")[0])
+         print (task["cmd"]," ",keyset)
+
+def extract_commands(commandlist):
+   commands = []
+   for l in commandlist:
+       task = {}
+       # each l is a standalone command piped together
+       l.rstrip('\n')
+       l.rstrip()
+       l.rstrip('|')
+       tokens = l.split(" ")
+       # take out stuff we don't care about
+       tokens = remove_tokens(tokens,'', 1)
+       tokens = remove_tokens(tokens,'\n', 1)
+       tokens = remove_tokens(tokens,'|', 1)
+       tokens = remove_tokens(tokens,'\\\n', 1)
+       tokens = remove_tokens(tokens,"--session", 2)
+       tokens = remove_tokens(tokens,"--severity", 2)
+       tokens = remove_tokens(tokens,"--shm-segment-id", 2)
+       tokens = remove_tokens(tokens,"--shm-segment-size", 2)
+       tokens = remove_tokens(tokens,"--resources-monitoring", 2)
+       tokens = remove_tokens(tokens,"--resources-monitoring-dump-interval", 2)
+       tokens = remove_tokens(tokens,"--delay", 2)
+       tokens = remove_tokens(tokens,"--loop", 2)
+       tokens = remove_tokens(tokens,"--early-forward-policy", 2)
+       tokens = remove_tokens(tokens,"--fairmq-rate-logging", 2)
+       tokens = remove_tokens(tokens,"--pipeline", 2)
+       tokens = remove_tokens(tokens,"--disable-mc", 1)
+       tokens = remove_tokens(tokens,"--disable-root-input", 1)
+
+       cmd = tokens[0]
+       tokens = tokens[1:len(tokens)]
+       task['cmd'] = cmd
+       # we look out for a list of special settings
+
+       # config-params
+       task['configval'] = extract_config_key_values(tokens)
+       tokens = remove_tokens(tokens,"--configKeyValues", 2)
+
+       # we store the remaining options for furter processing later
+       task['remainingargs'] = tokens
+       commands.append(task)
+
+   return commands
+
+cmdlist = get_topology_cmd("workflowconfig.log")
+#print (cmdlist)
+cmds = extract_commands(cmdlist)
+# print_untreated_args(cmds)
+print_principalconfigkeys_pertask(cmds)
+flat_config = flatten_config_values(cmds)
+#print (flat_config)
+parse_important_DPL_args(cmds, flat_config)
+configValues_to_json(flat_config)


### PR DESCRIPTION
This commit is a step in the direction of being
able to anchor MC workflows to the settings use in
DATA reconstruction passes.

This is achieved via a couple of ingredients:

a) improved configurability of o2dpg_sim_workflow:

   - we can give a json config externally, which
     may include ConfigKeyValues and other keys
     to which the MC workflow creation is sensitive

   - separation of default config creation into extra
     script

   - slight change in the way how tasks declare what ConfigKeyValues
     they need / are sensitive too

   - can now configure list of sensitive detectors
   - can now configure input lists for vertexers and track matcher tasks

b) A script that can parse DPL topologies and parameters from
   a file created by DATA reconstruction, and which creates
   a json config that can be fed to MC workflow creating via a)