### PR TITLE
Do not overwrite SEVERITY and INFOLOGGER SEVERITY variables for MID

### DIFF
--- a/DATA/testing/detectors/MID/mid_common.sh
+++ b/DATA/testing/detectors/MID/mid_common.sh
@@ -3,8 +3,6 @@
 # shellcheck disable=SC1091
 source common/setenv.sh
 
-SEVERITY=warning
-INFOLOGGER_SEVERITY=warning
 ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE"
 ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
 ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"


### PR DESCRIPTION
Since the variables were overwritten to warning, no debugging info was available.
With this PR, we restore the default behaviour.