### PR TITLE
Inject estimated resources into WF runner

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -41,6 +41,7 @@ parser.add_argument('-tt','--target-tasks', nargs='+', help='Runs the pipeline b
 parser.add_argument('--produce-script', help='Produces a shell script that runs the workflow in serialized manner and quits.')
 parser.add_argument('--rerun-from', help='Reruns the workflow starting from given task (or pattern). All dependent jobs will be rerun.')
 parser.add_argument('--list-tasks', help='Simply list all tasks by name and quit.', action='store_true')
+parser.add_argument('--update-resources', dest="update_resources", help='Read resource estimates from a JSON and apply where possible.')
 
 parser.add_argument('--mem-limit', help='Set memory limit as scheduling constraint (in MB)', default=0.9*max_system_mem/1024./1024)
 parser.add_argument('--cpu-limit', help='Set CPU limit (core count)', default=8)
@@ -283,8 +284,8 @@ def build_graph(taskuniverse, workflowspec):
     return (edges, nodes)
         
 
-# loads the workflow specification
-def load_workflow(workflowfile):
+# loads json into dict, e.g. for workflow specification
+def load_json(workflowfile):
     fp=open(workflowfile)
     workflowspec=json.load(fp)
     return workflowspec
@@ -405,6 +406,32 @@ def build_dag_properties(workflowspec):
     # print (global_next_tasks)
     return { 'nexttasks' : global_next_tasks, 'weights' : task_weights, 'topological_ordering' : tup[0] }
 
+# update the resource estimates of a workflow based on resources given via JSON
+def update_resource_estimates(workflow, resource_json):
+    resource_dict = load_json(resource_json)
+    stages = workflow["stages"]
+
+    for task in stages:
+        if task["timeframe"] >= 1:
+            tf = task["timeframe"]
+            name = "_".join(task["name"].split("_")[:-1])
+        else:
+            name = task["name"]
+
+        if name not in resource_dict:
+            continue
+
+        new_resources = resource_dict[name]
+
+        task["resources"]["mem"] = new_resources.get("mem", task["resources"]["mem"])
+        # CPU is a bit more invlolved
+        if "cpu" in new_resources:
+            cpu = new_resources["cpu"]
+            rel_cpu = task["resources"]["relative_cpu"]
+            if rel_cpu is not None:
+                # respect the relative CPU settings
+                cpu *= rel_cpu
+            task["resources"]["cpu"] = cpu
 
 #
 # functions for execution; encapsulated in a WorkflowExecutor class
@@ -414,7 +441,7 @@ class WorkflowExecutor:
     def __init__(self, workflowfile, args, jmax=100):
       self.args=args
       self.workflowfile = workflowfile
-      self.workflowspec = load_workflow(workflowfile)
+      self.workflowspec = load_json(workflowfile)
       self.workflowspec = filter_workflow(self.workflowspec, args.target_tasks, args.target_labels)
 
       if not self.workflowspec['stages']:
@@ -436,6 +463,9 @@ class WorkflowExecutor:
       for i in range(len(self.taskuniverse)):
           self.tasktoid[self.taskuniverse[i]]=i
           self.idtotask[i]=self.taskuniverse[i]
+
+      if args.update_resources:
+          update_resource_estimates(self.workflowspec, args.update_resources)
 
       self.maxmemperid = [ self.workflowspec['stages'][tid]['resources']['mem'] for tid in range(len(self.taskuniverse)) ]
       self.cpuperid = [ self.workflowspec['stages'][tid]['resources']['cpu'] for tid in range(len(self.taskuniverse)) ]

--- a/MC/utils/o2dpg_sim_metrics.py
+++ b/MC/utils/o2dpg_sim_metrics.py
@@ -560,13 +560,13 @@ def main():
   
   sub_parsers = parser.add_subparsers(dest="command")
   
-  extract_parser = sub_parsers.add_parser("extract")
+  extract_parser = sub_parsers.add_parser("extract", help="Extract metrics as JSON format from metric_pipeline")
   extract_parser.set_defaults(func=extract)
   extract_parser.add_argument("--path", help="path to pipeline_metrics file to be evaluated", required=True)
   extract_parser.add_argument("--tags", help="key-value pairs, seperated by ;, example: alidist=1234567;o2=7654321;tag=someTag")
   extract_parser.add_argument("--output", "-o", help="output name", default="metrics.json")
 
-  plot_parser = sub_parsers.add_parser("plot")
+  plot_parser = sub_parsers.add_parser("plot", help="Plot (multiple) metrcis from extracted metrics JSON file(s)")
   plot_parser.set_defaults(func=plot)
   plot_parser.add_argument("--metrics", nargs="+", help="metric JSON files")
   plot_parser.add_argument("--cpu-eff", dest="cpu_eff", action="store_true", help="run only cpu efficiency evaluation")
@@ -574,7 +574,7 @@ def main():
   plot_parser.add_argument("--output", help="output_directory", default="metrics_summary")
   plot_parser.add_argument("--metrics-summary", dest="metrics_summary", action="store_true", help="create the metrics summary")
 
-  influx_parser = sub_parsers.add_parser("influx")
+  influx_parser = sub_parsers.add_parser("influx", help="Derive a format which can be sent to InfluxDB")
   influx_parser.set_defaults(func=influx)
   influx_parser.add_argument("--metrics", help="pmetric JSON file to prepare for InfluxDB", required=True)
   influx_parser.add_argument("--table-base", dest="table_base", help="base name of InfluxDB table name", default="O2DPG_MC")


### PR DESCRIPTION
Central to this PR

* o2dpg_sim_metrics.py resources
  produces a resource estimate for mem and CPU based on previously
  derived metrics from one or more runs
  --take argument can be used to define to take
  * average
  * min
  * max
  in case multiple metric JSONs are passed. The estimates are written to
  a JSON again

  Treat every TF the same so the estimate file only contains
  "task_name": {
    "mem": <memory>,
    "cpu": <cpu>
  }
  without TF suffix

* o2_dpg_workflow_runner --update-resources
  takes a JSON produced by previous resource estimation and updates the
  resources on the fly
  Due to above comment, all TFs get the same resource estimate
  
  Other
  
  some consolidation and help for argparse