### PR TITLE
Removed AnalysisQC merged task

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -197,7 +197,7 @@ if [[ -f "AO2D.root" ]]; then
 	exit $exitcode
     fi
     if [[ $ALIEN_JDL_RUNANALYSISQC == 1 ]]; then 
-      ${O2DPG_ROOT}/MC/analysis_testing/o2dpg_analysis_test_workflow.py --merged-task -f AO2D.root
+      ${O2DPG_ROOT}/MC/analysis_testing/o2dpg_analysis_test_workflow.py -f AO2D.root
       ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow_analysis_test.json > analysisQC.log
       if [[ -f "Analysis/MergedAnalyses/AnalysisResults.root" ]]; then
 	mv Analysis/MergedAnalyses/AnalysisResults.root .


### PR DESCRIPTION
Hi @chiarazampolli,

Merged task of AnalysisQC was removed while ago from O2DPG, thus we need to remove it from production script.
Thanks!

Yours,
Catalin.