### PR TITLE
Adjust workflows to use SHMID of SHM management tool if used on EPNs

### DIFF
--- a/DATA/common/getCommonArgs.sh
+++ b/DATA/common/getCommonArgs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ -z $SEVERITY || -z $NUMAID || -z $SHMSIZE || -z $FILEWORKDIR || -z $EPNSYNCMODE || -z $INFOLOGGER_SEVERITY || -z $SHMTHROW || -z $NORATELOG ]]; then
+  echo "Configuration Environment Variable Missing in getCommonArgs.sh" 1>&2
+  exit 1
+fi
+
+ARGS_ALL="--session ${OVERRIDE_SESSION:-default} --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA --early-forward-policy noraw"
+ARGS_ALL_CONFIG="NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirGRP=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+if [[ $EPNSYNCMODE == 1 ]]; then
+  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
+  ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 15"
+  ARGS_ALL_CONFIG+="NameConf.mCCDBServer=$GEN_TOPO_EPN_CCDB_SERVER;"
+  export DPL_CONDITION_BACKEND=$GEN_TOPO_EPN_CCDB_SERVER
+elif [[ "0$ENABLE_METRICS" != "01" ]]; then
+  ARGS_ALL+=" --monitoring-backend no-op://"
+fi
+[[ $SHMTHROW == 0 ]] && ARGS_ALL+=" --shm-throw-bad-alloc 0"
+[[ ! -z $SHM_MANAGER_SHMID && "0$GEN_TOPO_CALIB_WORKFLOW" != "01" ]] && ARGS_ALL+=" --no-cleanup --shm-no-cleanup on --shmid $SHM_MANAGER_SHMID"
+[[ $NORATELOG == 1 ]] && ARGS_ALL+=" --fairmq-rate-logging 0"

--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -71,7 +71,11 @@ if [ $EPNSYNCMODE == 0 ]; then
   if [ -z "$EDJSONS_DIR" ];   then export EDJSONS_DIR="jsons"; fi      # output directory for ED json files
   if [ -z "${WORKFLOW_DETECTORS_FLP_PROCESSING+x}" ]; then export WORKFLOW_DETECTORS_FLP_PROCESSING=""; fi # No FLP processing by default when we do not run the sync EPN workflow, e.g. full system test will also run full FLP processing
 else # Defaults when running on the EPN
-  if [ -z "$SHMSIZE" ];              then export SHMSIZE=$(( 256 << 30 )); fi
+  if [[ "0$GEN_TOPO_CALIB_WORKFLOW" != "01" ]]; then
+    if [ -z "$SHMSIZE" ];              then export SHMSIZE=$(( 32 << 30 )); fi
+  else
+    if [ -z "$SHMSIZE" ];              then export SHMSIZE=$(( 256 << 30 )); fi
+  fi
   if [ -z "$NGPUS" ];                then export NGPUS=4; fi
   if [ -z "$EXTINPUT" ];             then export EXTINPUT=1; fi
   if [ -z "$EPNPIPELINES" ];         then export EPNPIPELINES=1; fi

--- a/DATA/production/calib/its-noise-aggregator.sh
+++ b/DATA/production/calib/its-noise-aggregator.sh
@@ -4,23 +4,14 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 INPTYPE=""
 if [[ -z $USECLUSTERS ]]; then
   PROXY_INSPEC="A:ITS/DIGITS/0;B:ITS/DIGITSROF/0;eos:***/INFORMATION"
 else
   PROXY_INSPEC="A:ITS/COMPCLUSTERS/0;B:ITS/PATTERNS/0;C:ITS/CLUSTERSROF/0;eos:***/INFORMATION"
-  INPTYPE=" --use-clusters "  
+  INPTYPE=" --use-clusters "
 fi
 
 if [[ -z $NTHREADS ]] ; then NTHREADS=1; fi

--- a/DATA/production/calib/its-noise-processing.sh
+++ b/DATA/production/calib/its-noise-processing.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 

--- a/DATA/production/calib/its-threshold-aggregator.sh
+++ b/DATA/production/calib/its-threshold-aggregator.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0;eos:***/INFORMATION"
 

--- a/DATA/production/calib/its-threshold-processing.sh
+++ b/DATA/production/calib/its-threshold-processing.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 PROXY_OUTSPEC="tunestring:ITS/TSTR/0;runtype:ITS/RUNT/0;fittype:ITS/FITT/0;scantype:ITS/SCANT/0"

--- a/DATA/production/calib/mch-badchannel-aggregator.sh
+++ b/DATA/production/calib/mch-badchannel-aggregator.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:MCH/PDIGITS/0"
 CONSUL_ENDPOINT="alio2-cr1-hv-aliecs.cern.ch:8500"

--- a/DATA/production/calib/mch-badchannel-processing.sh
+++ b/DATA/production/calib/mch-badchannel-processing.sh
@@ -5,16 +5,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:MCH/RAWDATA;B:FLP/DISTSUBTIMEFRAME/0"
 PROXY_OUTSPEC="downstream:MCH/PDIGITS/0"

--- a/DATA/production/calib/mft-noise-aggregator.sh
+++ b/DATA/production/calib/mft-noise-aggregator.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:MFT/DIGITS/0;B:MFT/DIGITSROF/0"
 

--- a/DATA/production/calib/mft-noise-processing.sh
+++ b/DATA/production/calib/mft-noise-processing.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:MFT/RAWDATA;B:FLP/DISTSUBTIMEFRAME/0"
 PROXY_OUTSPEC="downstream:MFT/DIGITS/0;downstream:MFT/DIGITSROF/0"

--- a/DATA/production/calib/phs-led.sh
+++ b/DATA/production/calib/phs-led.sh
@@ -2,20 +2,7 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 
 if [ -z $PHS_MAX_STATISTICS ]; then
   PHS_MAX_STATISTICS=1000000

--- a/DATA/production/calib/phs-pedestal.sh
+++ b/DATA/production/calib/phs-pedestal.sh
@@ -2,20 +2,7 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 
 if [ -z $PHS_MAX_STATISTICS ] ; then
   PHS_MAX_STATISTICS=10000

--- a/DATA/production/calib/tof-diagn-aggregator.sh
+++ b/DATA/production/calib/tof-diagn-aggregator.sh
@@ -4,15 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
 PROXY_INSPEC="diagWords:TOF/DIAFREQ/0;eos:***/INFORMATION"

--- a/DATA/production/calib/tof-standalone-cosmic-reco-time-calib.sh
+++ b/DATA/production/calib/tof-standalone-cosmic-reco-time-calib.sh
@@ -4,16 +4,8 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
+ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=1

--- a/DATA/production/calib/tof-standalone-reco.sh
+++ b/DATA/production/calib/tof-standalone-reco.sh
@@ -4,16 +4,8 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
+ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=1

--- a/DATA/production/calib/tof-time-calib-aggregator.sh
+++ b/DATA/production/calib/tof-time-calib-aggregator.sh
@@ -4,15 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
 
 PROXY_INSPEC="calclus:TOF/INFOCALCLUS/0;cosmics:TOF/INFOCOSMICS/0;trkcos:TOF/INFOTRACKCOS/0;trksiz:TOF/INFOTRACKSIZE/0;eos:***/INFORMATION"

--- a/DATA/production/calib/tpc-laser.sh
+++ b/DATA/production/calib/tpc-laser.sh
@@ -11,28 +11,12 @@ FILEWORKDIR="/home/wiechula/processData/inputFilesTracking/triggeredLaser"
 
 FILEWORKDIR2="/home/epn/odc/files/"
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
+ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR2;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
-if [ $GPUTYPE != "CPU" ]; then
-  ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR2;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
-
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then

--- a/DATA/production/calib/tpc-pedestal.sh
+++ b/DATA/production/calib/tpc-pedestal.sh
@@ -2,20 +2,8 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
+
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi

--- a/DATA/production/calib/tpc-pulser.sh
+++ b/DATA/production/calib/tpc-pulser.sh
@@ -3,25 +3,11 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
+
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKD
-IR;keyval.output_dir=/dev/null"
 
 PROXY_INSPEC="A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 CALIB_INSPEC="A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPileline.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPileline.sh
@@ -3,7 +3,7 @@
 PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
 NCPU=12 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 
 INFOLOGGER_SEVERITY_RAWPROXY=warning

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineCTF.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineCTF.sh
@@ -12,7 +12,7 @@ hash=$1
 
 VERBOSE=""
 NCPU=12 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 
 # CTF compression dictionary

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQCAlllocalCTF.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQCAlllocalCTF.sh
@@ -5,7 +5,7 @@ source /home/mfasel/alice/O2DataProcessing/common/setenv.sh
 PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
 NCPU=20 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 HOST=epn
 

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocal.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocal.sh
@@ -5,7 +5,7 @@ source /home/mfasel/alice/O2DataProcessing/common/setenv.sh
 PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
 NCPU=12 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 HOST=epn
 

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocalCTF.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocalCTF.sh
@@ -5,7 +5,7 @@ source /home/mfasel/alice/O2DataProcessing/common/setenv.sh
 PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
 NCPU=20 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 HOST=epn
 

--- a/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocalCTFSingle.sh
+++ b/DATA/testing/detectors/EMC/runEMCRawToDigitsRecoPilelineQClocalCTFSingle.sh
@@ -3,7 +3,7 @@
 PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
 NCPU=12 #$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
-ARGS_ALL="-b --session default --shm-segment-size $SHMSIZE"
+source common/getCommonArgs.sh
 #HOST='$(hostname -s)-ib'
 HOST=epn
 

--- a/DATA/testing/detectors/FDD/fdd-ctf.sh
+++ b/DATA/testing/detectors/FDD/fdd-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FDD/fdd-digits-ctf.sh
+++ b/DATA/testing/detectors/FDD/fdd-digits-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FDD/fdd-digits-qc-ctf.sh
+++ b/DATA/testing/detectors/FDD/fdd-digits-qc-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FT0/ft0-ctf.sh
+++ b/DATA/testing/detectors/FT0/ft0-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FT0/ft0-digits-ctf.sh
+++ b/DATA/testing/detectors/FT0/ft0-digits-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FV0/fv0-ctf.sh
+++ b/DATA/testing/detectors/FV0/fv0-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/FV0/fv0-digits-ctf.sh
+++ b/DATA/testing/detectors/FV0/fv0-digits-ctf.sh
@@ -3,11 +3,8 @@
 source common/setenv.sh
 
 SEVERITY=WARNING
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
+source common/getCommonArgs.sh
 if [ -z $CTF_DIR ];                  then CTF_DIR=$FILEWORKDIR; fi        # Directory where to store dictionary files
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`

--- a/DATA/testing/detectors/MID/mid_common.sh
+++ b/DATA/testing/detectors/MID/mid_common.sh
@@ -3,11 +3,7 @@
 # shellcheck disable=SC1091
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 MID_PROXY_INSPEC_EOS="eos:***/INFORMATION"
 MID_PROXY_INSPEC_DD="dd:FLP/DISTSUBTIMEFRAME/0"

--- a/DATA/testing/detectors/TOF/tof-epn-cosmics-dig.sh
+++ b/DATA/testing/detectors/TOF/tof-epn-cosmics-dig.sh
@@ -5,17 +5,14 @@ source common/setenv.sh
 calibration_node="epn007-ib:30453"
 
 SEVERITY=warning
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+source common/getCommonArgs.sh
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`
 # The directory must exist
 CTFOUT="/home/fnoferin/public/out/"
-MYDIR="$(dirname $(readlink -f $0))" 
+MYDIR="$(dirname $(readlink -f $0))"
 OUT_CHANNEL="name=downstream,method=connect,address=tcp://${calibration_node},type=push,transport=zeromq"
 PROXY_OUTSPEC="dd:FLP/DISTSUBTIMEFRAME;dig:TOF/DIGITS;head:TOF/DIGITHEADER;row:TOF/READOUTWINDOW;patt:TOF/PATTERNS"
 

--- a/DATA/testing/detectors/TOF/tof-epn-cosmics-digNoQC.sh
+++ b/DATA/testing/detectors/TOF/tof-epn-cosmics-digNoQC.sh
@@ -5,17 +5,14 @@ source common/setenv.sh
 calibration_node="epn003-ib:30453"
 
 SEVERITY=warning
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+source common/getCommonArgs.sh
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=2
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`
 # The directory must exist
 CTFOUT="/home/fnoferin/public/out/"
-MYDIR="$(dirname $(readlink -f $0))" 
+MYDIR="$(dirname $(readlink -f $0))"
 OUT_CHANNEL="name=downstream,method=connect,address=tcp://${calibration_node},type=push,transport=zeromq"
 PROXY_OUTSPEC="dd:FLP/DISTSUBTIMEFRAME;dig:TOF/DIGITS;head:TOF/DIGITHEADER;row:TOF/READOUTWINDOW;patt:TOF/PATTERNS"
 

--- a/DATA/testing/detectors/TOF/tof-epn-cosmics.sh
+++ b/DATA/testing/detectors/TOF/tof-epn-cosmics.sh
@@ -5,17 +5,14 @@ source common/setenv.sh
 calibration_node="epn003-ib:30453"
 
 SEVERITY=warning
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+source common/getCommonArgs.sh
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=1
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`
 # The directory must exist
 CTFOUT="/home/fnoferin/public/out/"
-MYDIR="$(dirname $(readlink -f $0))" 
+MYDIR="$(dirname $(readlink -f $0))"
 OUT_CHANNEL="name=downstream,method=connect,address=tcp://${calibration_node},type=push,transport=zeromq"
 PROXY_OUTSPEC="dd:FLP/DISTSUBTIMEFRAME;calclus:TOF/INFOCALCLUS;cosmics:TOF/INFOCOSMICS;trkcos:TOF/INFOTRACKCOS;trksiz:TOF/INFOTRACKSIZE"
 

--- a/DATA/testing/detectors/TOF/tof-epn-cosmicsNoQC.sh
+++ b/DATA/testing/detectors/TOF/tof-epn-cosmicsNoQC.sh
@@ -5,17 +5,14 @@ source common/setenv.sh
 calibration_node="epn003-ib:30453"
 
 SEVERITY=warning
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-ARGS_ALL+=" --infologger-severity $SEVERITY"
-#ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-ARGS_ALL_CONFIG="HBFUtils.nHBFPerTF=128;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+source common/getCommonArgs.sh
 CTF_DICT="--ctf-dict $FILEWORKDIR/ctf_dictionary.root"
 PROXY_INSPEC="x:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 NTHREADS=1
 # Output directory for the CTF, to write to the current dir., remove `--output-dir  $CTFOUT` from o2-ctf-writer-workflow or set to `CTFOUT=\"""\"`
 # The directory must exist
 CTFOUT="/home/fnoferin/public/out/"
-MYDIR="$(dirname $(readlink -f $0))" 
+MYDIR="$(dirname $(readlink -f $0))"
 OUT_CHANNEL="name=downstream,method=connect,address=tcp://${calibration_node},type=push,transport=zeromq"
 PROXY_OUTSPEC="dd:FLP/DISTSUBTIMEFRAME;calclus:TOF/INFOCALCLUS;cosmics:TOF/INFOCOSMICS;trkcos:TOF/INFOTRACKCOS;trksiz:TOF/INFOTRACKSIZE"
 

--- a/DATA/testing/detectors/TPC/tpc-krypton-raw.sh
+++ b/DATA/testing/detectors/TPC/tpc-krypton-raw.sh
@@ -5,28 +5,13 @@ source common/setenv.sh
 
 export SHMSIZE=$(( 128 << 30 )) #  GB for the global SHMEM # for kr cluster finder
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dr=$FILEWORKDIR;keyval.output_dir=/dev/null"
-
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then
@@ -83,4 +68,3 @@ o2-dpl-raw-proxy $ARGS_ALL \
     --time-bins-before 20 \
     | o2-qc $ARGS_ALL --config $QC_CONFIG --local --host $HOST \
     | o2-dpl-run $ARGS_ALL --dds | grep -v ERROR
-

--- a/DATA/testing/detectors/TPC/tpc-krypton.sh
+++ b/DATA/testing/detectors/TPC/tpc-krypton.sh
@@ -4,27 +4,13 @@ source common/setenv.sh
 
 export GLOBAL_SHMSIZE=$(( 128 << 30 )) #  GB for the global SHMEM # for kr cluster finder
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then
@@ -64,7 +50,7 @@ QC_CONFIG="consul-json://aliecs.cern.ch:8500/o2/components/qc/ANY/any/tpc-full-q
 if [ $WRITER_TYPE == "EPN" ]; then
    KR_CONFIG="--writer-type ${WRITER_TYPE} --meta-output-dir /data/epn2eos_tool/epn2eos/ --output-dir /data/tf/raw --max-tf-per-file 2000 "
 else
-   KR_CONFIG="--writer-type ${WRITER_TYPE} "  
+   KR_CONFIG="--writer-type ${WRITER_TYPE} "
 fi
 
 
@@ -84,4 +70,3 @@ o2-dpl-raw-proxy $ARGS_ALL \
     $KR_CONFIG \
     | o2-qc $ARGS_ALL --config $QC_CONFIG --local --host localhost \
     | o2-dpl-run --dds  | grep -v ERROR
-

--- a/DATA/testing/detectors/TPC/tpc-laser.sh
+++ b/DATA/testing/detectors/TPC/tpc-laser.sh
@@ -11,27 +11,13 @@ FILEWORKDIR="/home/wiechula/processData/inputFilesTracking/triggeredLaser"
 
 FILEWORKDIR2="/home/epn/odc/files/"
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR2;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then

--- a/DATA/testing/detectors/TPC/tpc-pedestal.sh
+++ b/DATA/testing/detectors/TPC/tpc-pedestal.sh
@@ -2,21 +2,7 @@
 
 source common/setenv.sh
 
-
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
@@ -24,7 +10,6 @@ fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then

--- a/DATA/testing/detectors/TPC/tpc-pulser.sh
+++ b/DATA/testing/detectors/TPC/tpc-pulser.sh
@@ -3,25 +3,10 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKD
-IR;keyval.output_dir=/dev/null"
 
 PROXY_INSPEC="A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 CALIB_INSPEC="A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"

--- a/DATA/testing/detectors/TPC/tpc-standalone.sh
+++ b/DATA/testing/detectors/TPC/tpc-standalone.sh
@@ -9,27 +9,13 @@ export HOSTMEMSIZE=$(( 5 << 30 ))
 
 FILEWORKDIR="/home/epn/odc/files/"
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then
@@ -83,4 +69,3 @@ o2-dpl-raw-proxy $ARGS_ALL \
     --configKeyValues "$ARGS_ALL_CONFIG;align-geom.mDetectors=none;GPU_global.deviceType=$GPUTYPE;GPU_proc.tpcIncreasedMinClustersPerRow=500000;GPU_proc.ignoreNonFatalGPUErrors=1;$GPU_CONFIG_KEY" \
     | o2-qc $ARGS_ALL --config consul-json://aliecs.cern.ch:8500/o2/components/qc/ANY/any/tpc-full-qcmn --local --host $HOST \
     | o2-dpl-run $ARGS_ALL --dds | grep -v ERROR
-

--- a/DATA/testing/detectors/TPC/tpc-workflow.sh
+++ b/DATA/testing/detectors/TPC/tpc-workflow.sh
@@ -2,27 +2,13 @@
 
 source common/setenv.sh
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  #ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock"
-  ARGS_ALL+=" --monitoring-backend no-op://"
-else
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
+source common/getCommonArgs.sh
 if [ $NUMAGPUIDS != 0 ]; then
   ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
 if [ $GPUTYPE != "CPU" ]; then
   ARGS_ALL+="  --shm-mlock-segment-on-creation 1"
 fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
 
 if [ $GPUTYPE == "HIP" ]; then
   if [ $NUMAID == 0 ] || [ $NUMAGPUIDS == 0 ]; then
@@ -72,4 +58,3 @@ o2-dpl-raw-proxy $ARGS_ALL \
 
 #HOST=localhost
 #| o2-qc $ARGS_ALL --config json:///home/epn/odc/files/tpcQCTasks_multinode_ALL.json --local --host $HOST \
-

--- a/DATA/testing/examples/example-calib-aggregator.sh
+++ b/DATA/testing/examples/example-calib-aggregator.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:ITS/COMPCLUSTERS/0;B:ITS/PATTERNS/0;C:ITS/CLUSTERSROF/0;eos:***/INFORMATION"
 

--- a/DATA/testing/examples/example-calib-processing.sh
+++ b/DATA/testing/examples/example-calib-processing.sh
@@ -4,16 +4,7 @@ source common/setenv.sh
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set general arguments
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE $ARGS_ALL_EXTRA"
-ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-if [ $SHMTHROW == 0 ]; then
-  ARGS_ALL+=" --shm-throw-bad-alloc 0"
-fi
-if [ $NORATELOG == 1 ]; then
-  ARGS_ALL+=" --fairmq-rate-logging 0"
-fi
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;$ALL_EXTRA_CONFIG"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 PROXY_OUTSPEC="downstreamA:ITS/COMPCLUSTERS/0;downstreamB:ITS/PATTERNS/0;downstreamC:ITS/CLUSTERSROF/0"

--- a/DATA/testing/examples/example-workflow.sh
+++ b/DATA/testing/examples/example-workflow.sh
@@ -3,16 +3,7 @@
 source common/setenv.sh
 
 SEVERITY=warning
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE"
-if [ $EPNSYNCMODE == 1 ]; then
-  ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
-  ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 15"
-elif [ "0$ENABLE_METRICS" != "01" ]; then
-  ARGS_ALL+=" --monitoring-backend no-op://"
-fi
-[ $NORATELOG == 1 ] && ARGS_ALL+=" --fairmq-rate-logging 0"
-
-ARGS_ALL_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR;keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null"
+source common/getCommonArgs.sh
 
 PROXY_INSPEC="A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 

--- a/DATA/tools/parse
+++ b/DATA/tools/parse
@@ -98,6 +98,7 @@ for line in f:
                 if args[i].startswith('reco'):
                     wf = args[i].split(',', 3)
                     recoworkflows.append(filename)
+                    is_calib_workflow = 0
                 elif args[i].startswith('calib'):
                     wf = args[i].split(',', 2)
                     filenamecore = filename
@@ -106,6 +107,7 @@ for line in f:
                     wf[1] = '1';
                     wf[2] = wf[1]
                     calibworkflows.append(filenamecore)
+                    is_calib_workflow = 1
                 else:
                     print('Invalid workflow type', args[i])
                     raise
@@ -116,7 +118,7 @@ for line in f:
                     command_log_filter = '"^\["'
                 else:
                     command_log_filter = '"^\[INFO"'
-                command_preopt = ''
+                command_preopt = 'GEN_TOPO_CALIB_WORKFLOW=' + str(is_calib_workflow)
                 if 'GEN_TOPO_OOM_WORKAROUND' in os.environ and int(os.environ['GEN_TOPO_OOM_WORKAROUND']):
                     json_cache_path = os.environ['GEN_TOPO_WORKDIR'] + '/json_cache'
                     filename_xml = filename


### PR DESCRIPTION
This unifies the setting up of `$ARGS_ALL`, making all workflows load it from a common script, which also takes into account the SHM management tool. To be tested at P2 before merged.