### PR TITLE
make NEntries test critical when dealing with TEfficiency

### DIFF
--- a/RelVal/ExtractAndFlatten.C
+++ b/RelVal/ExtractAndFlatten.C
@@ -268,7 +268,7 @@ void WriteTEfficiency(TEfficiency* hEff, TDirectory* outDir, std::string const& 
   // recreate the efficiency dividing numerator for denominator:
   auto heff = (TH1*)(hEffNomin->Clone("heff"));
   heff->SetTitle(Form("%s", hEff->GetTitle()));
-  heff->SetName(Form("%s", hEff->GetName()));
+  heff->SetName(Form("%s_efficiency", hEff->GetName()));
   heff->Divide(hEffNomin, hEffDenom, 1.0, 1.0, "B");
 
   WriteToDirectory(hEffNomin, outDir, currentPrefix);

--- a/RelVal/ExtractAndFlatten.C
+++ b/RelVal/ExtractAndFlatten.C
@@ -262,13 +262,13 @@ void WriteTEfficiency(TEfficiency* hEff, TDirectory* outDir, std::string const& 
   // separate numerator and denominator of the efficiency
   auto hEffNomin = (TH1*)hEff->GetPassedHistogram(); // eff nominator
   auto hEffDenom = (TH1*)hEff->GetTotalHistogram();  // eff denominator
-  hEffNomin->SetName(Form("%s_effnominator", hEffNomin->GetName()));
-  hEffDenom->SetName(Form("%s_effdenominator", hEffDenom->GetName()));
+  hEffNomin->SetName(Form("%s_numeratorFromTEfficiency", hEffNomin->GetName()));
+  hEffDenom->SetName(Form("%s_denominatorFromTEfficiency", hEffDenom->GetName()));
 
   // recreate the efficiency dividing numerator for denominator:
   auto heff = (TH1*)(hEffNomin->Clone("heff"));
   heff->SetTitle(Form("%s", hEff->GetTitle()));
-  heff->SetName(Form("%s_efficiency", hEff->GetName()));
+  heff->SetName(Form("%s_ratioFromTEfficiency", hEff->GetName()));
   heff->Divide(hEffNomin, hEffDenom, 1.0, 1.0, "B");
 
   WriteToDirectory(hEffNomin, outDir, currentPrefix);

--- a/RelVal/ReleaseValidation.C
+++ b/RelVal/ReleaseValidation.C
@@ -782,7 +782,13 @@ TestResult CompareNentr(TH1* hA, TH1* hB, double val, bool areComparable)
   res.threshold = val;
   res.testname = "test_num_entries";
 
-  res.critical = false;
+  if(std::strstr(hA->GetName(),"_efficiency")){ //make NEntries-test critical when dealing with efficiencies
+    res.critical = true;
+  }
+  else{
+    res.critical = false;
+  }
+  
 
   res.passed = false;
   res.comparable = areComparable;

--- a/RelVal/ReleaseValidation.C
+++ b/RelVal/ReleaseValidation.C
@@ -782,7 +782,7 @@ TestResult CompareNentr(TH1* hA, TH1* hB, double val, bool areComparable)
   res.threshold = val;
   res.testname = "test_num_entries";
 
-  if(std::strstr(hA->GetName(),"_efficiency")){ //make NEntries-test critical when dealing with efficiencies
+  if(TString(hA->GetName()).EndsWith("_ratioFromTEfficiency")){ //make NEntries-test critical when dealing with efficiencies
     res.critical = true;
   }
   else{


### PR DESCRIPTION
small changes in ExtractAndFlatten.C and ReleaseValidation.C to detect if dealing with an efficiency plot in the NEntries test and make it critical in that case.