### PR TITLE
adapt ITS threshold scripts to PR8346 in O2 + added QC

### DIFF
--- a/DATA/production/calib/its-threshold-aggregator.sh
+++ b/DATA/production/calib/its-threshold-aggregator.sh
@@ -18,7 +18,7 @@ ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;Na
 PROXY_INSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0;eos:***/INFORMATION"
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-thr-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-thr-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
-WORKFLOW+="o2-its-threshold-aggregator-workflow -b --ccdb-url=\"http://alio2-cr1-flp199.cern.ch:8083\" $ARGS_ALL | "
+WORKFLOW+="o2-its-threshold-aggregator-workflow -b --ccdb-url=\"\" $ARGS_ALL | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://alio2-cr1-flp199.cern.ch:8083\" | "
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 

--- a/DATA/production/calib/its-threshold-aggregator.sh
+++ b/DATA/production/calib/its-threshold-aggregator.sh
@@ -18,7 +18,7 @@ ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;Na
 PROXY_INSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0;eos:***/INFORMATION"
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-thr-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-thr-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
-WORKFLOW+="o2-its-threshold-aggregator-workflow -b --ccdb-url=\"\" $ARGS_ALL | "
+WORKFLOW+="o2-its-threshold-aggregator-workflow -b $ARGS_ALL | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://alio2-cr1-flp199.cern.ch:8083\" | "
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 

--- a/DATA/production/calib/its-threshold-processing.sh
+++ b/DATA/production/calib/its-threshold-processing.sh
@@ -17,10 +17,12 @@ ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;Na
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 PROXY_OUTSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0"
+HOST=localhost
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,rateLogging=0,transport=shmem\" | "
-WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 4 --no-clusters --no-cluster-patterns --enable-calib-data --digits | "
-WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 20 --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
+WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 1  --pipeline its-stf-decoder:6 --no-clusters --no-cluster-patterns --enable-calib-data --digits | "
+WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 4 --enable-eos --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
+WORKFLOW+="o2-qc $ARGS_ALL --config consul-json://alio2-cr1-hv-aliecs:8500/o2/components/qc/ANY/any/its-qc-calibration --local --host $HOST | "
 WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-thr-input-proxy --channel-config \"name=its-thr-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=0\" | "
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 


### PR DESCRIPTION
Changes:
- added 6 pipelines for decoder --> compatible with PR8346 in O2
- added QC workflow for calibration scans 
- removed DCS CCDB link from its-aggregator-wf to use the object upload through ccdb-populator-wf
- added --enable-eos to use end-of-stream at P2
- 1 thread in the decoder: multiple thread meaningless in calibration mode because 1 RU data per TF
- 4 threads in o2-its-thr-calib because the improvement is negligible with more threads. 