### PR TITLE
Temporarily disable TPC PADGAINCALIB, it is too slow

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -49,6 +49,9 @@ if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
     CALIB_TPC_RESPADGAIN=0
   fi
 
+  # WORKAROUND - DISABLE TPC PADGAIN CALIB - TOO SLOW
+  CALIB_TPC_RESPADGAIN=0
+
   # calibrations for TRD
   if has_detector_calib TRD && has_detectors ITS TPC TRD ; then
     if [[ -z ${CALIB_TRD_VDRIFTEXB+x} ]]; then CALIB_TRD_VDRIFTEXB=1; fi


### PR DESCRIPTION
@chiarazampolli : I have to disable this since it runs in the default FST and it is way too slow. TPC should look into that, and probably process only a fraction of the data in case of Pb-Pb.