### PR TITLE
fix for name too long in json

### DIFF
--- a/DATA/production/qc-sync/itstpctrdtof.json
+++ b/DATA/production/qc-sync/itstpctrdtof.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks" : {
-      "MatchingTOFwithTRD" : {
+      "MatchingTOFwTRD" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::tof::TOFMatchedTracks",
         "moduleName" : "QcTOF",


### PR DESCRIPTION
@davidrohr 
I think that the name is too long and it may break with the recent changes in QC framework