### PR TITLE
[EMCAL-756] Async QC at cell level must use subspec 0

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -32,7 +32,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR"
+          "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0"
         }
       }
     }


### PR DESCRIPTION
Once the recalibrator will be included cells will be
available on 2 supsecifications: 1 - uncalibrated, 0 -
calibrated. Only calibrated cells must be monitored
by the cell-level QC during the asynchronous stage.