### PR TITLE
Removed explicit IR argument, proc set to cdiff

### DIFF
--- a/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
+++ b/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
@@ -84,8 +84,7 @@ NSIGEVENTS=${NSIGEVENTS:-22}
 baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER}"
 
 # THIS NEEDS TO COME FROM OUTSIDE
-remainingargs="-eCM 900 -col pp -gen pythia8 -proc inel -ns ${NSIGEVENTS}                                                                                                 \
-               -interactionRate 2000                                                                                                                                      \
+remainingargs="-eCM 900 -col pp -gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                \
                -confKey \"Diamond.width[2]=6.0;Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.position[0]=0.0;Diamond.position[1]=-0.035;Diamond.position[2]=0.41\"  \
               --include-local-qc --include-analysis"
 


### PR DESCRIPTION
Ciao @chiarazampolli and @sawenzel,

Removed setting the IR explicitly, plus changed the proc to cdiff, to include UD collisions.
Please review and merge if you think these are appropriate.

Thanks!

Yours,
Catalin.
