### PR TITLE
Remove TRD from reconstructed detectors for apass4

### DIFF
--- a/DATA/production/configurations/2021/OCT/apass4/setenv_extra.sh
+++ b/DATA/production/configurations/2021/OCT/apass4/setenv_extra.sh
@@ -8,7 +8,7 @@
 export SETENV_NO_ULIMIT=1
 
 # detector list
-export WORKFLOW_DETECTORS=ITS,TPC,TOF,TRD,FV0,FT0,FDD,MID,MFT
+export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT
 
 # ad-hoc settings for CTF reader: we are on the grid, we read the files remotely
 echo "*********************** mode = ${MODE}"


### PR DESCRIPTION
@noferini , @shahor02 , @sawenzel , @martenole , @tdietel

TRD is now disabled for apass4. 

@sawenzel , can you confirm that you will use this folder for the MC anchored to apass3, to take the correct TPC calibrations, as discussed yesterday?
If so, this is correct, because we want to exclude TRD from MC reco, since in data we saw very low matching efficiency and this cannot now be reproduced in MC.

