### PR TITLE
CTF_METAFILES_DIR not required for printing workflow

### DIFF
--- a/DATA/tools/epn/gen_topo_o2dpg.sh
+++ b/DATA/tools/epn/gen_topo_o2dpg.sh
@@ -23,7 +23,7 @@ if [[ -z "$MULTIPLICITY_FACTOR_REST" ]]; then echo \$MULTIPLICITY_FACTOR_REST mi
 if [[ -z "$FILEWORKDIR" ]]; then echo \$FILEWORKDIR missing; exit 1; fi
 if [[ -z "$INRAWCHANNAME" ]]; then echo \$INRAWCHANNAME missing; exit 1; fi
 if [[ -z "$CTF_DIR" ]]; then echo \$CTF_DIR missing; exit 1; fi
-if [[ -z "$CTF_METAFILES_DIR" ]]; then echo \$CTF_METAFILES_DIR missing; exit 1; fi
+if [[ -z "$CTF_METAFILES_DIR" ]] && [[ $WORKFLOWMODE != "print" ]]; then echo \$CTF_METAFILES_DIR missing; exit 1; fi
 if [[ -z "$GEN_TOPO_WORKDIR" ]]; then echo \$GEN_TOPO_WORKDIR missing; exit 1; fi
 if [[ -z "$GEN_TOPO_STDERR_LOGGING" ]]; then echo \$GEN_TOPO_STDERR_LOGGING missing; exit 1; fi
 if [[ -z "$IS_SIMULATED_DATA" ]]; then echo \$IS_SIMULATED_DATA missing; exit 1; fi


### PR DESCRIPTION
@davidrohr not 100% if its OK like this. When I would like to see the workflow which was running on the EPNs, I usually grep the topology generation command line from the ODC logs and prepend `WORKFLOWMODE=print GEN_TOPO_WORKDIR=$PWD`. But then I get this complaint `$CTF_METAFILES_DIR missing`. So I also prepend `CTF_METAFILES_DIR=foo` so that it works. But that should not be needed I think