### PR TITLE
ITS calib: added chip-mod-selector and chip-mod-base + set default to 40 EPNs

### DIFF
--- a/DATA/production/calib/its-threshold-processing.sh
+++ b/DATA/production/calib/its-threshold-processing.sh
@@ -17,12 +17,13 @@ ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;Na
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 PROXY_OUTSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0"
-HOST=localhost
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,rateLogging=0,transport=shmem\" | "
 WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 1  --pipeline its-stf-decoder:6 --no-clusters --no-cluster-patterns --enable-calib-data --digits | "
-WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 4 --enable-eos --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
-WORKFLOW+="o2-qc $ARGS_ALL --config consul-json://alio2-cr1-hv-aliecs:8500/o2/components/qc/ANY/any/its-qc-calibration --local --host $HOST | "
+WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 4 --enable-eos --chip-mod-selector 0 --chip-mod-base 3 --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
+WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 4 --enable-eos --chip-mod-selector 1 --chip-mod-base 3 --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
+WORKFLOW+="o2-its-threshold-calib-workflow -b --nthreads 4 --enable-eos --chip-mod-selector 2 --chip-mod-base 3 --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" $ARGS_ALL | "
+WORKFLOW+="o2-qc --config consul-json://alio2-cr1-hv-aliecs:8500/o2/components/qc/ANY/any/its-qc-calibration --local --host epn $ARGS_ALL -b | "
 WORKFLOW+="o2-dpl-output-proxy ${ARGS_ALL} --dataspec \"$PROXY_OUTSPEC\" --proxy-channel-name its-thr-input-proxy --channel-config \"name=its-thr-input-proxy,method=connect,type=push,transport=zeromq,rateLogging=0\" | "
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/standalone-calibration.desc
+++ b/DATA/production/standalone-calibration.desc
@@ -2,7 +2,7 @@ ITS-noise-calibration: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELIN
 
 ITS-noise-calibration-clusters: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELINES=6 USECLUSTERS=1 production/calib/its-noise-processing.sh" calib,20,"USECLUSTERS=1 NTHREADS=32 production/calib/its-noise-aggregator.sh"
 
-ITS-thr-calibration: "O2PDPSuite" reco,20,20,"production/calib/its-threshold-processing.sh" calib,20,"production/calib/its-threshold-aggregator.sh"
+ITS-thr-calibration: "O2PDPSuite" reco,40,40,"production/calib/its-threshold-processing.sh" calib,40,"production/calib/its-threshold-aggregator.sh"
 
 TOF-diagnostic-calibration: "O2PDPSuite" reco,10,10,"SHMSIZE=64000000000 production/calib/tof-standalone-reco.sh" calib,4,"production/calib/tof-diagn-aggregator.sh" 
 


### PR DESCRIPTION
This goes with O2 PR8471 (https://github.com/AliceO2Group/AliceO2/pull/8471). In addition:

- refinements for o2-qc 
- 20 -> 40 EPNs (based on last tests at P2)

