### PR TITLE
add TOF cal

### DIFF
--- a/DATA/production/configurations/2021/OCT/apass4/setenv_extra.sh
+++ b/DATA/production/configurations/2021/OCT/apass4/setenv_extra.sh
@@ -65,7 +65,7 @@ export ITSTPCMATCH="tpcitsMatch.maxVDriftUncertainty=0.2;tpcitsMatch.safeMarginT
 export CONFIG_EXTRA_PROCESS_o2_tpcits_match_workflow="$VDRIFT;$ITSEXTRAERR;$ITSTPCMATCH"
 
 # ad-hoc settings for TOF matching
-export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="--output-type matching-info"
+export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="--output-type matching-info,calib-info --enable-dia"
 export CONFIG_EXTRA_PROCESS_o2_tof_matcher_workflow="$VDRIFT;$ITSEXTRAERR"
 
 # ad-hoc settings for TRD matching


### PR DESCRIPTION
TOF calibration included now

o2calib_tof.root generated

tested with 1 CTF  (66 TFs) from pilot beam

o2calib_tof.root size = 0.5% AO2D size