### PR TITLE
fix wrong typo due to clang-format

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
@@ -1,7 +1,7 @@
 // usage
 // o2-sim -j 4 -n 10 -g external  -o sgn  --configKeyValues "GeneratorExternal.fileName=GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C;GeneratorExternal.funcName=GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV()"
 //
-R__ADD_INCLUDE_PATH($O2DPG_ROOT / MC / config / PWGDQ / EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
 #include "GeneratorEvtGen.C"
 
 namespace o2


### PR DESCRIPTION
Fix a typo error due to clang-format in the R__ADD_INCLUDE_PATH function