### PR TITLE
Parametrized IR for pilot beam anchored MC, MFT full reco and cdiff for proc

### DIFF
--- a/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
+++ b/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
@@ -22,6 +22,7 @@
 #   point to an existing config (O2DPG repo or local disc or whatever)
 
 RUNNUMBER=${ALIEN_JDL_LPMRUNNUMBER:-505673}
+INTERACTIONRATE=${INTERACTIONRATE:-2000}
 
 # get the async script (we need to modify it)
 # the script location can be configured with a JDL option
@@ -89,10 +90,10 @@ NSIGEVENTS=${NSIGEVENTS:-22}
 baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER}"
 
 # THIS NEEDS TO COME FROM OUTSIDE
-remainingargs="-eCM 900 -col pp -gen pythia8 -proc inel -ns ${NSIGEVENTS}                                                                                                 \
-               -interactionRate 2000                                                                                                                                      \
+remainingargs="-eCM 900 -col pp -gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                \
+               -interactionRate ${INTERACTIONRATE}                                                                                                                        \
                -confKey \"Diamond.width[2]=6.0;Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.position[0]=0.0;Diamond.position[1]=-0.035;Diamond.position[2]=0.41\"  \
-              --include-local-qc --include-analysis"
+              --include-local-qc --include-analysis --mft-reco-full"
 
 remainingargs="${remainingargs} -e ${SIMENGINE} -j ${NWORKERS}"
 remainingargs="${remainingargs} -productionTag ${ALIEN_JDL_LPMPRODUCTIONTAG:-alibi_anchorTest_tmp}"


### PR DESCRIPTION
Ciao @sawenzel, @chiarazampolli and @noferini,

Here are some changes to the pilot beam anchored MC:
- **Parametrized IR**, following Francesco's suggestion;

- Added **MFT full reco**:
https://alice.its.cern.ch/jira/browse/O2-2888?focusedCommentId=283333&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-283333
[Rafael Pezzi](https://alice.its.cern.ch/jira/secure/ViewProfile.jspa?name=pezzi) added a comment - [5 hours ago](https://alice.its.cern.ch/jira/browse/O2-2888?focusedCommentId=283333&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-283333)

Hi [Catalin-Lucian Ristea](https://alice.its.cern.ch/jira/secure/ViewProfile.jspa?name=cristea) , yes, please keep --mft-reco-full for mc productions.

Thanks,
Rafael

- **cdiff instead of inel**
O2DPG Mattermost channel:
https://mattermost.web.cern.ch/alice/pl/uobtd633gtghzrsdfy3zb1n8ga

Paul Alois Buhler
Oct, 29 2021	12:12 PM

Dear all, could you please use in all these pp MCs the option proc='cdiff' instead of proc='inel' (like is e.g. used in the 13 TeV simulations at LHC21i3a/301002)? cdiff is basically inel, but adds a few diffractive events.

Please review the changes and merge if you agree to these.

Thanks!

Yours,
Catalin.
