### PR TITLE
Move heavy lifting to macro, small fix

### DIFF
--- a/RelVal/README.md
+++ b/RelVal/README.md
@@ -41,7 +41,7 @@ The wrapper includes 3 different sub-commands for now
 
 If you would like to compare 2 files, simply run
 ```bash
-python o2dpg_release_validation.py rel-val -i <file1> <file2> [-o <output/dir>]
+python o2dpg_release_validation.py rel-val -i <list-of-first-files> -j <list-of-second-files> [-o <output/dir>]
 ```
 This performs all of the above mentioned tests. If only certain tests should be performed, this can be achieved with the flags `--with-test-<which-test>` where `<which-test>` is one of
 1. `chi2`,
@@ -52,28 +52,18 @@ By default, all of them are switched on.
 
 ### Apply to entire simulation outcome
 
-In addition to simply comparing 2 ROOT files, the script offers the possibility of comparing 2 corresponding directories that contain simulation artifacts (and potentially QC and analysis results). This then automatically runs the RelVal on
-1. QC output,
-1. analysis results output,
-1. TPC tracks output,
-1. MC kinematics,
-1. MC hits.
+In addition to simply comparing 2 ROOT files, the script offers the possibility of comparing 2 corresponding directories that contain simulation artifacts (and potentially QC and analysis results). It is not foreseen to run over everything inside those directories but the files must be specifiec via a small config file. See [this example](config/rel_val_sim_dirs_default.json). It is passed via the option `--dirs-config`. In addition, top-level keys can be enabled(disabled) with `--dirs-config-enable <keys>`(`dirs-config-disable <keys>`) where disabling takes precedence.
 
-**NOTE** That each single one of the comparison types if only done if mutual files were found in the 2 corresponding directories. As an example, one could do
+**NOTE** That each single one of the comparisons is only done if mutual files were found in the 2 corresponding directories. As an example, one could do
 ```bash
 cd ${DIR1}
 python o2dpg_workflow_runner.py -f <workflow-json1>
 cd ${DIR2}
 # potentially something has changed in the software or the simulation/reconstruction parameters
 python o2dpg_workflow_runner.py -f <workflow-json2>
-python ${O2DPG_ROOT}/ReleaseValidation/o2dpg_release_validation.py rel-val -i ${DIR1} ${DIR2} [-o <output/dir>] [<test-flags>]
+python ${O2DPG_ROOT}/ReleaseValidation/o2dpg_release_validation.py rel-val -i ${DIR1} -j ${DIR2} --dirs-config ${O2DPG_ROOT}/RelVal/config/rel_val_sim_dirs_default.json --dirs-config-enable QC [-o <output/dir>] [<test-flags>]
 ```
-Again, also here it can be specified explicitly on what the tests should be run by specifying one or more `<test-flags>` such as
-1. `--with-type-qc`,
-1. `--with-type-analysis`,
-1. `--with-type-tpctracks`,
-1. `--with-type-kine`,
-1. `--with-type-hits`.
+This would run the RelVal von everything specified under the top key `QC`.
 
 ### Quick inspection
 

--- a/RelVal/config/rel_val_sim_dirs_default.json
+++ b/RelVal/config/rel_val_sim_dirs_default.json
@@ -1,0 +1,43 @@
+{
+    "hits": {
+        "ITS": "tf*/*HitsITS.root",
+        "TPC": "tf*/*HitsTPC.root",
+        "TOF": "tf*/*HitsTOF.root",
+        "TRD": "tf*/*HitsTRD.root",
+        "EMC": "tf*/*HitsEMC.root",
+        "PHS": "tf*/*HitsPHS.root",
+        "FT0": "tf*/*HitsFT0.root",
+        "FV0": "tf*/*HitsFV0.root",
+        "HMP": "tf*/*HitsHMP.root",
+        "MFT": "tf*/*HitsMFT.root",
+        "FDD": "tf*/*HitsFDD.root",
+        "MID": "tf*/*HitsMID.root",
+        "MCH": "tf*/*HitsMCH.root",
+        "CPV": "tf*/*HitsCPV.root",
+        "ZDC": "tf*/*HitsZDC.root"
+    },
+    "tpctracks": {
+        "TPCtracks": "tf*/tpctracks.root"
+    },
+    "QC": {
+        "emcCellQC": "QC/emcCellQC.root",
+        "ITSTPCmatchQC": "QC/ITSTPCmatchQC.root",
+        "ITSTrackSimTask": "QC/ITSTrackSimTask.root",
+        "mftAsyncQC": "QC/mftAsyncQC.root",
+        "mftClustersQC": "QC/mftClustersQC.root",
+        "mftDigitsQC": "QC/mftDigitsQC.root",
+        "RecPointsQC": "QC/RecPointsQC.root",
+        "tofDigitsQC": "QC/tofDigitsQC.root",
+        "tofft0PIDQC": "QC/tofft0PIDQC.root",
+        "TOFMatchQC": "QC/TOFMatchQC.root",
+        "TOFMatchWithTRDQC": "QC/TOFMatchWithTRDQC.root",
+        "tofPIDQC": "QC/tofPIDQC.root",
+        "tpcStandardQC": "QC/tpcStandardQC.root",
+        "trdDigitsQC": "QC/trdDigitsQC.root",
+        "vectexQC": "QC/vertexQC.root"
+    },
+    "MCKine": {
+        "MCKine": "tf*/*Kine.root"
+    }
+
+}


### PR DESCRIPTION
* all file exploration, understanding and extraction happens now in
  ReleasveValidation.C instead of having any additional preparation
  steps in the Python script

* ROOT macro takes now 2 lists (comma-separated strings) of input files
  instead of only one file per version. This enables more complex
  comparisons and more generic comparisons in particular for TTrees

* more flexible configuration when comparing 2 directories
  * o2dpg_release_validation.py --dirs-config <config.json>
    ==> see RelVal/config/rel_val_sim_dirs_default.json
  * use --dirs-config-enable(--dirs-config-disable) <topKeys> to
    enable(disable) specific top keys to be taken into account for
    validation

* fix when passing 2 files to python wrapper