### PR TITLE
Change MID digits query alias to cope with QC modifications now in QC 1.63.0

### DIFF
--- a/DATA/production/qc-async/mid.json
+++ b/DATA/production/qc-async/mid.json
@@ -146,7 +146,7 @@
       "id": "mid-digits",
       "active": "true",
       "machines": [],
-      "query": "digits:MID/DATA;digitrofs:MID/DATAROF",
+      "query": "digits:MID/DATA;digits_rof:MID/DATAROF",
       "samplingConditions": [
         {
           "condition": "random",

--- a/DATA/production/qc-sync/mid-digits.json
+++ b/DATA/production/qc-sync/mid-digits.json
@@ -55,7 +55,7 @@
       "id": "middigits",
       "active": "true",
       "machines": [],
-      "query": "digits:MID/DATA;digitrofs:MID/DATAROF",
+      "query": "digits:MID/DATA;digits_rof:MID/DATAROF",
       "samplingConditions": [
         {
           "condition": "random",

--- a/DATA/production/qc-sync/mid.json
+++ b/DATA/production/qc-sync/mid.json
@@ -182,7 +182,7 @@
         "epn",
         "localhost"
       ],
-      "query": "digits:MID/DATA;digitrofs:MID/DATAROF",
+      "query": "digits:MID/DATA;digits_rof:MID/DATAROF",
       "samplingConditions": [
         {
           "condition": "random",


### PR DESCRIPTION
This commit was kind of reverted because the corresponding commit in QC was not bumped. This resulted in a failure of the fullCI tests, that was still using an old QC version.
Now the QC is bumped, and the tagged version contains the needed information. The json files can be therefore safely modified accordingly.