### PR TITLE
[EMCAL-755] Change DigitsQCTask to CellTask in simulation

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -78,7 +78,7 @@ def include_all_QC_finalization(ntimeframes, standalone, run, productionTag):
   add_QC_finalization('mftDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-digit-0.json', MFTDigitsQCneeds)
   add_QC_finalization('mftClustersQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-cluster.json')
   add_QC_finalization('mftAsyncQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/qc-mft-async.json')
-  add_QC_finalization('emcDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/emc-digits-task.json')
+  add_QC_finalization('emcCellQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/emc-cell-task.json')
   #add_QC_finalization('tpcTrackingQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-tracking-direct.json')
   add_QC_finalization('tpcStandardQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-standard-direct.json')
   add_QC_finalization('trdDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/trd-digits-task.json')

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -981,10 +981,10 @@ for tf in range(1, NTIMEFRAMES + 1):
 
      ### EMCAL
      if isActive('EMC'):
-        addQCPerTF(taskName='emcDigitsQC',
+        addQCPerTF(taskName='emcCellQC',
                    needs=[EMCRECOtask['name']],
                    readerCommand='o2-emcal-cell-reader-workflow --infile emccells.root',
-                   configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/emc-digits-task.json')
+                   configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/emc-cell-task.json')
      ### FT0
      addQCPerTF(taskName='RecPointsQC',
                    needs=[FT0RECOtask['name']],

--- a/MC/config/QC/json/emc-cell-task.json
+++ b/MC/config/QC/json/emc-cell-task.json
@@ -26,16 +26,16 @@
       }
     },
     "tasks": {
-      "DigitsTask": {
+      "CellTask": {
         "active": "true",
-        "className": "o2::quality_control_modules::emcal::DigitsQcTask",
+        "className": "o2::quality_control_modules::emcal::CellTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",
         "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR"
+          "query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR"
         }
       }
     },


### PR DESCRIPTION
CellTask was branched off several months ago to
monitor cell level information (in AliRoot Digits and Cells
were the same objects for EMCAL as the time response
was not simulated, with the introduction of time sampling
they diverged). A transition period was kept to not affect
existing productions. The workflows should be adapted now
to allow using the DigitsQCTask to monitor digits (time
sample) level quantities.