### PR TITLE
to set the possibility to use one node for TPC IDCs

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -44,7 +44,14 @@ if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
     if ( has_detectors ITS TPC && has_detector_matching ITSTPC ); then
       if [[ -z ${CALIB_TPC_VDRIFTTGL+x} ]]; then CALIB_TPC_VDRIFTTGL=1; fi
     fi
-    if [[ -z ${CALIB_TPC_IDC+x} ]]; then CALIB_TPC_IDC=0; fi # default is off
+    # IDCs
+    if [[ -z ${CALIB_TPC_IDC+x} ]]; then
+      CALIB_TPC_IDC=0; # default is off
+    else
+      if [[ -z {$CALIB_TPC_IDC_BOTH+x} ]]; then
+	CALIB_TPC_IDC_BOTH=0;
+      fi # by default, A and C side are processed separately
+    fi
   fi
 
   # calibrations for TRD
@@ -104,13 +111,20 @@ if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_TPC_TIMEGAIN = $CALIB_TPC_TIMEGAIN" 1>&2
   echo "CALIB_TPC_RESPADGAIN = $CALIB_TPC_RESPADGAIN" 1>&2
   echo "CALIB_TPC_IDC = $CALIB_TPC_IDC" 1>&2
+  if [[ $CALIB_TPC_IDC == 1 ]]; then
+    if [[ ! -z $CALIB_TPC_IDC_BOTH == 1 ]]; then
+      echo "CALIB_TPC_IDC_BOTH = $CALIB_TPC_IDC_BOTH" 1>&2
+    else
+      echo "CALIB_TPC_IDC_BOTH not set, A and C side will be run separately"
+    fi
+  fi
   echo "CALIB_CPV_GAIN = $CALIB_CPV_GAIN" 1>&2
 fi
 
 # define spec for proxy for TF-based outputs from BARREL
 if [[ -z $CALIBDATASPEC_BARREL_TF ]]; then
   # prim vtx
-  if [[ $CALIB_PRIMVTX_MEANVTX == 1 ]] ; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "pvtx:GLO/PVTX/0"; fi
+  if [[ $CALIB_PRIMVTX_MEANVTX == 1 ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "pvtx:GLO/PVTX/0"; fi
 
   # TOF
   if [[ $CALIB_TOF_LHCPHASE == 1 ]] || [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "calibTOF:TOF/CALIBDATA/0"; fi

--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -15,37 +15,52 @@ SOURCE_GUARD_SETENV_CALIB=1
 # Remove this line to only send unbinned residuals
 if [[ -z "$CALIB_TPC_SCDCALIB_SENDTRKDATA" ]];  then export CALIB_TPC_SCDCALIB_SENDTRKDATA=1; fi
 
+# define the conditions for each calibration
+if has_detector_calib ITS && has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]]; then CAN_DO_CALIB_PRIMVTX_MEANVTX=1; else CAN_DO_CALIB_PRIMVTX_MEANVTX=0; fi
+if has_detector_calib TOF && has_detector_reco TOF; then CAN_DO_CALIB_TOF_DIAGNOSTICS=1; else CAN_DO_CALIB_TOF_DIAGNOSTICS=0; fi
+if has_detector_calib TOF && has_detector_reco TOF && (( has_detectors_reco ITS TPC && has_detector_matching ITSTPCTOF ) || ( has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRDTOF )); then CAN_DO_CALIB_TOF_LHCPHASE=1; CAN_DO_CALIB_TOF_CHANNELOFFSETS=1; else CAN_DO_CALIB_TOF_LHCPHASE=0; CAN_DO_CALIB_TOF_CHANNELOFFSETS=0; fi
+if has_detector_calib TPC && has_detectors ITS TPC TOF TRD && has_detector_matching ITSTPCTRDTOF; then CAN_DO_CALIB_TPC_SCDCALIB=1; else CAN_DO_CALIB_TPC_SCDCALIB=0; fi
+if has_detector_calib TPC && has_processing_step TPC_DEDX; then CAN_DO_CALIB_TPC_TIMEGAIN=1; CAN_DO_CALIB_TPC_RESPADGAIN=1; else CAN_DO_CALIB_TPC_TIMEGAIN=0; CAN_DO_CALIB_TPC_RESPADGAIN=0; fi
+if has_detector_calib TPC && has_detectors ITS TPC && has_detector_matching ITSTPC; then CAN_DO_CALIB_TPC_VDRIFTTGL=1; else CAN_DO_CALIB_TPC_VDRIFTTGL=0; fi
+if has_detector_calib TPC; then CAN_DO_CALIB_TPC_IDC=1; else CAN_DO_CALIB_TPC_IDC=0; fi
+if has_detector_calib TRD && has_detectors ITS TPC TRD; then CAN_DO_CALIB_TRD_VDRIFTEXB=1; else CAN_DO_CALIB_TRD_VDRIFTEXB=0; fi
+if has_detector_calib EMC && has_detector_reco EMC; then CAN_DO_CALIB_EMC_BADCHANNELCALIB=1; CAN_DO_CALIB_EMC_TIMECALIB=1; else CAN_DO_CALIB_EMC_BADCHANNELCALIB=0; CAN_DO_CALIB_EMC_TIMECALIB=0; fi
+if has_detector_calib PHS && has_detector_reco PHS; then CAN_DO_CALIB_PHS_ENERGYCALIB=1; CAN_DO_CALIB_PHS_BADMAPCALIB=1; CAN_DO_CALIB_PHS_TURNONCALIB=1; CAN_DO_CALIB_PHS_RUNBYRUNCALIB=1; else CAN_DO_CALIB_PHS_ENERGYCALIB=0; CAN_DO_CALIB_PHS_BADMAPCALIB=0; CAN_DO_CALIB_PHS_TURNONCALIB=0; CAN_DO_CALIB_PHS_RUNBYRUNCALIB=0; fi
+if has_detector_calib CPV && has_detector_reco CPV; then CAN_DO_CALIB_CPV_GAIN=1; else CAN_DO_CALIB_CPV_GAIN=0; fi
+
 if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
   # calibrations for primary vertex
-  if has_detector_calib ITS && has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]]; then
+  if [[ $CAN_DO_PRIMVTX_MEANVTX == 1 ]]; then
     if [[ -z ${CALIB_PRIMVTX_MEANVTX+x} ]]; then CALIB_PRIMVTX_MEANVTX=1; fi
   fi
 
   # calibrations for TOF
-  if has_detector_calib TOF && has_detector_reco TOF; then
-    if ( has_detectors_reco ITS TPC && has_detector_matching ITSTPCTOF ) || ( has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRDTOF ); then
-      if [[ -z ${CALIB_TOF_LHCPHASE+x} ]]; then CALIB_TOF_LHCPHASE=1; fi
-      if [[ -z ${CALIB_TOF_CHANNELOFFSETS+x} ]]; then CALIB_TOF_CHANNELOFFSETS=1; fi
-    fi
+  if [[ $CAN_DO_CALIB_TOF_DIAGNOSTICS == 1 ]]; then
     if [[ -z ${CALIB_TOF_DIAGNOSTICS+x} ]]; then CALIB_TOF_DIAGNOSTICS=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_TOF_LHCPHASE == 1 ]]; then
+    if [[ -z ${CALIB_TOF_LHCPHASE+x} ]]; then CALIB_TOF_LHCPHASE=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
+    if [[ -z ${CALIB_TOF_CHANNELOFFSETS+x} ]]; then CALIB_TOF_CHANNELOFFSETS=1; fi
   fi
 
   # calibrations for TPC
-  if has_detector_calib TPC; then
-    if has_detectors ITS TPC TOF TRD; then
-      if has_detectors TPC ITS TRD TOF && has_detector_matching ITSTPCTRDTOF; then
-        if [[ -z ${CALIB_TPC_SCDCALIB+x} ]]; then CALIB_TPC_SCDCALIB=1; fi
-      fi
-    fi
-    if has_processing_step TPC_DEDX; then
-      if [[ -z ${CALIB_TPC_TIMEGAIN+x} ]]; then CALIB_TPC_TIMEGAIN=1; fi
-      if [[ -z ${CALIB_TPC_RESPADGAIN+x} ]]; then CALIB_TPC_RESPADGAIN=1; fi
-    fi
-    if ( has_detectors ITS TPC && has_detector_matching ITSTPC ); then
-      if [[ -z ${CALIB_TPC_VDRIFTTGL+x} ]]; then CALIB_TPC_VDRIFTTGL=1; fi
-    fi
-    # IDCs
-    if [[ -z ${CALIB_TPC_IDC+x} ]]; then
+  if [[ $CAN_DO_CALIB_TPC_SCDCALIB == 1 ]] ; then
+    if [[ -z ${CALIB_TPC_SCDCALIB+x} ]]; then CALIB_TPC_SCDCALIB=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_TPC_TIMEGAIN == 1 ]]; then
+    if [[ -z ${CALIB_TPC_TIMEGAIN+x} ]]; then CALIB_TPC_TIMEGAIN=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_TPC_RESPADGAIN == 1 ]]; then
+    if [[ -z ${CALIB_TPC_RESPADGAIN+x} ]]; then CALIB_TPC_RESPADGAIN=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_TPC_VDRIFTTGL == 1 ]]; then
+    if [[ -z ${CALIB_TPC_VDRIFTTGL+x} ]]; then CALIB_TPC_VDRIFTTGL=1; fi
+  fi
+  # IDCs
+  if [[ $CAN_DO_CALIB_TPC_IDC == 1 ]]; then
+    if [[ -z ${CALIB_TPC_IDC+x} ]] || [[ $CALIB_TPC_IDC == 0 ]]; then
       CALIB_TPC_IDC=0; # default is off
     else
       if [[ -z {$CALIB_TPC_IDC_BOTH+x} ]]; then
@@ -55,46 +70,54 @@ if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
   fi
 
   # calibrations for TRD
-  if has_detector_calib TRD && has_detectors ITS TPC TRD ; then
+  if [[ $CAN_DO_CALIB_TRD_VDRIFTEXB == 1 ]] ; then
     if [[ -z ${CALIB_TRD_VDRIFTEXB+x} ]]; then CALIB_TRD_VDRIFTEXB=1; fi
   fi
 
   # calibrations for EMC
-  if has_detector_calib EMC && has_detector_reco EMC; then
+  if [[ $CAN_DO_CALIB_EMC_BADCHANNELCALIB == 1 ]]; then
     if [[ -z ${CALIB_EMC_BADCHANNELCALIB+x} ]]; then CALIB_EMC_BADCHANNELCALIB=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_EMC_TIMECALIB == 1 ]]; then
     if [[ -z ${CALIB_EMC_TIMECALIB+x} ]]; then CALIB_EMC_TIMECALIB=1; fi
   fi
 
   # calibrations for PHS
-  if has_detector_calib PHS && has_detector_reco PHS; then
+  if [[ $CAN_DO_CALIB_PHS_ENERGYCALIB == 1 ]]; then
     if [[ -z ${CALIB_PHS_ENERGYCALIB+x} ]]; then CALIB_PHS_ENERGYCALIB=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_PHS_BADMAPCALIB == 1 ]]; then
     if [[ -z ${CALIB_PHS_BADMAPCALIB+x} ]]; then CALIB_PHS_BADMAPCALIB=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_PHS_TURNONCALIB == 1 ]]; then
     if [[ -z ${CALIB_PHS_TURNONCALIB+x} ]]; then CALIB_PHS_TURNONCALIB=1; fi
+  fi
+  if [[ $CAN_DO_CALIB_PHS_RUNBYRUNCALIB == 1 ]]; then
     if [[ -z ${CALIB_PHS_RUNBYRUNCALIB+x} ]]; then CALIB_PHS_RUNBYRUNCALIB=1; fi
   fi
 
   # calibrations for CPV
-  if has_detector_calib CPV && has_detector_reco CPV; then
+  if [[ $CAN_DO_CALIB_CPV_GAIN == 1 ]]; then
     if [[ -z ${CALIB_CPV_GAIN+x} ]]; then CALIB_CPV_GAIN=1; fi
   fi
 fi
 
-[[ -z ${CALIB_PRIMVTX_MEANVTX} ]] && CALIB_PRIMVTX_MEANVTX=0
-[[ -z ${CALIB_TOF_LHCPHASE} ]] && CALIB_TOF_LHCPHASE=0
-[[ -z ${CALIB_TOF_CHANNELOFFSETS} ]] && CALIB_TOF_CHANNELOFFSETS=0
-[[ -z ${CALIB_TOF_DIAGNOSTICS} ]] && CALIB_TOF_DIAGNOSTICS=0
-[[ -z ${CALIB_TPC_SCDCALIB} ]] && CALIB_TPC_SCDCALIB=0
-[[ -z ${CALIB_TPC_TIMEGAIN} ]] && CALIB_TPC_TIMEGAIN=0
-[[ -z ${CALIB_TPC_RESPADGAIN} ]] && CALIB_TPC_RESPADGAIN=0
-( [[ -z ${CALIB_TPC_IDC} ]] || ! has_detector TPC ) && CALIB_TPC_IDC=0
-[[ -z ${CALIB_TRD_VDRIFTEXB} ]] && CALIB_TRD_VDRIFTEXB=0
-[[ -z ${CALIB_EMC_BADCHANNELCALIB} ]] && CALIB_EMC_BADCHANNELCALIB=0
-[[ -z ${CALIB_EMC_TIMECALIB} ]] && CALIB_EMC_TIMECALIB=0
-[[ -z ${CALIB_PHS_ENERGYCALIB} ]] && CALIB_PHS_ENERGYCALIB=0
-[[ -z ${CALIB_PHS_BADMAPCALIB} ]] && CALIB_PHS_BADMAPCALIB=0
-[[ -z ${CALIB_PHS_TURNONCALIB} ]] && CALIB_PHS_TURNONCALIB=0
-[[ -z ${CALIB_PHS_RUNBYRUNCALIB} ]] && CALIB_PHS_RUNBYRUNCALIB=0
-[[ -z ${CALIB_CPV_GAIN} ]] && CALIB_CPV_GAIN=0
+( [[ -z ${CALIB_PRIMVTX_MEANVTX} ]] || [[ $CAN_DO_CALIB_PRIMVTX_MEANVTX == 0 ]] ) && CALIB_PRIMVTX_MEANVTX=0
+( [[ -z ${CALIB_TOF_LHCPHASE} ]] || [[ $CAN_DO_CALIB_TOF_LHCPHASE == 0 ]] ) && CALIB_TOF_LHCPHASE=0
+( [[ -z ${CALIB_TOF_CHANNELOFFSETS} ]] || [[ $CAN_DO_CALIB_TOF_CHANNELOFFSETS == 0 ]] ) && CALIB_TOF_CHANNELOFFSETS=0
+( [[ -z ${CALIB_TOF_DIAGNOSTICS} ]] || [[ $CAN_DO_CALIB_TOF_DIAGNOSTICS == 0 ]] ) && CALIB_TOF_DIAGNOSTICS=0
+( [[ -z ${CALIB_TPC_SCDCALIB} ]] || [[ $CAN_DO_CALIB_TPC_SCDCALIB == 0 ]] ) && CALIB_TPC_SCDCALIB=0
+( [[ -z ${CALIB_TPC_TIMEGAIN} ]] || [[ $CAN_DO_CALIB_TPC_TIMEGAIN == 0 ]] ) && CALIB_TPC_TIMEGAIN=0
+( [[ -z ${CALIB_TPC_RESPADGAIN} ]] || [[ $CAN_DO_CALIB_TPC_RESPADGAIN == 0 ]] ) && CALIB_TPC_RESPADGAIN=0
+( [[ -z ${CALIB_TPC_IDC} ]] || [[ $CAN_DO_CALIB_TPC_IDC == 0 ]] ) && CALIB_TPC_IDC=0
+( [[ -z ${CALIB_TRD_VDRIFTEXB} ]] || [[ $CAN_DO_CALIB_TRD_VDRIFTEXB == 0 ]] ) && CALIB_TRD_VDRIFTEXB=0
+( [[ -z ${CALIB_EMC_BADCHANNELCALIB} ]] || [[ $CAN_DO_CALIB_EMC_BADCHANNELCALIB == 0 ]] ) && CALIB_EMC_BADCHANNELCALIB=0
+( [[ -z ${CALIB_EMC_TIMECALIB} ]] || [[ $CAN_DO_CALIB_EMC_TIMECALIB == 0 ]] ) && CALIB_EMC_TIMECALIB=0
+( [[ -z ${CALIB_PHS_ENERGYCALIB} ]] || [[ $CAN_DO_CALIB_PHS_ENERGYCALIB == 0 ]] ) && CALIB_PHS_ENERGYCALIB=0
+( [[ -z ${CALIB_PHS_BADMAPCALIB} ]] || [[ $CAN_DO_ == 0 ]] ) && CALIB_PHS_BADMAPCALIB=0
+( [[ -z ${CALIB_PHS_TURNONCALIB} ]] || [[ $CAN_DO_CALIB_PHS_BADMAPCALIB == 0 ]] ) && CALIB_PHS_TURNONCALIB=0
+( [[ -z ${CALIB_PHS_RUNBYRUNCALIB} ]] || [[ $CAN_DO_CALIB_PHS_RUNBYRUNCALIB == 0 ]] ) && CALIB_PHS_RUNBYRUNCALIB=0
+( [[ -z ${CALIB_CPV_GAIN} ]] || [[ $CAN_DO_CALIB_CPV_GAIN == 0 ]] ) && CALIB_CPV_GAIN=0
 
 if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_PRIMVTX_MEANVTX = $CALIB_PRIMVTX_MEANVTX" 1>&2
@@ -112,10 +135,10 @@ if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_TPC_RESPADGAIN = $CALIB_TPC_RESPADGAIN" 1>&2
   echo "CALIB_TPC_IDC = $CALIB_TPC_IDC" 1>&2
   if [[ $CALIB_TPC_IDC == 1 ]]; then
-    if [[ ! -z $CALIB_TPC_IDC_BOTH == 1 ]]; then
+    if [[ $CALIB_TPC_IDC_BOTH == 1 ]]; then
       echo "CALIB_TPC_IDC_BOTH = $CALIB_TPC_IDC_BOTH" 1>&2
     else
-      echo "CALIB_TPC_IDC_BOTH not set, A and C side will be run separately"
+      echo "CALIB_TPC_IDC: A and C side will be run separately" 1>&2
     fi
   fi
   echo "CALIB_CPV_GAIN = $CALIB_CPV_GAIN" 1>&2


### PR DESCRIPTION
@davidrohr : this is just to set if we run the IDCs on both sides together or not from the setenv_calib. I put it here to be consistent with the rest: each calibration is on or off in this script. 