### PR TITLE
disentangle jsons for flp and epn to avoid conflict in TOF matching QC

### DIFF
--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -25,9 +25,9 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     fi
     if [[ -z "$QC_JSON_TOF" ]]; then
       if has_detector_flp_processing TOF; then
-        QC_JSON_TOF=consul://o2/components/qc/ANY/any/tof-full-qcmn
+        QC_JSON_TOF=consul://o2/components/qc/ANY/any/tof-full-qcmn-on-epn
       else
-        QC_JSON_TOF=consul://o2/components/qc/ANY/any/tof-full-epn-qcmn
+        QC_JSON_TOF=consul://o2/components/qc/ANY/any/tof-full-epn-qcmn-on-epn
       fi
     fi
     [[ -z "$QC_JSON_FDD" ]] && QC_JSON_FDD=consul://o2/components/qc/ANY/any/fdd-digits-qc-epn


### PR DESCRIPTION
This is to disentangle the jsons for flp and epn loaded from consul otherwise we didn't find any way to avoid conflicts (epn needs the possibility to adjust TOF matching QC setting independently of FLPs: with TRD w/o TRD)

At the moment we just cloned flp json (already done) so the situation is not yet changed wrt before (we just disentagled the two jsons).
Once this PR is available in EPNs we can run a test with synthetic runs.

@njacazio @ercolessi 
