### PR TITLE
remove consul server name in async QC json

### DIFF
--- a/DATA/production/qc-async/itstpctof.json
+++ b/DATA/production/qc-async/itstpctof.json
@@ -16,7 +16,7 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "http://consul-test.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
         "url" : "ccdb-test.cern.ch:8080"

--- a/DATA/production/qc-async/phs.json
+++ b/DATA/production/qc-async/phs.json
@@ -16,7 +16,7 @@
         "url": "influxdb-unix:///tmp/telegraf.sock"
       },
       "consul": {
-        "url": "http://ali-consul.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "http://localhost:8084"

--- a/DATA/production/qc-async/tof.json
+++ b/DATA/production/qc-async/tof.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/DATA/production/qc-async/tpc.json
+++ b/DATA/production/qc-async/tpc.json
@@ -20,7 +20,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"


### PR DESCRIPTION
I cleaned up the consul server name in few qc json for async (others were already without it).
I noted that in local analysis (consul server not reachable) it prevents job to close at the end.
@knopers8 can you confirm it is correct what I did? 
If it is we should check also MC.
Cheers,
Francesco