### PR TITLE
MCH QC : only activate MCH-MID track QC if MID is there

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -178,6 +178,11 @@ has_pid_qc()
     return 0
 }
 
+has_track_source() 
+{
+  [[ $TRACK_SOURCES =~ (^|,)"$1"(,|$) ]]
+} 
+
 has_tof_matching_source()
 {
   [[ $TOF_SOURCES =~ (^|,)"$1"(,|$) ]]

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -36,7 +36,11 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_EMC" ]] && QC_JSON_EMC=consul://o2/components/qc/ANY/any/emc-qcmn-epnall
     if [[ -z "$QC_JSON_MCH" ]]; then
       if has_detector MCH && has_processing_step MCH_RECO; then
-        QC_JSON_MCH=consul://o2/components/qc/ANY/any/mch-qcmn-epn-full
+        if has_track_source "MCH-MID"; then
+          QC_JSON_MCH=consul://o2/components/qc/ANY/any/mch-qcmn-epn-full-track-matching
+        else
+          QC_JSON_MCH=consul://o2/components/qc/ANY/any/mch-qcmn-epn-full
+        fi
       else
         QC_JSON_MCH=consul://o2/components/qc/ANY/any/mch-qcmn-epn-digits
       fi


### PR DESCRIPTION
@aferrero2707 this will avoid crashing the MCH track QC when MID is not in the run. 

Tested at Pt2 (e.g. run 524404) with `mch-laurent-cosmics` ECS configuration (based on COSMIC one)