### PR TITLE
Fix condition for TOF calibration

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -22,7 +22,7 @@ if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
 
     # calibrations for TOF
     if has_detector_calib TOF && has_detector_reco TOF; then
-	if has_detector_matching ITSTPCTOF || has_detector_matching ITSTPCTRDTOF; then
+	if ( has_detectors_reco ITS TPC && has_detector_matching ITSTPCTOF ) || ( has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRDTOF ); then
 	    if [[ -z ${CALIB_TOF_LHCPHASE+x} ]]; then CALIB_TOF_LHCPHASE=1; fi
 	    if [[ -z ${CALIB_TOF_CHANNELOFFSETS+x} ]]; then CALIB_TOF_CHANNELOFFSETS=1; fi
 	else
@@ -71,6 +71,17 @@ if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
     fi
 
 fi
+
+echo "CALIB_PRIMVTX_MEANVTX = $CALIB_PRIMVTX_MEANVTX" 1>&2
+echo "CALIB_TOF_LHCPHASE = $CALIB_TOF_LHCPHASE" 1>&2
+echo "CALIB_TOF_CHANNELOFFSETS = $CALIB_TOF_CHANNELOFFSETS" 1>&2
+echo "CALIB_TOF_DIAGNOSTICS = $CALIB_TOF_DIAGNOSTICS" 1>&2
+echo "CALIB_EMC_CHANNELCALIB = $CALIB_EMC_CHANNELCALIB" 1>&2
+echo "CALIB_PHS_ENERGYCALIB = $CALIB_PHS_ENERGYCALIB" 1>&2
+echo "CALIB_PHS_BADMAPCALIB = $CALIB_PHS_BADMAPCALIB" 1>&2
+echo "CALIB_PHS_TURNONCALIB = $CALIB_PHS_TURNONCALIB" 1>&2
+echo "CALIB_PHS_RUNBYRUNCALIB = $CALIB_PHS_RUNBYRUNCALIB" 1>&2
+echo "CALIB_TRD_VDRIFTEXB = $CALIB_TRD_VDRIFTEXB" 1>&2
 
 if [[ -z $CALIBDATASPEC_BARREL ]]; then
     # prim vtx


### PR DESCRIPTION
@davidrohr 

@noferini : in the current implementation we attach the calibration for TOF (with tracks) also when we have the ITSTPCTOFTRD matching, but probably this case is not needed since, if I am not wrong, we only use ITSTPCTPOF tracks. Can you confirm? If so, I will remove it (even if it does not harm).