### PR TITLE
enabling TPC-ITS AfterBurner

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -93,6 +93,10 @@ export CONFIG_EXTRA_PROCESS_o2_secondary_vertexing_workflow="$SVTX"
 # ad-hoc settings for its-tpc matching
 export ITSTPCMATCH="tpcitsMatch.maxVDriftUncertainty=0.2;tpcitsMatch.safeMarginTimeCorrErr=10.;tpcitsMatch.cutMatchingChi2=1000;tpcitsMatch.crudeAbsDiffCut[0]=5;tpcitsMatch.crudeAbsDiffCut[1]=5;tpcitsMatch.crudeAbsDiffCut[2]=0.3;tpcitsMatch.crudeAbsDiffCut[3]=0.3;tpcitsMatch.crudeAbsDiffCut[4]=10;tpcitsMatch.crudeNSigma2Cut[0]=200;tpcitsMatch.crudeNSigma2Cut[1]=200;tpcitsMatch.crudeNSigma2Cut[2]=200;tpcitsMatch.crudeNSigma2Cut[3]=200;tpcitsMatch.crudeNSigma2Cut[4]=900;"
 export CONFIG_EXTRA_PROCESS_o2_tpcits_match_workflow="TPCGasParam.DriftV=$VDRIFT;$ITSEXTRAERR;$ITSTPCMATCH"
+# enabling AfterBurner
+if [[ $WORKFLOW_DETECTORS =~ (^|,)"FT0"(,|$) ]] ; then
+  export ARGS_EXTRA_PROCESS_o2_tpcits_match_workflow="--use-ft0"
+fi
 
 # ad-hoc settings for TOF matching
 export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="--output-type matching-info,calib-info --enable-dia"


### PR DESCRIPTION
In async reco, this will produce:

```
o2-tpcits-match-workflow --session default_1781296_1476 --severity info --shm-segment-id 0 --shm-segment-size 16000000000  --resources-monitoring 50 --resources-monitoring-dump-interval 50 --early-forward-policy noraw --fairmq-rate
-logging 0 --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 --disable-root-input  --disable-mc  --pipeline itstpc-track-matcher:1 **--use-ft0** --configKeyValues "NameConf.mDirGeom=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;
NameConf.mDirMatLUT=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirCollContext=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;NameConf.mDirGRP=/home/zampolli/work/O2/PilotBeamMay22/LHC22f;keyval.input_dir=/home/zampolli/wo
rk/O2/PilotBeamMay22/LHC22f;keyval.output_dir=/dev/null;;TPCGasParam.DriftV=2.6616;ITSCATrackerParam.sysErrY2[0]=9e-4;ITSCATrackerParam.sysErrZ2[0]=9e-4;ITSCATrackerParam.sysErrY2[1]=9e-4;ITSCATrackerParam.sysErrZ2[1]=9e-4;ITSCATra
ckerParam.sysErrY2[2]=9e-4;ITSCATrackerParam.sysErrZ2[2]=9e-4;ITSCATrackerParam.sysErrY2[3]=1e-2;ITSCATrackerParam.sysErrZ2[3]=1e-2;ITSCATrackerParam.sysErrY2[4]=1e-2;ITSCATrackerParam.sysErrZ2[4]=1e-2;ITSCATrackerParam.sysErrY2[5]
=1e-2;ITSCATrackerParam.sysErrZ2[5]=1e-2;ITSCATrackerParam.sysErrY2[6]=1e-2;ITSCATrackerParam.sysErrZ2[6]=1e-2;;tpcitsMatch.maxVDriftUncertainty=0.2;tpcitsMatch.safeMarginTimeCorrErr=10.;tpcitsMatch.cutMatchingChi2=1000;tpcitsMatch
.crudeAbsDiffCut[0]=5;tpcitsMatch.crudeAbsDiffCut[1]=5;tpcitsMatch.crudeAbsDiffCut[2]=0.3;tpcitsMatch.crudeAbsDiffCut[3]=0.3;tpcitsMatch.crudeAbsDiffCut[4]=10;tpcitsMatch.crudeNSigma2Cut[0]=200;tpcitsMatch.crudeNSigma2Cut[1]=200;tp
citsMatch.crudeNSigma2Cut[2]=200;tpcitsMatch.crudeNSigma2Cut[3]=200;tpcitsMatch.crudeNSigma2Cut[4]=900;;" | \
```
in bold what @fmazzasc requested. 
@davidrohr , a comment. As you will see, I replicated the "has_detector" function, which is in setenv.sh. Unfortunately, I cannot source setenv.sh before setenv_extra.sh, this will produce an error:
```
EXTINPUT must not be set!
```
One option would be to move all these functions (`has_detector`, `has_detector_reco`...) to yet another script, just for functions. What do you think?
In addition, since the list of reco detectors is not yet available at this point, I did not call the `has_detector_reco` with FT0. I would expect that checking that it is in the WORFLOW_DETECTORS is enough, what do you think? Otherwise we could change dpl_workflow.sh and include the `--use-ft0` only when we are in async reco.

Pinging @catalinristea , since if merged this needs to become the default for the apass of the current data - if I understood well. 
Timewise it should not be an issue, on the grid it takes ~1h40min for a subjob. 

Pinging also @mpuccio , for information.
