### PR TITLE
Fix getTPCvdrift.C location in setenv_extra.sh of special TPC apass

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1_TPCcalib/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1_TPCcalib/setenv_extra.sh
@@ -49,8 +49,7 @@ else
 fi
 
 # TPC vdrift
-#root -b -q "$O2DPG_ROOT/DATA/production/configurations/$ALIEN_JDL_LPMANCHORYEAR/$O2DPGPATH/$ALIEN_JDL_LPMPASSNAME/getTPCvdrift.C+($RUNNUMBER)"
-root -b -q "/home/zampolli/SOFT/alibuild/ali-o2-dev1/O2DPG/DATA/production/configurations/$ALIEN_JDL_LPMANCHORYEAR/$O2DPGPATH/$ALIEN_JDL_LPMPASSNAME/getTPCvdrift.C+($RUNNUMBER)"
+root -b -q "$O2DPG_ROOT/DATA/production/configurations/$ALIEN_JDL_LPMANCHORYEAR/$O2DPGPATH/$ALIEN_JDL_LPMPASSNAME/getTPCvdrift.C+($RUNNUMBER)"
 export VDRIFT=`cat vdrift.txt`
 
 # remove monitoring-backend


### PR DESCRIPTION
If I am mistaken and this was intentional, please ignore.