### PR TITLE
Introduce retry_count as a task property

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -760,6 +760,7 @@ for tf in range(1, NTIMEFRAMES + 1):
        tpcclussect['cmd'] = '${O2_ROOT}/bin/o2-tpc-chunkeddigit-merger --tpc-sectors ' + str(s)+'-'+str(s+sectorpertask-1) + ' --tpc-lanes ' + str(NWORKERS)
        tpcclussect['cmd'] += ' | ${O2_ROOT}/bin/o2-tpc-reco-workflow ' + getDPL_global_options(bigshm=True) + ' --input-type digitizer --output-type clusters,send-clusters-per-sector --outfile tpc-native-clusters-part' + str((int)(s/sectorpertask)) + '.root --tpc-sectors ' + str(s)+'-'+str(s+sectorpertask-1) + ' ' + putConfigValuesNew(["GPU_global"], {"GPU_proc.ompThreads" : 4})
        tpcclussect['env'] = { "OMP_NUM_THREADS" : "4", "SHMSIZE" : "16000000000" }
+       tpcclussect['retry_count'] = 2  # the task has a race condition --> makes sense to retry
        workflow['stages'].append(tpcclussect)
 
      TPCCLUSMERGEtask=createTask(name='tpcclustermerge_'+str(tf), needs=tpcclustertasks, tf=tf, cwd=timeframeworkdir, lab=["RECO"], cpu='1', mem='10000')


### PR DESCRIPTION
Can now specify in the workflow json which tasks
merit a "retry". This is useful for tasks that suffer
from random (e.g., race condition) failures. Retrying such
tasks might save compute resources, which would otherwise
be lost when leading to a complete exit of the workflow.

The feature complements the global option "--retry-on-failure"
in the workflow runner.

For the moment using the feature for TPC clusterization
until https://alice.its.cern.ch/jira/browse/O2-3069 is fixed.