### PR TITLE
Use IPC for local calib connections

### DIFF
--- a/DATA/tools/epn/gen_topo.sh
+++ b/DATA/tools/epn/gen_topo.sh
@@ -37,7 +37,7 @@ else
   # Note that this does not load the module, but just needs an O2DPG path to find, which then does the bulk of the topology generation.
   # gen_topo_o2dpg.sh is kept compatible between O2DPG versions, thus it doesn't really depend on which O2DPG version we use at this point.
   if [[ -z $O2DPG_ROOT ]]; then
-    O2DPG_ROOT=`bash -c "module load O2DPG > /dev/null; echo \\\$O2DPG_ROOT;"`
+    O2DPG_ROOT=`bash -c "module load O2DPG &> /dev/null; echo \\\$O2DPG_ROOT;"`
   fi
 fi
 # Now we know which gen_topo_o2dpg.sh we can use, and all EPN related env variables are set, so we can run the topology generation.


### PR DESCRIPTION
@chiarazampolli : Haven't tested this yet, but this is what I had in mind for the proxy channels:
So for testing locally, but in 2 separate shells, i.e. without CALIB_LOCAL_INTEGRATED_AGGREGATOR, one has to set both CALIB_PROXIES and CALIB_LOCAL_AGGREGATOR. Then it will use SHM transport with a socket file based on the channel name.
If CALIB_PROXIES is set, but CALIB_LOCAL_AGGREGATOR is not, i.e. when we run online on the EPN, we use zeromq transport and leave the address empty, to be filled by FairMQ automatically, in the same way we are doing for the calib workflows at P2 right now already.