### PR TITLE
Adding GLO QC for EPN and SYNC mode

### DIFF
--- a/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
+++ b/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
@@ -23,29 +23,6 @@
       }
     },
     "tasks" : {
-      "Vertexing" : {
-        "active" : "true",
-        "className" : "o2::quality_control_modules::glo::VertexingQcTask",
-        "moduleName" : "QcGLO",
-        "detectorName" : "GLO",
-        "cycleDurationSeconds" : "600",
-        "maxNumberCycles" : "-1",
-        "dataSource" : {
-          "type" : "dataSamplingPolicy",
-          "name" : "VtxSampling"
-        },
-	"taskParameters" : {
-          "isMC": "false"
-        },
-        "location" : "local",
-	"localMachines": [
-            "epn",
-	    "localhost"
-        ],
-        "remoteMachine": "alio2-cr1-qc07.cern.ch",
-	"remotePort": "47760",
-	"localControl": "odc"
-      },
       "MTCITSTPC" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::glo::ITSTPCMatchingTask",
@@ -80,20 +57,6 @@
     }
   },
   "dataSamplingPolicies" : [
-    {
-      "id" : "VtxSampling",
-      "active" : "true",
-      "machines" : [],
-      "query" : "pvtx:GLO/PVTX/0",
-      "samplingConditions" : [
-         {
-           "condition" : "random",
-           "fraction" : "0.1",
-           "seed" : "1234"
-          }
-       ],
-         "blocking" : "false"
-    },
     {
       "id" : "ITSTPCmSamp",
       "active" : "true",

--- a/DATA/production/qc-sync/glo-qcmn-epn.json
+++ b/DATA/production/qc-sync/glo-qcmn-epn.json
@@ -1,0 +1,113 @@
+{
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ali-qcdb.cern.ch:8083",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
+      },
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
+      },
+      "monitoring" : {
+        "url" : "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul" : {
+        "url" : "http://ali-consul.cern.ch:8500"
+      },
+      "conditionDB" : {
+        "url" : "http://localhost:8084"
+      }
+    },
+    "tasks" : {
+      "Vertexing" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::glo::VertexingQcTask",
+        "moduleName" : "QcGLO",
+        "detectorName" : "GLO",
+        "cycleDurationSeconds" : "600",
+        "maxNumberCycles" : "-1",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "VtxSampling"
+        },
+	"taskParameters" : {
+          "isMC": "false"
+        },
+        "location" : "local",
+	"localMachines": [
+            "epn",
+	    "localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qc07.cern.ch",
+	"remotePort": "47760",
+	"localControl": "odc"
+      },
+      "MTCITSTPC" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::glo::ITSTPCMatchingTask",
+        "moduleName" : "QcGLO",
+        "detectorName" : "GLO",
+        "cycleDurationSeconds" : "600",
+        "maxNumberCycles" : "-1",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "ITSTPCmSamp"
+        },
+        "taskParameters" : {
+          "GID" : "ITS-TPC,ITS",
+          "verbose" : "false",
+          "minPtCut" : "0.1f",
+          "etaCut" : "1.4f",
+          "minNTPCClustersCut" : "60",
+          "minDCACut" : "100.f",
+          "minDCACutY" : "10.f",
+          "grpFileName" : "o2sim_grp.root",
+          "geomFileName" : "o2sim_geometry-aligned.root"
+        },
+        "location" : "local",
+	  "localMachines": [
+            "epn",
+	    "localhost"
+          ],
+        "remoteMachine": "alio2-cr1-qc07.cern.ch",
+	"remotePort": "47761",
+	"localControl": "odc"
+      }
+    }
+  },
+  "dataSamplingPolicies" : [
+    {
+      "id" : "VtxSampling",
+      "active" : "true",
+      "machines" : [],
+      "query" : "pvtx:GLO/PVTX/0",
+      "samplingConditions" : [
+         {
+           "condition" : "random",
+           "fraction" : "0.1",
+           "seed" : "1234"
+          }
+       ],
+         "blocking" : "false"
+    },
+    {
+      "id" : "ITSTPCmSamp",
+      "active" : "true",
+      "machines" : [],
+      "query_comment" : "checking every 10% matched track",
+      "query" : "trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS",
+      "samplingConditions" : [
+         {
+           "condition" : "random",
+           "fraction" : "0.1",
+           "seed" : "1234"
+          }
+      ],
+      "blocking" : "false"
+    }
+  ]
+}

--- a/DATA/production/qc-sync/glo-vtx-qcmn-epn.json
+++ b/DATA/production/qc-sync/glo-vtx-qcmn-epn.json
@@ -1,0 +1,67 @@
+{
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ali-qcdb.cern.ch:8083",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
+      },
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
+      },
+      "monitoring" : {
+        "url" : "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul" : {
+        "url" : "http://ali-consul.cern.ch:8500"
+      },
+      "conditionDB" : {
+        "url" : "http://localhost:8084"
+      }
+    },
+    "tasks" : {
+      "Vertexing" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::glo::VertexingQcTask",
+        "moduleName" : "QcGLO",
+        "detectorName" : "GLO",
+        "cycleDurationSeconds" : "600",
+        "maxNumberCycles" : "-1",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "VtxSampling"
+        },
+	"taskParameters" : {
+          "isMC": "false"
+        },
+        "location" : "local",
+	"localMachines": [
+            "epn",
+	    "localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qc07.cern.ch",
+	"remotePort": "47760",
+	"localControl": "odc"
+      }
+    }
+  },
+  "dataSamplingPolicies" : [
+    {
+      "id" : "VtxSampling",
+      "active" : "true",
+      "machines" : [],
+      "query" : "pvtx:GLO/PVTX/0",
+      "samplingConditions" : [
+         {
+           "condition" : "random",
+           "fraction" : "0.1",
+           "seed" : "1234"
+          }
+       ],
+         "blocking" : "false"
+    }
+  ]
+}

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -56,7 +56,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=consul://o2/components/qc/ANY/any/cpv-physics-qcmn-epn
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=consul://o2/components/qc/ANY/any/trd-full-qcmn-nopulseheight-epn
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=consul://o2/components/qc/ANY/any/phos-raw-clusters-epn
-    [[ -z "$QC_JSON_GLO" ]] && QC_JSON_GLO=consul://o2/components/qc/ANY/any/glo-qcmn-epn
+    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_GLO=consul://o2/components/qc/ANY/any/glo-vtx-qcmn-epn
+    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_GLO=consul://o2/components/qc/ANY/any/glo-itstpc-mtch-qcmn-epn
     [[ -z "$QC_JSON_GLOBAL" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-sync/qc-global-epn.json
     if [[ -z "$QC_JSON_TOF_MATCH" ]]; then
       if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
@@ -86,7 +87,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=$O2DPG_ROOT/DATA/production/qc-sync/cpv.json
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=$O2DPG_ROOT/DATA/production/qc-sync/phs.json
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=$O2DPG_ROOT/DATA/production/qc-sync/trd.json
-    [[ -z "$QC_JSON_GLO" ]] && QC_JSON_GLO=$O2DPG_ROOT/DATA/production/qc-sync/glo-qcmn-epn.json
+    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_GLO=$O2DPG_ROOT/DATA/production/qc-sync/glo-vtx-qcmn-epn.json
+    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_GLO=$O2DPG_ROOT/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
     [[ -z "$QC_JSON_GLOBAL" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-sync/qc-global.json
     if [[ -z "$QC_JSON_TOF_MATCH" ]]; then
       if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
@@ -109,8 +111,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=$O2DPG_ROOT/DATA/production/qc-async/phs.json
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=$O2DPG_ROOT/DATA/production/qc-async/trd.json
     # the following two ($QC_JSON_PRIMVTX and $QC_JSON_ITSTPC) replace $QC_JSON_GLO for async processing
-    [[ -z "$QC_JSON_PRIMVTX" ]] && QC_JSON_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-async/primvtx.json
-    [[ -z "$QC_JSON_ITSTPC" ]] && QC_JSON_ITSTPC=$O2DPG_ROOT/DATA/production/qc-async/itstpc.json
+    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-async/primvtx.json
+    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_ITSTPC=$O2DPG_ROOT/DATA/production/qc-async/itstpc.json
     [[ -z "$QC_JSON_TOF_MATCH" ]] && QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-async/itstpctof.json
     [[ -z "$QC_JSON_PID_FT0TOF" ]] && QC_JSON_PID_FT0TOF=$O2DPG_ROOT/DATA/production/qc-async/pidft0tof.json
     [[ -z "$QC_JSON_GLOBAL" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-async/qc-global.json
@@ -154,33 +156,12 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     fi
   done
 
-  ADD_ITSTPCQC=1
-  ADD_PRIMVTX=1
-  if [[ $SYNCMODE == 1 ]]; then
-    if ! has_detectors_reco ITS TPC || ! has_detector_matching ITSTPC; then
-      QC_CONFIG+="--override-values \"qc.tasks.MTCITSTPC.active=false\""
-      ADD_ITSTPCQC=0
-    fi
-    if ! has_detectors_reco ITS || ! has_detector_matching PRIMVTX; then
-      QC_CONFIG+="--override-values \"qc.tasks.Vertexing.active=false\""
-      ADD_PRIMVTX=0
-    fi
-    if [[ $ADD_ITSTPCQC == 1 ]] || [[ $ADD_PRIMVTX == 1 ]]; then
-      add_QC_JSON GLO $QC_JSON_GLO
-    fi
-  else # async processing
-    LIST_OF_GLOQC=
-    has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_comma_separated LIST_OF_GLOQC ITSTPC
-    has_detectors_reco ITS && has_detector_matching PRIMVTX && add_comma_separated LIST_OF_GLOQC PRIMVTX
-    for i in $(echo $LIST_OF_GLOQC | sed "s/,/ /g"); do
-      GLO_JSON_FILE="QC_JSON_$i"
-      if has_detector_matching $i && has_matching_qc $i && [ ! -z "${!GLO_JSON_FILE}" ]; then
-	add_QC_JSON $i ${!GLO_JSON_FILE}
-      fi
-    done
+  # GLO QC: VTX and ITSTPC_MTCH
+  if has_detectors_reco ITS && has_detector_matching PRIMVTX; then
+    add_QC_JSON GLO $QC_JSON_GLO_VTX
   fi
-  if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
-    echo ADD_ITSTPCQC=$ADD_ITSTPCQC ADD_PRIMVTX=$ADD_PRIMVTX 1>&2
+  if has_detectors_reco ITS TPC && has_detector_matching ITSTPC; then
+    add_QC_JSON GLO $QC_JSON_GLO_ITSTPC_MTCH
   fi
 
   # PID QC


### PR DESCRIPTION
@knopers8 
I left untouched what we do in async. 
I tried in SYNC mode, which behaves like EPN, but taking the files from O2DPG instead of consul. I only built the json, and for me it looks fine. 
The only drawback is that in the json the tasks will always look active, it is just the argument passed to o2-qc that disables them, e.g.:
```
o2-qc --session default_3884606_24780 --severity info --shm-segment-id 0 --shm-segment-size 16000000000  --resources-monitoring 50 --resources-monitor
ing-dump-interval 50 --early-forward-policy noraw --fairmq-rate-logging 0 --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 --config json:///a
rchive/O2/testQCconfig/json_cache/20220921-222315-3884617-11198--ITS-GLO.json --local-batch=QC.root --override-values "qc.config.Activity.number=52314
4;qc.config.Activity.passName=apass1;qc.config.Activity.periodName=LHC22m" --override-values "qc.tasks.MTCITSTPC.active=false"  --configKeyValues "Nam
eConf.mDirGeom=/home/zampolli/work/O2/testQCconfig;NameConf.mDirGRP=/home/zampolli/work/O2/testQCconfig;keyval.input_dir=/home/zampolli/work/O2/testQC
config;keyval.output_dir=/dev/null;;" | \
```
This might not be straightforward, but it should be no problem since we don't have the same issue that we need the original json for merging that we have on the grid.
The other option is to split, as we discussed today.