### PR TITLE
MCH: get the onlyAtEndOfStream option be driven by an AliECS env var …

### DIFF
--- a/DATA/production/calib/mch-badchannel-aggregator.sh
+++ b/DATA/production/calib/mch-badchannel-aggregator.sh
@@ -18,7 +18,8 @@ ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;Na
 PROXY_INSPEC="A:MCH/PDIGITS/0"
 CONSUL_ENDPOINT="alio2-cr1-hv-aliecs.cern.ch:8500"
 
-BADCHANNEL_CONFIG="${ARGS_ALL_CONFIG};MCHBadChannelCalibratorParam.maxPed=200.0;MCHBadChannelCalibratorParam.maxNoise=2.0;MCHBadChannelCalibratorParam.minRequiredNofEntriesPerChannel=100;MCHBadChannelCalibratorParam.minRequiredCalibratedFraction=0.5;MCHBadChannelCalibratorParam.onlyAtEndOfStream=true"
+MCH_END_OF_STREAM_ONLY=${MCH_END_OF_STREAM_ONLY:-true}
+BADCHANNEL_CONFIG="${ARGS_ALL_CONFIG};MCHBadChannelCalibratorParam.maxPed=200.0;MCHBadChannelCalibratorParam.maxNoise=2.0;MCHBadChannelCalibratorParam.minRequiredNofEntriesPerChannel=100;MCHBadChannelCalibratorParam.minRequiredCalibratedFraction=0.5;MCHBadChannelCalibratorParam.onlyAtEndOfStream=${MCH_END_OF_STREAM_ONLY}"
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name mch-badchannel-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=mch-badchannel-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
 WORKFLOW+="o2-calibration-mch-badchannel-calib-workflow $ARGS_ALL --configKeyValues \"$BADCHANNEL_CONFIG\" | "


### PR DESCRIPTION
…(MCH_END_OF_STREAM_ONLY)

This is to workaround the fact that the end-of-stream seems to be broken again.