### PR TITLE
FIT: hotfix for QC async json configs

### DIFF
--- a/DATA/production/qc-async/fdd.json
+++ b/DATA/production/qc-async/fdd.json
@@ -25,7 +25,7 @@
       "tasks": {
         "RecPointsQcTask": {
           "active": "true",
-          "className": "o2::quality_control_modules::fdd::RecPointsQcTask",
+          "className": "o2::quality_control_modules::fdd::RecPointsQcTaskFDD",
           "moduleName": "QcFDD",
           "detectorName": "FDD",
           "cycleDurationSeconds": "600",

--- a/DATA/production/qc-async/ft0.json
+++ b/DATA/production/qc-async/ft0.json
@@ -23,7 +23,7 @@
         }
       },
       "tasks": {
-        "RecPointsQcTask": {
+        "RecPointsQcTaskFT0": {
           "active": "true",
           "className": "o2::quality_control_modules::ft0::RecPointsQcTask",
           "moduleName": "QcFT0",


### PR DESCRIPTION
FDD and FT0 had the same task name. Fixed.