### PR TITLE
Prevent two timeframes from having the same seed

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
@@ -30,9 +30,15 @@ FairGenerator*
     printf("PDG %d \n", std::stoi(spdg));
   }
   gen->SetForceDecay(kEvtBJpsiDiElectron);
+  
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
+  
   // print debug
   // gen->PrintDebug();
 

--- a/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
@@ -33,7 +33,11 @@ FairGenerator*
   // gen->PrintDebug();
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
 
   return gen;
 }


### PR DESCRIPTION
Random:seed = 0 assign a random seed to pythia using Stdlib time(0). If the two timeframes are created in less than a second, they share the same seed. To avoid this, the random seed is now given by urandom.