### PR TITLE
New behavior for --mft-reco-full: activate full cluster scan

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -71,7 +71,6 @@ def create_sim_config(args):
 
     # MFT tracking settings
     if args.mft_reco_full == True:
-        add(config, {"MFTTracking.forceZeroField" : 0,
-                     "MFTTracking.LTFclsRCut" : 0.0100})
+        add(config, {"MFTTracking.FullClusterScan" : 1})
 
     return config

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -107,7 +107,7 @@ parser.add_argument('--include-analysis', '--include-an', '--analysis',
                     action='store_true', help='a flag to include O2 analysis in the workflow')
 
 # MFT reconstruction configuration
-parser.add_argument('--mft-reco-full', action='store_true', help='enables complete mft reco instead of simplified misaligned version')
+parser.add_argument('--mft-reco-full', action='store_true', help='enables full MFT cluster scan (i.e. disables track finding optimization needed for PbPb)')
 parser.add_argument('--mft-assessment-full', action='store_true', help='enables complete assessment of mft reco')
 
 # Global Forward reconstruction configuration

--- a/MC/run/PWGDQ/runBeautyToJpsi_fwdy_PbPb.sh
+++ b/MC/run/PWGDQ/runBeautyToJpsi_fwdy_PbPb.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runBeautyToPsi_fwdy_PbPb.sh
+++ b/MC/run/PWGDQ/runBeautyToPsi_fwdy_PbPb.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-trigger "external" -ini $O2DPG_ROOT/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-assessment-full --fwdmatching-assessment-full
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json

--- a/MC/run/PWGDQ/runFwdMuBoxGen_PbPb.sh
+++ b/MC/run/PWGDQ/runFwdMuBoxGen_PbPb.sh
@@ -18,7 +18,7 @@ NBOXMUONS=${NBOXMUONS:2}
 
 NMUONS=$NBOXMUONS ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBoxFwd.C;GeneratorExternal.funcName=fwdMuBoxGen()"  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
 
 # run workflow (MFT-related tasks)
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt "(mft.*)" 

--- a/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
+++ b/MC/run/PWGDQ/runPromptCharmonia_fwdy_PbPb.sh
@@ -16,7 +16,7 @@ NTIMEFRAMES=${NTIMEFRAMES:-1}
 
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -e TGeant4 -mod "--skipModules ZDC" \
 	-confKey "GeneratorExternal.fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV.C;GeneratorExternal.funcName=GeneratorCocktailPromptCharmoniaToMuonEvtGen_PbPb5TeV()"  \
-        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-reco-full --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
+        -genBkg pythia8 -procBkg "heavy_ion" -colBkg PbPb --embedding -nb ${NBKGEVENTS} --mft-assessment-full --fwdmatching-assessment-full --fwdmatching-save-trainingdata
 
 # run workflow
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json


### PR DESCRIPTION
Please merge this PR in sync with https://github.com/AliceO2Group/AliceO2/pull/8852

**Changes:**
- Old mft reconstruction configuration is the default one after https://github.com/AliceO2Group/AliceO2/pull/8852
- `--mft-reco-full` now enables full cluster scan, i.e. search for tracks with any orientation by disabling optimization necessary for PbPb collisions

It is not recommended to use `--mft-reco-full` in PbPb collisions as the combinatorics of full cluster scan explodes track-finding computation time. This PR ensures `MFTTracking.FullClusterScan` is not set on PbPb generator scripts.