### PR TITLE
MFT: Add cluster patterns to MC json.

### DIFF
--- a/MC/config/QC/json/qc-mft-cluster.json
+++ b/MC/config/QC/json/qc-mft-cluster.json
@@ -36,7 +36,7 @@
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",
-          "query": "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0;patterns:MFT/PATTERNS/0",
+          "query": "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0;patterns:MFT/PATTERNS/0"
         },
         "taskParameters": {
           "myOwnKey": "myOwnValue"

--- a/MC/config/QC/json/qc-mft-cluster.json
+++ b/MC/config/QC/json/qc-mft-cluster.json
@@ -36,7 +36,7 @@
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",
-          "query": "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0"
+          "query": "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0;patterns:MFT/PATTERNS/0",
         },
         "taskParameters": {
           "myOwnKey": "myOwnValue"
@@ -50,12 +50,12 @@
         "dataSource": [{
           "type": "Task",
           "name": "QcMFTClusterTask",
-          "MOs": ["mMFTClusterSensorIndex"]
+          "MOs" : ["mClusterOccupancy","mClusterPatternIndex","mClusterSizeSummary","mGroupedClusterSizeSummary","mClusterOccupancySummary"]
         }],
         "className": "o2::quality_control_modules::mft::QcMFTClusterCheck",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
-        "policy": "OnAny"
+        "policy": "OnEachSeparately"
       }
     }    
   },


### PR DESCRIPTION
Fix issue with MC nightly productions crashing due to the MFT clusters patterns query missing in the json file. 