### PR TITLE
add TOF cal in global workflow

### DIFF
--- a/DATA/production/configurations/2021/OCT/apass5/async_pass.sh
+++ b/DATA/production/configurations/2021/OCT/apass5/async_pass.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# Script to run the async processing
+#
+# if run locally, you need to export e.g.:
+#
+# export ALIEN_JDL_LPMRUNNUMBER=505673
+# export ALIEN_JDL_LPMINTERACTIONTYPE=pp
+# export ALIEN_JDL_LPMPRODUCTIONTAG=OCT
+# export ALIEN_JDL_LPMPASSNAME=apass4
+# export ALIEN_JDL_LPMANCHORYEAR=2021
+
+
+if [[ "${1##*.}" == "root" ]]; then
+    #echo ${1##*.}
+    #echo "alien://${1}" > list.list
+    #export MODE="remote"
+    echo "${1}" > list.list
+    export MODE="LOCAL"
+    shift
+elif [[ "${1##*.}" == "xml" ]]; then
+    sed -rn 's/.*turl="([^"]*)".*/\1/p' $1 > list.list
+    export MODE="remote"
+    shift
+fi
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -rnb|--run-number)
+      RUNNUMBER="$2"
+      shift
+      shift
+      ;;
+    -b|--beam-type)
+      BEAMTYPE="$2"
+      shift
+      shift
+      ;;
+    -m|--mode)
+      MODE="$2"
+      shift
+      shift
+      ;;
+    -p|--period)
+      PERIOD="$2"
+      shift
+      shift
+      ;;
+    -pa|--pass)
+      PASS="$2"
+      shift
+      shift
+      ;;
+    *)
+    POSITIONAL+=("$1")
+    shift
+    ;;
+  esac
+done
+
+# now we overwrite if we found them in the jdl
+if [[ -n "$ALIEN_JDL_LPMRUNNUMBER" ]]; then
+    export RUNNUMBER="$ALIEN_JDL_LPMRUNNUMBER"
+fi
+
+# beam type
+if [[ -n "$ALIEN_JDL_LPMINTERACTIONTYPE" ]]; then
+    export BEAMTYPE="$ALIEN_JDL_LPMINTERACTIONTYPE"
+fi
+
+# period
+if [[ -n "$ALIEN_JDL_LPMPRODUCTIONTAG" ]]; then
+    export PERIOD="$ALIEN_JDL_LPMPRODUCTIONTAG"
+fi
+
+# pass
+if [[ -n "$ALIEN_JDL_LPMPASSNAME" ]]; then
+    export PASS="$ALIEN_JDL_LPMPASSNAME"
+fi
+
+if [[ -z $RUNNUMBER ]] || [[ -z $PERIOD ]] || [[ -z $BEAMTYPE ]] || [[ -z $PASS ]]; then
+    echo "check env variables we need RUNNUMBER (--> $RUNNUMBER), PERIOD (--> $PERIOD), PASS (--> $PASS), BEAMTYPE (--> $BEAMTYPE)"
+    return 3
+fi
+
+echo processing run $RUNNUMBER, from period $PERIOD with $BEAMTYPE collisions and mode $MODE
+
+###if [[ $MODE == "remote" ]]; then 
+    # common archive
+    if [[ ! -f commonInput.tgz ]]; then
+	echo "No commonInput.tgz found returning"
+	return 2
+    fi
+    # run specific archive
+    if [[ ! -f runInput_$RUNNUMBER.tgz ]]; then
+	echo "No runInput_$RUNNUMBER.tgz found returning"
+	return 2
+    fi
+    tar -xzvf commonInput.tgz
+    ln -s o2sim_geometry.root o2sim_geometry-aligned.root
+    tar -xzvf runInput_$RUNNUMBER.tgz
+###fi
+
+echo "Checking current directory content"
+ls -altr 
+
+if [[ -f "setenv_extra.sh" ]]; then
+    source setenv_extra.sh $RUNNUMBER $BEAMTYPE
+else
+    echo "************************************************************************************"
+    echo "No ad-hoc setenv_extra settings for current async processing; using the one in O2DPG"
+    echo "************************************************************************************"
+    if [[ -f $O2DPG_ROOT/DATA/production/configurations/$ALIEN_JDL_LPMANCHORYEAR/$ALIEN_JDL_LPMPRODUCTIONTAG/$ALIEN_JDL_LPMPASSNAME/setenv_extra.sh ]]; then
+	ln -s $O2DPG_ROOT/DATA/production/configurations/$ALIEN_JDL_LPMANCHORYEAR/$ALIEN_JDL_LPMPRODUCTIONTAG/$ALIEN_JDL_LPMPASSNAME/setenv_extra.sh
+	source setenv_extra.sh $RUNNUMBER $BEAMTYPE
+    else
+	echo "*********************************************************************************************************"
+	echo "No setenev_extra for $ALIEN_JDL_LPMANCHORYEAR/$ALIEN_JDL_LPMPRODUCTIONTAG/$ALIEN_JDL_LPMPASSNAME in O2DPG"
+	echo "                No special settings will be used"
+	echo "*********************************************************************************************************"
+    fi
+fi
+
+rm -f /dev/shm/*
+
+if [[ -f run-workflow-on-inputlist.sh ]]; then
+    echo "Use run-workflow-on-inputlist.sh macro passed as input"
+else
+    echo "Use run-workflow-on-inputlist.sh macro from O2"
+    cp $O2_ROOT/prodtests/full-system-test/run-workflow-on-inputlist.sh .
+fi
+
+if [[ -z $DPL_WORKFLOW_FROM_OUTSIDE ]]; then
+    echo "Use dpl-workflow.sh from O2"
+    cp $O2_ROOT/prodtests/full-system-test/dpl-workflow.sh .
+else
+    echo "Use dpl-workflow.sh passed as input"
+    cp $DPL_WORKFLOW_FROM_OUTSIDE .
+fi
+
+if [[ ! -z $QC_JSON_FROM_OUTSIDE ]]; then
+    echo "QC json from outside is $QC_JSON_FROM_OUTSIDE"
+fi
+
+ln -sf $O2DPG_ROOT/DATA/common/setenv.sh
+
+# reco and matching
+# print workflow
+IS_SIMULATED_DATA=0 WORKFLOWMODE=print DISABLE_ROOT_OUTPUT="" TFDELAY=40 NTIMEFRAMES=-1 SHMSIZE=16000000000 DDSHMSIZE=32000 ./run-workflow-on-inputlist.sh CTF list.list > workflowconfig.log
+# run it
+IS_SIMULATED_DATA=0 WORKFLOWMODE=run DISABLE_ROOT_OUTPUT="" TFDELAY=40 NTIMEFRAMES=-1 SHMSIZE=16000000000 DDSHMSIZE=32000 ./run-workflow-on-inputlist.sh CTF list.list 
+
+# now extract all performance metrics
+IFS=$'\n'
+if [[ -f "performanceMetrics.json" ]]; then
+    for workflow in `grep ': {' performanceMetrics.json`; do
+	strippedWorkflow=`echo $workflow | cut -d\" -f2`
+	cat performanceMetrics.json | jq '.'\"${strippedWorkflow}\"'' > ${strippedWorkflow}_metrics.json
+    done
+fi
+
+# now checking AO2D file
+if [[ -f "AO2D.root" ]]; then
+    root -l -b -q $O2DPG_ROOT/DATA/production/common/readAO2Ds.C > checkAO2D.log
+    exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+	echo "exit code from AO2D check is " $exitcode > validation_error.message
+	echo "exit code from AO2D check is " $exitcode
+	exit $exitcode
+    fi
+fi
+
+# copying the QC json file here
+if [[ ! -z $QC_JSON_FROM_OUTSIDE ]]; then
+    QC_JSON=$QC_JSON_FROM_OUTSIDE
+else
+    if [[ -d $GEN_TOPO_WORKDIR/json_cache ]]; then
+	echo "copying latest file found in ${GEN_TOPO_WORKDIR}/json_cache"
+	QC_JSON=`ls -dArt $GEN_TOPO_WORKDIR/json_cache/* | tail -n 1`
+    else
+	echo "No QC files found, probably QC was not run"
+    fi
+fi
+if [[ ! -z $QC_JSON ]]; then
+    cp $QC_JSON QC_production.json
+fi

--- a/DATA/production/configurations/2021/OCT/apass5/setenv_extra.sh
+++ b/DATA/production/configurations/2021/OCT/apass5/setenv_extra.sh
@@ -1,0 +1,104 @@
+# script to set extra env variables
+# taking some stuff from alien
+
+# process flags passed to the script
+
+export SETENV_NO_ULIMIT=1
+
+# detector list
+export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT
+
+# ad-hoc settings for CTF reader: we are on the grid, we read the files remotely
+echo "*********************** mode = ${MODE}"
+unset ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow
+if [[ $MODE == "remote" ]]; then
+  export INPUT_FILE_COPY_CMD="\"alien_cp ?src file://?dst\""
+  export ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow="--remote-regex \"^alien:///alice/data/.+\""
+fi
+# other ad-hoc settings for CTF reader
+export ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow="$ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow --allow-missing-detectors "
+
+# run-dependent options
+if [[ -f "setenv_run.sh" ]]; then
+    source setenv_run.sh 
+else
+    echo "************************************************************"
+    echo No ad-hoc run-dependent settings for current async processing
+    echo "************************************************************"
+fi
+
+# remove monitoring-backend
+export ENABLE_METRICS=1
+
+# add the performance metrics
+#export ARGS_ALL_EXTRA=" --resources-monitoring 10 --resources-monitoring-dump-interval 10"
+export ARGS_ALL_EXTRA=" --resources-monitoring 50 --resources-monitoring-dump-interval 50"
+
+# some settings in common between workflows
+export ITSEXTRAERR="ITSCATrackerParam.sysErrY2[0]=9e-4;ITSCATrackerParam.sysErrZ2[0]=9e-4;ITSCATrackerParam.sysErrY2[1]=9e-4;ITSCATrackerParam.sysErrZ2[1]=9e-4;ITSCATrackerParam.sysErrY2[2]=9e-4;ITSCATrackerParam.sysErrZ2[2]=9e-4;ITSCATrackerParam.sysErrY2[3]=1e-2;ITSCATrackerParam.sysErrZ2[3]=1e-2;ITSCATrackerParam.sysErrY2[4]=1e-2;ITSCATrackerParam.sysErrZ2[4]=1e-2;ITSCATrackerParam.sysErrY2[5]=1e-2;ITSCATrackerParam.sysErrZ2[5]=1e-2;ITSCATrackerParam.sysErrY2[6]=1e-2;ITSCATrackerParam.sysErrZ2[6]=1e-2;"
+
+export MFT_STROBELGT="MFTAlpideParam.roFrameLengthInBC=198"
+
+# ad-hoc options for ITS reco workflow
+export ITS_CONFIG=" --tracking-mode sync_misaligned"
+export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2"
+
+# ad-hoc options for GPU reco workflow
+export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="$VDRIFT;GPU_global.dEdxUseFullGainMap=1;GPU_global.dEdxDisableResidualGainMap=1"
+
+# ad-hoc settings for TOF reco
+# export ARGS_EXTRA_PROCESS_o2_tof_reco_workflow="--use-ccdb --ccdb-url-tof \"http://alice-ccdb.cern.ch\""
+# since commit on Dec, 4
+export ARGS_EXTRA_PROCESS_o2_tof_reco_workflow="--use-ccdb"
+
+# ad-hoc options for primary vtx workflow
+#export PVERTEXER="pvertexer.acceptableScale2=9;pvertexer.minScale2=2.;pvertexer.nSigmaTimeTrack=4.;pvertexer.timeMarginTrackTime=0.5;pvertexer.timeMarginVertexTime=7.;pvertexer.nSigmaTimeCut=10;pvertexer.dbscanMaxDist2=30;pvertexer.dcaTolerance=3.;pvertexer.pullIniCut=100;pvertexer.addZSigma2=0.1;pvertexer.tukey=20.;pvertexer.addZSigma2Debris=0.01;pvertexer.addTimeSigma2Debris=1.;pvertexer.maxChi2Mean=30;pvertexer.timeMarginReattach=3.;pvertexer.addTimeSigma2Debris=1.;"
+# following comment https://alice.its.cern.ch/jira/browse/O2-2691?focusedCommentId=278262&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-278262
+export PVERTEXER="pvertexer.acceptableScale2=9;pvertexer.minScale2=2.;pvertexer.nSigmaTimeTrack=4.;pvertexer.timeMarginTrackTime=0.5;pvertexer.timeMarginVertexTime=7.;pvertexer.nSigmaTimeCut=10;pvertexer.dbscanMaxDist2=36;pvertexer.dcaTolerance=3.;pvertexer.pullIniCut=100;pvertexer.addZSigma2=0.1;pvertexer.tukey=20.;pvertexer.addZSigma2Debris=0.01;pvertexer.addTimeSigma2Debris=1.;pvertexer.maxChi2Mean=30;pvertexer.timeMarginReattach=3.;pvertexer.addTimeSigma2Debris=1.;pvertexer.dbscanDeltaT=24;pvertexer.maxChi2TZDebris=100;pvertexer.maxMultRatDebris=1.;pvertexer.dbscanAdaptCoef=20.;"
+export SVTX="svertexer.checkV0Hypothesis=false;svertexer.checkCascadeHypothesis=false"
+
+export CONFIG_EXTRA_PROCESS_o2_primary_vertexing_workflow="$VDRIFT;$PVERTEXER;$MFT_STROBELGT"
+export CONFIG_EXTRA_PROCESS_o2_secondary_vertexing_workflow="$SVTX"
+
+# ad-hoc settings for its-tpc matching
+export ITSTPCMATCH="tpcitsMatch.maxVDriftUncertainty=0.2;tpcitsMatch.safeMarginTimeCorrErr=10.;tpcitsMatch.cutMatchingChi2=1000;tpcitsMatch.crudeAbsDiffCut[0]=5;tpcitsMatch.crudeAbsDiffCut[1]=5;tpcitsMatch.crudeAbsDiffCut[2]=0.3;tpcitsMatch.crudeAbsDiffCut[3]=0.3;tpcitsMatch.crudeAbsDiffCut[4]=10;tpcitsMatch.crudeNSigma2Cut[0]=200;tpcitsMatch.crudeNSigma2Cut[1]=200;tpcitsMatch.crudeNSigma2Cut[2]=200;tpcitsMatch.crudeNSigma2Cut[3]=200;tpcitsMatch.crudeNSigma2Cut[4]=900;"
+export CONFIG_EXTRA_PROCESS_o2_tpcits_match_workflow="$VDRIFT;$ITSEXTRAERR;$ITSTPCMATCH"
+
+# ad-hoc settings for TOF matching
+export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="--output-type matching-info,calib-info --enable-dia"
+export CONFIG_EXTRA_PROCESS_o2_tof_matcher_workflow="$VDRIFT;$ITSEXTRAERR"
+
+# ad-hoc settings for TRD matching
+export CONFIG_EXTRA_PROCESS_o2_trd_global_tracking="$VDRIFT;$ITSEXTRAERR"
+
+# ad-hoc settings for FT0
+export ARGS_EXTRA_PROCESS_o2_ft0_reco_workflow="--ft0-reconstructor"
+
+# ad-hoc settings for FV0
+export ARGS_EXTRA_PROCESS_o2_fv0_reco_workflow="--fv0-reconstructor"
+
+# ad-hoc settings for FDD
+#...
+
+# ad-hoc settings for MFT 
+export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="$MFT_STROBELGT"
+
+# Enabling AOD
+export WORKFLOW_PARAMETERS="AOD,${WORKFLOW_PARAMETERS}"
+
+# ad-hoc settings for AOD
+#...
+
+# Enabling QC
+export WORKFLOW_PARAMETERS="QC,${WORKFLOW_PARAMETERS}"
+export QC_CONFIG_PARAM="--local-batch=QC.root --override-values \"qc.config.Activity.number=$RUNNUMBER;qc.config.Activity.passName=$PASS;qc.config.Activity.periodName=$PERIOD\""
+export GEN_TOPO_WORKDIR="./"
+#export QC_JSON_FROM_OUTSIDE="QC-20211214.json"
+
+if [[ ! -z $QC_JSON_FROM_OUTSIDE ]]; then
+    sed -i 's/REPLACE_ME_RUNNUMBER/'"${RUNNUMBER}"'/g' $QC_JSON_FROM_OUTSIDE
+    sed -i 's/REPLACE_ME_PASS/'"${PASS}"'/g' $QC_JSON_FROM_OUTSIDE
+    sed -i 's/REPLACE_ME_PERIOD/'"${PERIOD}"'/g' $QC_JSON_FROM_OUTSIDE
+fi
+
+

--- a/DATA/production/dpl-cal-workflow.sh
+++ b/DATA/production/dpl-cal-workflow.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "0$O2_ROOT" == "0" ]; then
+    echo O2 environment not loaded 1>&2
+    exit 1
+fi
+
+export DPL_CONDITION_BACKEND="http://o2-ccdb.internal"
+
+export TOF_PROXY_OUTSPEC="diagWords:TOF/DIAFREQ"
+
+source $O2_ROOT/prodtests/full-system-test/dpl-workflow.sh

--- a/DATA/production/production.desc
+++ b/DATA/production/production.desc
@@ -1,2 +1,3 @@
 synchronous-workflow: "O2PDPSuite" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=64000000000 production/dpl-workflow.sh" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=64000000000 production/dpl-workflow.sh"
 synchronous-workflow-1numa: "O2PDPSuite" reco,128,128,"SYNCMODE=1 production/dpl-workflow.sh"
+synchronous-cal-workflow: "O2PDPSuite" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=64000000000 production/dpl-cal-workflow.sh" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=64000000000 production/dpl-workflow.sh" calib,4,"production/calib/tof-diagn-aggregator.sh"


### PR DESCRIPTION
I created a new global production workflow for AliECS envirnoment where I added the first TOF sync-calibration prototype (tested in standalone mode).

The idea is to define here a variable (TOF_PROXY_OUTSPEC) to be used in O2(to be done) to set output proxy in the proper way.

Since there are no other example I did it in this way but if you prefer I do it in a different way let me know.