### PR TITLE
Fixes and some changes

### DIFF
--- a/RelVal/o2dpg_release_validation.py
+++ b/RelVal/o2dpg_release_validation.py
@@ -84,6 +84,9 @@ def find_mutual_files(dirs, glob_pattern, *, grep=None):
             f[i] = f[i][len(d):].lstrip("/")
 
     # build the intersection
+    if not files:
+        return []
+
     intersection = files[0]
     for f in files[1:]:
         intersection = list(set(intersection) & set(f))
@@ -392,7 +395,7 @@ def rel_val_sim_dirs(args):
     if args.with_qc:
         dir_qc1 = join(dir1, "QC")
         dir_qc2 = join(dir2, "QC")
-        qc_files = find_mutual_files((dir_qc1, dir_qc2), "*Async*.root")
+        qc_files = find_mutual_files((dir_qc1, dir_qc2), "*.root")
         output_dir_qc = join(output_dir, "qc")
         if not exists(output_dir_qc):
             makedirs(output_dir_qc)


### PR DESCRIPTION
* remove redundant plotting of simgle histograms, they are contained in
  the ratio plots

* taken out previous ratio plotting and replace by more modular approach
  TODO:
  * Add for 3D
  * write to summary ROOT file so that we can eventually extract
    critical histograms when desired

* update labels shown in ratio plots
  If only non-critical test failed, show "COMPATIBLE" label in ratio
  plots.
  If at least one critical test failed, show "BAD"
  (before that was overwritten by each proceeding test such that it
  could show compatoble even though an earlier critical test failed)

* resolve memory issues
  many mem problems, in particular from previous plotting. Most of the
  resolved by simply moving to new plotting;
  others were fixed