### PR TITLE
Updating forward Jpsi in pp scripts

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
@@ -1,0 +1,107 @@
+// usage
+// o2-sim -j 4 -n 10 -g external  -o sgn  --configKeyValues "GeneratorExternal.fileName=GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV()"
+//
+R__ADD_INCLUDE_PATH($O2DPG_ROOT / MC / config / PWGDQ / EvtGen)
+#include "GeneratorEvtGen.C"
+
+namespace o2
+{
+namespace eventgen
+{
+
+class O2_GeneratorParamJpsi : public GeneratorTGenerator
+{
+
+ public:
+  O2_GeneratorParamJpsi() : GeneratorTGenerator("ParamJpsi")
+  {
+    paramJpsi = new GeneratorParam(1, -1, PtJPsipp13TeV, YJPsipp13TeV, V2JPsipp13TeV, IpJPsipp13TeV);
+    paramJpsi->SetMomentumRange(0., 1.e6);
+    paramJpsi->SetPtRange(0, 999.);
+    paramJpsi->SetYRange(-4.2, -2.3);
+    paramJpsi->SetPhiRange(0., 360.);
+    paramJpsi->SetDecayer(new TPythia6Decayer());
+    paramJpsi->SetForceDecay(kNoDecay); // particle left undecayed
+    setTGenerator(paramJpsi);
+  };
+
+  ~O2_GeneratorParamJpsi()
+  {
+    delete paramJpsi;
+  };
+
+  Bool_t Init() override
+  {
+    GeneratorTGenerator::Init();
+    paramJpsi->Init();
+    return true;
+  }
+
+  void SetNSignalPerEvent(Int_t nsig) { paramJpsi->SetNumberParticles(nsig); }
+
+  //-------------------------------------------------------------------------//
+  static Double_t PtJPsipp13TeV(const Double_t* px, const Double_t* /*dummy*/)
+  {
+    // jpsi pT in pp at 13 TeV, tuned on data (2015)
+    Double_t x = *px;
+    Float_t p0, p1, p2, p3;
+    p0 = 1;
+    p1 = 4.75208;
+    p2 = 1.69247;
+    p3 = 4.49224;
+    return p0 * x / TMath::Power(1. + TMath::Power(x / p1, p2), p3);
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t YJPsipp13TeV(const Double_t* py, const Double_t* /*dummy*/)
+  {
+    // jpsi y in pp at 13 TeV, tuned on data (2015)
+    Double_t y = *py;
+    Float_t p0, p1, p2;
+    p0 = 1;
+    p1 = 0;
+    p2 = 2.98887;
+    return p0 * TMath::Exp(-(1. / 2.) * TMath::Power(((y - p1) / p2), 2));
+  }
+
+  //-------------------------------------------------------------------------//
+  static Double_t V2JPsipp13TeV(const Double_t* /*dummy*/, const Double_t* /*dummy*/)
+  {
+    // jpsi v2
+    return 0.;
+  }
+
+  //-------------------------------------------------------------------------//
+  static Int_t IpJPsipp13TeV(TRandom*)
+  {
+    return 443;
+  }
+
+ private:
+  GeneratorParam* paramJpsi = nullptr;
+};
+
+} // namespace eventgen
+} // namespace o2
+
+FairGenerator*
+  GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV(TString pdgs = "443")
+{
+  auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::O2_GeneratorParamJpsi>();
+  gen->SetNSignalPerEvent(1); // number of jpsis per event
+
+  std::string spdg;
+  TObjArray* obj = pdgs.Tokenize(";");
+  gen->SetSizePdg(obj->GetEntriesFast());
+  for (int i = 0; i < obj->GetEntriesFast(); i++) {
+    spdg = obj->At(i)->GetName();
+    gen->AddPdg(std::stoi(spdg), i);
+    printf("PDG %d \n", std::stoi(spdg));
+  }
+  gen->SetForceDecay(kEvtDiMuon);
+
+  // print debug
+  gen->PrintDebug();
+
+  return gen;
+}

--- a/MC/run/PWGDQ/runBeautyToJpsi_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runBeautyToJpsi_fwdy_pp.sh
@@ -14,7 +14,7 @@ NBKGEVENTS=${NBKGEVENTS:-1}
 NWORKERS=${NWORKERS:-8} 
 NTIMEFRAMES=${NTIMEFRAMES:-1}
 
-${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13600 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini  \
         -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 

--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_pp.sh
@@ -14,8 +14,8 @@ NBKGEVENTS=${NBKGEVENTS:-1}
 NWORKERS=${NWORKERS:-8}
 NTIMEFRAMES=${NTIMEFRAMES:-1}
 
-${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 900 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
-	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_pp13TeV()"  \
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13600 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
+	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV()"  \
         -genBkg pythia8 -procBkg inel -colBkg pp --embedding -nb ${NBKGEVENTS} --mft-reco-full
 
 


### PR DESCRIPTION
Updating beam energy in forward scripts to 13.6 TeV. Prompt script updated to generate only a single J/psi per event.