### PR TITLE
Add random engine based on TRandom and fix wrong units conversion

### DIFF
--- a/MC/config/PWGDQ/EvtGen/EvtTRandomEngine.hh
+++ b/MC/config/PWGDQ/EvtGen/EvtTRandomEngine.hh
@@ -1,0 +1,27 @@
+#ifndef EVT_TRANDOM_ENGINE_HH
+#define EVT_TRANDOM_ENGINE_HH
+
+R__LOAD_LIBRARY(EvtGen)
+R__ADD_INCLUDE_PATH($EVTGEN_ROOT/include)
+
+#include <TRandom.h>
+#include "EvtGenBase/EvtRandomEngine.hh"
+
+class EvtTRandomEngine : public EvtRandomEngine {
+public:
+  
+  EvtTRandomEngine(){
+    gRandom->SetSeed(0);
+  }
+  
+  void setSeed(unsigned int seed){
+    gRandom->SetSeed(seed);
+  }
+
+  virtual double random()
+  {
+    return gRandom->Rndm();
+  }
+};
+
+#endif

--- a/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
+++ b/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
@@ -3,18 +3,16 @@ R__ADD_INCLUDE_PATH($EVTGEN_ROOT/include)
 
 
 #include "EvtGenBase/EvtStdHep.hh"
-#include "EvtGenBase/EvtRandomEngine.hh"
-#include "EvtGenBase/EvtSimpleRandomEngine.hh" 
 #include "EvtGen/EvtGen.hh"
 #include "EvtGenBase/EvtParticle.hh"
 #include "EvtGenBase/EvtPDL.hh"
 #include "EvtGenBase/EvtParticleFactory.hh"
 #include "EvtGenExternal/EvtExternalGenList.hh"
 #include "EvtGenBase/EvtAbsRadCorr.hh"
-#include "EvtGenBase/EvtMTRandomEngine.hh"
 #include "EvtGenBase/EvtRandom.hh"
 #include "EvtGenBase/EvtReport.hh"
 #include "EvtGenExternal/EvtExternalGenList.hh"
+#include "EvtTRandomEngine.hh"
 
 enum DecayModeEvt {kEvtAll=0, kEvtBJpsiDiElectron, kEvtBJpsi, kEvtBJpsiDiMuon, kEvtBPsiDiElectron, kEvtBPsiDiMuon, kEvtBSemiElectronic, kEvtHadronicD, kEvtHadronicDWithout4Bodies, kEvtChiToJpsiGammaToElectronElectron, kEvtChiToJpsiGammaToMuonMuon, kEvtSemiElectronic, kEvtBSemiMuonic, kEvtSemiMuonic, kEvtDiElectron, kEvtDiMuon, kEvtBPsiPrimeDiMuon, kEvtBPsiPrimeDiElectron, kEvtJpsiDiMuon, kEvtPsiPrimeJpsiDiElectron, kEvtPhiKK, kEvtOmega, kEvtLambda, kEvtHardMuons, kEvtElectronEM, kEvtDiElectronEM, kEvtGammaEM, kEvtBeautyUpgrade};
 
@@ -52,12 +50,7 @@ protected:
     std::cout << "EVTGEN INITIALIZATION" << std::endl;
     mEvtstdhep = new EvtStdHep();
     
-#ifdef EVTGEN_CPP11
-    // Use the Mersenne-Twister generator (C++11 only)
-    mEng = new EvtMTRandomEngine();
-#else
-    mEng = new EvtSimpleRandomEngine();
-#endif
+    mEng = new EvtTRandomEngine(); //the default seed of gRandom is 0
     
     EvtRandom::setRandomEngine(mEng);
     
@@ -195,8 +188,8 @@ protected:
       py=p4.get(2);
       pz=p4.get(3);
       e=p4.get(0);
-      const Float_t kconvT=0.001/2.999792458e8; // mm/c to seconds conversion
-      const Float_t kconvL=1./10; // mm to cm conversion
+      const Float_t kconvT=0.01/2.999792458e8; // cm/c to seconds conversion
+      const Float_t kconvL=1.; // dummy conversion
       // shift time / position
       x=x4.get(1)*kconvL + T::mParticles[indexMother].Vx(); //[cm]
       y=x4.get(2)*kconvL + T::mParticles[indexMother].Vy(); //[cm]

--- a/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
+++ b/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
@@ -315,7 +315,7 @@ void ForceDecay()
   /// evtgen pointers
   EvtGen *mEvtGen=0x0; 
   EvtStdHep *mEvtstdhep=0x0;
-  EvtRandomEngine* mEng = 0;
+  EvtTRandomEngine* mEng = 0;
   // pdg particles to be decayed
   TArrayI mPdgString;
   bool mDebug = kFALSE; 


### PR DESCRIPTION
There was a wrong conversion of units which caused the decay length of the particles to be 10 times smaller.
The random engine used for EvtGen was EvtSimpleRandomEngine. It has a fixed seed and a short period. It is now replaced by EvtTRandomEngine, a wrapper for TRandom.