### PR TITLE
TPC: Updating cut parameters in TPC QC JSONs

### DIFF
--- a/DATA/production/qc-async/tpc.json
+++ b/DATA/production/qc-async/tpc.json
@@ -60,7 +60,17 @@
         "dataSource": {
           "type": "direct",
           "query" : "inputTracks:TPC/TRACKS/0"
-        }
+        },
+        "taskParameters": {
+          "cutMinNCluster": "60",
+          "cutAbsTgl": "1.",
+          "cutMindEdxTot": "10.",
+          "cutMaxdEdxTot": "2000.",
+          "cutMinpTPC": "0.05",
+          "cutMaxpTPC": "20.",
+          "cutMinpTPCMIPs": "0.45",
+          "cutMaxpTPCMIPs": "0.55"
+       }
       },
       "Tracks": {
         "active": "true",
@@ -73,6 +83,11 @@
         "dataSource": {
           "type": "direct",
           "query" : "inputTracks:TPC/TRACKS/0"
+        },
+        "taskParameters": {
+          "cutAbsEta": "1.",
+          "cutMinNCluster": "60",
+          "cutMindEdxTot": "20."
         }
       }
     }

--- a/DATA/production/qc-sync/tpc.json
+++ b/DATA/production/qc-sync/tpc.json
@@ -79,7 +79,16 @@
           "type": "direct",
           "query": "inputTracks:TPC/TRACKS/0"
         },
-        "taskParameters": {},
+        "taskParameters": {
+          "cutMinNCluster": "60",
+          "cutAbsTgl": "1.",
+          "cutMindEdxTot": "10.",
+          "cutMaxdEdxTot": "2000.",
+          "cutMinpTPC": "0.05",
+          "cutMaxpTPC": "20.",
+          "cutMinpTPCMIPs": "0.45",
+          "cutMaxpTPCMIPs": "0.55"
+        },
         "location": "local",
         "localMachines": [
           "localhost",
@@ -102,7 +111,11 @@
           "type": "direct",
           "query": "inputTracks:TPC/TRACKS/0"
         },
-        "taskParameters": {},
+        "taskParameters": {
+          "cutAbsEta": "1.",
+          "cutMinNCluster": "60",
+          "cutMindEdxTot": "20."
+        },
         "location": "local",
         "localMachines": [
           "localhost",

--- a/MC/config/QC/json/tpc-qc-standard-direct.json
+++ b/MC/config/QC/json/tpc-qc-standard-direct.json
@@ -62,7 +62,17 @@
         "dataSource": {
           "type": "direct",
           "query" : "inputTracks:TPC/TRACKS/0"
-        }
+        },
+        "taskParameters": {
+          "cutMinNCluster": "60",
+          "cutAbsTgl": "1.",
+          "cutMindEdxTot": "10.",
+          "cutMaxdEdxTot": "2000.",
+          "cutMinpTPC": "0.05",
+          "cutMaxpTPC": "20.",
+          "cutMinpTPCMIPs": "0.45",
+          "cutMaxpTPCMIPs": "0.55"
+       }
       },
       "Tracks": {
         "active": "true",
@@ -74,6 +84,11 @@
         "dataSource": {
           "type": "direct",
           "query" : "inputTracks:TPC/TRACKS/0"
+        },
+        "taskParameters": {
+          "cutAbsEta": "1.",
+          "cutMinNCluster": "60",
+          "cutMindEdxTot": "20."
         }
       }
     }


### PR DESCRIPTION
With the most recent updates to the **Tracks** and **PID** tasks in TPC QC, it is now possible (needed) to specify cuts on variables from the JSON file. Added the required task Parameters in the **MC, sync, and async TPC QC**.