### PR TITLE
GEN_TOPO_IGNORE_ERROR does not exist anymore

### DIFF
--- a/DATA/README.md
+++ b/DATA/README.md
@@ -119,7 +119,6 @@ DDWORKFLOW=tools/datadistribution_workflows/dd-processing.xml WORKFLOW_DETECTORS
   - `$RECO_NUM_NODES_OVERRIDE`: Overrides the number of nodes used for reconstruction (empty or 0 to disable)
   - `$DDMODE`: How to operate DataDistribution: **discard** (build TF and discard them), **disk** (build TF and store to disk), **processing** (build TF and run DPL workflow on TF data), **processing-disk** (both store TF to disk and run processing).
   - `$DDWORKFLOW`: (*alternative*): Explicit path to the XML file with the partial workflow for *DataDistribution*.
-  - `$GEN_TOPO_IGNORE_ERROR`: Ignore ERROR messages during workflow creation.
   - `$WORKFLOWMODE`: Can be set to print. In that case the parser will not create the DDS topology output, but the list of shell commands to start to run the workflows locally.
 - When run on the EPN farm for synchronous processing (indicated by the `$EPNSYNCMODE=1` variable), the *parser* will automaticall `module load` the modules specified in the *topology description*. Otherwise the user must load the respective O2 / QC version by himself.
 - The parser exports the env variable `$RECO_NUM_NODES_WORKFLOW` that contains on how many nodes the workflow will be running when running the workflow script. This can be used to tune the process multiplicities.
@@ -164,8 +163,6 @@ FILEWORKDIR=/home/epn/odc/files EPNSYNCMODE=1 DDWORKFLOW=tools/datadistribution_
 - Put the output file (default is `$HOME/gen_topo_output.xml`) as EPN DDS topology in the AliECS GUI.
 
 When adapting your workflow, please try to follow the style of the existing workflows. The [testing/examples/example-workflow.sh](testing/examples/example-workflow.sh) should be a simple start, for a more complex example you can have a look at [testing/detectors/TPC/tpc-workflow.sh](testing/detectors/TPC/tpc-workflow.sh), and as a fulll complex example of a global workflow please look at [production/full-system-test/dpl-workflow_local.sh](production/full-system-test/dpl-workflow_local.sh)
-
-**Please note that currently when creating a workflow that contains QC, ERROR messages will be written to the console. The workflow creation scripts sees these error messages and then fails. These failures can be ignored using the `GEN_TOPO_IGNORE_ERROR=1` env variable, which is thus temporarily mandatory for all workflows containing QC.**
 
 For reference, the `run.sh` script internally uses the `parser` to create the XML file, it essentially sets some environment variables and then calls the *parser*  with all options set. So in principle, you can also use the *parser* directly to create the workflow as described [here](Creating-a-full-topology-DDS-XML-file-manually).
 

--- a/DATA/testing/detectors/FDD/run_fdd_ctf.sh
+++ b/DATA/testing/detectors/FDD/run_fdd_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FDD/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fdd-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FDD                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FDD/run_fdd_digits_ctf.sh
+++ b/DATA/testing/detectors/FDD/run_fdd_digits_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FDD/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fdd-digits-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FDD                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FDD/run_fdd_digits_qc_ctf.sh
+++ b/DATA/testing/detectors/FDD/run_fdd_digits_qc_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FDD/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fdd-digits-qc-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FDD                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FT0/run_ft0_ctf.sh
+++ b/DATA/testing/detectors/FT0/run_ft0_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FT0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=ft0-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FT0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FT0/run_ft0_digits_ctf.sh
+++ b/DATA/testing/detectors/FT0/run_ft0_digits_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FT0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=ft0-digits-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FT0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FT0/run_ft0_digits_qc_ctf.sh
+++ b/DATA/testing/detectors/FT0/run_ft0_digits_qc_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FT0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=ft0-digits-qc-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FT0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FV0/run_fv0_ctf.sh
+++ b/DATA/testing/detectors/FV0/run_fv0_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FV0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fv0-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FV0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FV0/run_fv0_digits_ctf.sh
+++ b/DATA/testing/detectors/FV0/run_fv0_digits_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FV0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fv0-digits-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FV0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/detectors/FV0/run_fv0_digits_qc_ctf.sh
+++ b/DATA/testing/detectors/FV0/run_fv0_digits_qc_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/detectors/FV0/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fv0-digits-qc-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FV0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/private/afurs/run_fdd_ft0_fv0_ctf.sh
+++ b/DATA/testing/private/afurs/run_fdd_ft0_fv0_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/private/afurs/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fdd-ft0-fv0-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FDD,FT0,FV0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/private/afurs/run_fdd_ft0_fv0_digits_qc_ctf.sh
+++ b/DATA/testing/private/afurs/run_fdd_ft0_fv0_digits_qc_ctf.sh
@@ -9,7 +9,6 @@ export GEN_TOPO_SOURCE=v1.3                                         # Git hash t
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing            # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/private/afurs/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=fdd-ft0-fv0-digits-qc-ctf                     # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FDD,FT0,FV0                                      # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/private/afurs/run_ft0_fv0_ctf.sh
+++ b/DATA/testing/private/afurs/run_ft0_fv0_ctf.sh
@@ -10,7 +10,6 @@ export DDMODE=processing-disk                                             # Data
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing                  # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/private/afurs/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=ft0-fv0-ctf                # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FT0,FV0                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/private/afurs/run_ft0_fv0_digits_qc_ctf.sh
+++ b/DATA/testing/private/afurs/run_ft0_fv0_digits_qc_ctf.sh
@@ -9,7 +9,6 @@ export GEN_TOPO_SOURCE=v1.3                                         # Git hash t
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/afurs/O2DataProcessing            # Path to O2DataProcessing repository
-export GEN_TOPO_IGNORE_ERROR=1
 export GEN_TOPO_LIBRARY_FILE=testing/private/afurs/workflows.desc    # Topology description library file to load
 export GEN_TOPO_WORKFLOW_NAME=ft0-fv0-digits-qc-ctf                     # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=FT0,FV0                                      # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)

--- a/DATA/testing/private/shahoian/runTF_PB.sh
+++ b/DATA/testing/private/shahoian/runTF_PB.sh
@@ -29,7 +29,6 @@ export RECO_NUM_NODES_OVERRIDE=0                                     # Override 
 export NHBPERTF=128                                                  # Number of HBF per TF
 export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export MULTIPLICITY_FACTOR_RAWDECODERS=1
 export MULTIPLICITY_FACTOR_CTFENCODERS=1

--- a/DATA/testing/private/shahoian/runTF_ext_dpl.sh
+++ b/DATA/testing/private/shahoian/runTF_ext_dpl.sh
@@ -31,7 +31,6 @@ export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 #export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow=""
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="GPU_proc.debugLevel=1;"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export MULTIPLICITY_FACTOR_RAWDECODERS=1
 export MULTIPLICITY_FACTOR_CTFENCODERS=1

--- a/DATA/testing/private/shahoian/run_PB.sh
+++ b/DATA/testing/private/shahoian/run_PB.sh
@@ -29,7 +29,6 @@ export RECO_NUM_NODES_OVERRIDE=0                                     # Override 
 export NHBPERTF=128                                                  # Number of HBF per TF
 export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export MULTIPLICITY_FACTOR_RAWDECODERS=1
 export MULTIPLICITY_FACTOR_CTFENCODERS=1

--- a/DATA/testing/private/shahoian/run_ext.sh
+++ b/DATA/testing/private/shahoian/run_ext.sh
@@ -19,7 +19,6 @@ export WORKFLOW_PARAMETERS=                                          # Additiona
 export RECO_NUM_NODES_OVERRIDE=0                                     # Override the number of EPN compute nodes to use (default is specified in description library file)
 export NHBPERTF=256                                                  # Number of HBF per TF
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 ##---------------
 jq -n 'reduce inputs as $s (input; .qc.tasks += ($s.qc.tasks) | .qc.checks += ($s.qc.checks)  | .qc.externalTasks += ($s.qc.externalTasks) | .qc.postprocessing += ($s.qc.postprocessing)| .dataSamplingPolicies += ($s.dataSamplingPolicies))' /home/epn/odc/files/tpcQCTasks_multinode_ALL.json /home/epn/jliu/itsEPNv2.json > /home/shahoian/alice/O2DataProcessing/testing/private/shahoian/qc/qc-tpcMNAll-itsEPNv2.json

--- a/DATA/testing/private/shahoian/run_ext_dpl.sh
+++ b/DATA/testing/private/shahoian/run_ext_dpl.sh
@@ -31,7 +31,6 @@ export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 #export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow=""
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="GPU_proc.debugLevel=1;"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export MULTIPLICITY_FACTOR_RAWDECODERS=1
 export MULTIPLICITY_FACTOR_CTFENCODERS=1

--- a/DATA/testing/private/shahoian/run_test.sh
+++ b/DATA/testing/private/shahoian/run_test.sh
@@ -32,7 +32,6 @@ export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 #export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow=""
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="GPU_proc.debugLevel=1;"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export CTF_METAFILES_DIR=/data/epn2eos_tool/epn2eos
 

--- a/DATA/testing/private/zampolli/runTF_ext_dpl.sh
+++ b/DATA/testing/private/zampolli/runTF_ext_dpl.sh
@@ -31,7 +31,6 @@ export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 #export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow=""
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="GPU_proc.debugLevel=1;"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
                                                                                                                                                                                                                                                                                                                                                                
 export MULTIPLICITY_FACTOR_RAWDECODERS=1

--- a/DATA/testing/private/zampolli/run_ext_dpl.sh
+++ b/DATA/testing/private/zampolli/run_ext_dpl.sh
@@ -31,7 +31,6 @@ export ALL_EXTRA_CONFIG="HBFUtils.nHBFPerTF=$NHBPERTF"
 #export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow=""
 export CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow="GPU_proc.debugLevel=1;"
 
-export GEN_TOPO_IGNORE_ERROR=1
 
 export MULTIPLICITY_FACTOR_RAWDECODERS=1
 export MULTIPLICITY_FACTOR_CTFENCODERS=1


### PR DESCRIPTION
So don't mention it in the README anymore and remove it from all workflows where it was set