### PR TITLE
Prefetch CCDB objects for anchored MC

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -918,14 +918,16 @@ for tf in range(1, NTIMEFRAMES + 1):
                 needs=[ITSTPCMATCHtask['name']],
                 readerCommand='o2-global-track-cluster-reader --track-types "TPC,ITS-TPC"',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/ITSTPCmatchedTracks_direct_MC.json')
-     addQCPerTF(taskName='TOFMatchQC',
-                needs=[TOFTPCMATCHERtask['name']],
-                readerCommand='o2-global-track-cluster-reader --track-types "ITS-TPC-TOF,TPC-TOF,TPC" --cluster-types none',
-                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct_MC.json')
-     addQCPerTF(taskName='TOFMatchWithTRDQC',
-                needs=[TOFTPCMATCHERtask['name']],
-                readerCommand='o2-global-track-cluster-reader --track-types "ITS-TPC-TOF,TPC-TOF,TPC,ITS-TPC-TRD,ITS-TPC-TRD-TOF,TPC-TRD,TPC-TRD-TOF" --cluster-types none',
-                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_AllTypes_direct_MC.json')
+     if isActive('TOF'):
+        addQCPerTF(taskName='TOFMatchQC',
+                   needs=[TOFTPCMATCHERtask['name']],
+                   readerCommand='o2-global-track-cluster-reader --track-types "ITS-TPC-TOF,TPC-TOF,TPC" --cluster-types none',
+                   configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct_MC.json')
+     if isActive('TOF') and isActive('TRD'):
+        addQCPerTF(taskName='TOFMatchWithTRDQC',
+                   needs=[TOFTPCMATCHERtask['name']],
+                   readerCommand='o2-global-track-cluster-reader --track-types "ITS-TPC-TOF,TPC-TOF,TPC,ITS-TPC-TRD,ITS-TPC-TRD-TOF,TPC-TRD,TPC-TRD-TOF" --cluster-types none',
+                   configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_AllTypes_direct_MC.json')
  
    #secondary vertexer
    svfinder_threads = ' --threads 1 '


### PR DESCRIPTION
We use prefetching and CCDB_CACHING mechanism to serve
the CCDB objects for MC.
Otherwise, they would currently not be fetched at a consistent timestamp
(in line with the run). See https://alice.its.cern.ch/jira/browse/O2-2852.