### PR TITLE
Special settings valid from run 521889, using digits for ITS and MFT

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -38,6 +38,13 @@ echo remapping = $REMAPPING
 
 # other ad-hoc settings for CTF reader
 export ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow="$ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow --allow-missing-detectors $REMAPPING"
+echo RUN = $RUNNUMBER
+if [[ $RUNNUMBER -ge 521889 ]]; then
+  export ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow="$ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow --its-digits --mft-digits"
+  export DISABLE_DIGIT_CLUSTER_INPUT="--digits-from-upstream"
+  MAXBCDIFFTOMASKBIAS_ITS="ITSClustererParam.maxBCDiffToMaskBias=10"
+  MAXBCDIFFTOMASKBIAS_MFT="MFTClustererParam.maxBCDiffToMaskBias=10"
+fi
 
 # run-dependent options
 if [[ -f "setenv_run.sh" ]]; then
@@ -64,7 +71,7 @@ export ITSEXTRAERR="ITSCATrackerParam.sysErrY2[0]=9e-4;ITSCATrackerParam.sysErrZ
 
 # ad-hoc options for ITS reco workflow
 export ITS_CONFIG=" --tracking-mode sync_misaligned"
-export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2"
+export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;$MAXBCDIFFTOMASKBIAS_ITS"
 
 # ad-hoc options for GPU reco workflow
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="TPCGasParam.DriftV=$VDRIFT;GPU_global.dEdxDisableResidualGainMap=1"
@@ -104,8 +111,8 @@ export ARGS_EXTRA_PROCESS_o2_fv0_reco_workflow="--fv0-reconstructor"
 #...
 
 # ad-hoc settings for MFT 
-export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.forceZeroField=true;MFTTracking.FullClusterScan=true;MFTTracking.LTFclsRCut=0.2;"
-export ARGS_EXTRA_PROCESS_o2_mft_reco_workflow=" --run-assessment "
+export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.forceZeroField=true;MFTTracking.FullClusterScan=true;MFTTracking.LTFclsRCut=0.2;$MAXBCDIFFTOMASKBIAS_MFT"
+export ARGS_EXTRA_PROCESS_o2_mft_reco_workflow="$ARGS_EXTRA_PROCESS_mft_reco_workflow --run-assessment "
 
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"


### PR DESCRIPTION
Needs https://github.com/AliceO2Group/AliceO2/pull/9586
@shahor02 , @davidrohr 

ctf reader then becomes e.g.:
```
o2-ctf-reader-workflow --session default_835747_6385 --severity info --shm-segment-id 0 --shm-segment-size 16000000000  --resources-monitoring 50 --resources-monitor
ing-dump-interval 50 --early-forward-policy noraw --fairmq-rate-logging 0 --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 --delay 8 --loop 0  --ctf-input l
ist.list   --onlyDet ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT,MCH,TRD,EMC,PHS,CPV --pipeline tpc-entropy-decoder:1  --allow-missing-detectors  --its-digits --mft-digits --con
figKeyValues "NameConf.mDirGeom=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirMatLUT=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirCollContex
t=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirGRP=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;keyval.input_dir=/home/zampolli/work/O2/PilotBeamMay22/L
HC22f;keyval.output_dir=/dev/null;;" | \
```

its-reco:
```
o2-its-reco-workflow --session default_835747_6385 --severity info --shm-segment-id 0 --shm-segment-size 16000000000  --resources-monitoring 50 --resources-monitorin
g-dump-interval 50 --early-forward-policy noraw --fairmq-rate-logging 0 --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 --trackerCA  --tracking-mode sync_m
isaligned --disable-mc --digits-from-upstream  --pipeline its-tracker:1  --configKeyValues "NameConf.mDirGeom=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.m
DirMatLUT=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirCollContext=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirGRP=/home/zampolli/work/O2/
PilotBeamMay22/LHC22f;keyval.input_dir=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;keyval.output_dir=/dev/null;;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.cluster
ContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;;;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;ITSClus
tererParam.maxBCDiffToMaskBias=10;" | \
```

mft reco:
```
o2-mft-reco-workflow --session default_835747_6385 --severity info --shm-segment-id 0 --shm-segment-size 16000000000  --resources-monitoring 50 --resources-monitorin
g-dump-interval 50 --early-forward-policy noraw --fairmq-rate-logging 0 --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 --digits-from-upstream --disable-mc
  --pipeline mft-tracker:1  --run-assessment  --configKeyValues "NameConf.mDirGeom=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirMatLUT=/home/zampolli/wo
rk/O2/PilotBeamMay22/LHC22f;NameConf.mDirCollContext=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirGRP=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;keyva
l.input_dir=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;keyval.output_dir=/dev/null;;MFTTracking.forceZeroField=true;MFTTracking.FullClusterScan=true;MFTTracking.LT
FclsRCut=0.2;MFTClustererParam.maxBCDiffToMaskBias=10;" | \
```

@catalinristea , this is then to be used for all coming data. Since we discussed to have a general folder for the future, I did the commit in the 22f folder.