### PR TITLE
Move value-threshold comparison to python

### DIFF
--- a/RelVal/o2dpg_release_validation.py
+++ b/RelVal/o2dpg_release_validation.py
@@ -12,58 +12,69 @@
 # See O2DPG/RelVal/config/rel_val_sim_dirs_default.json for as an example
 #
 # The full help message would be
-# usage: o2dpg_release_validation.py rel-val [-h] -i [INPUT1 ...] -j
-#                                            [INPUT2 ...] [--with-test-chi2]
-#                                            [--with-test-bincont]
-#                                            [--with-test-numentries]
-#                                            [--chi2-threshold CHI2_THRESHOLD]
-#                                            [--rel-mean-diff-threshold REL_MEAN_DIFF_THRESHOLD]
-#                                            [--rel-entries-diff-threshold REL_ENTRIES_DIFF_THRESHOLD]
-#                                            [--select-critical]
-#                                            [--use-values-as-thresholds USE_VALUES_AS_THRESHOLDS]
-#                                            [--dir-config DIR_CONFIG]
-#                                            [--dir-config-enable [DIR_CONFIG_ENABLE ...]]
-#                                            [--dir-config-disable [DIR_CONFIG_DISABLE ...]]
-#                                            [--include-dirs [INCLUDE_DIRS ...]]
-#                                            [--add] [--output OUTPUT]
-# 
-# optional arguments:
-#   -h, --help            show this help message and exit
-#   -i [INPUT1 ...], --input1 [INPUT1 ...]
-#                         EITHER first set of input files for comparison OR
-#                         first input directory from simulation for comparison
-#   -j [INPUT2 ...], --input2 [INPUT2 ...]
-#                         EITHER second set of input files for comparison OR
-#                         second input directory from simulation for comparison
-#   --with-test-chi2      run chi2 test
-#   --with-test-bincont   run bin-content test
-#   --with-test-numentries
-#                         run number-of-entries test
-#   --chi2-threshold CHI2_THRESHOLD
-#                         Chi2 threshold
-#   --rel-mean-diff-threshold REL_MEAN_DIFF_THRESHOLD
-#                         Threshold of relative difference in mean
-#   --rel-entries-diff-threshold REL_ENTRIES_DIFF_THRESHOLD
-#                         Threshold of relative difference in number of entries
-#   --select-critical     Select the critical histograms and dump to file
-#   --use-values-as-thresholds USE_VALUES_AS_THRESHOLDS
-#                         Use values from another run as thresholds for this one
-#   --dir-config DIR_CONFIG
-#                         What to take into account in a given directory
-#   --dir-config-enable [DIR_CONFIG_ENABLE ...]
-#                         only enable these top keys in your dir-config
-#   --dir-config-disable [DIR_CONFIG_DISABLE ...]
-#                         disable these top keys in your dir-config (precedence
-#                         over dir-config-enable)
-#   --include-dirs [INCLUDE_DIRS ...]
-#                         only inlcude directories; note that each pattern is
-#                         assumed to start in the top-directory (at the moment
-#                         no regex or *)
-#   --add                 If given and there is already a RelVal in the output
-#                         directory, extracted objects will be added to the
-#                         existing ones
-#   --output OUTPUT, -o OUTPUT
-#                         output directory
+#usage: o2dpg_release_validation.py rel-val [-h] -i [INPUT1 ...] -j
+#                                           [INPUT2 ...]
+#                                           [--chi2-threshold CHI2_THRESHOLD]
+#                                           [--rel-mean-diff-threshold REL_MEAN_DIFF_THRESHOLD]
+#                                           [--rel-entries-diff-threshold REL_ENTRIES_DIFF_THRESHOLD]
+#                                           [--use-values-as-thresholds USE_VALUES_AS_THRESHOLDS]
+#                                           [--chi2-threshold-margin CHI2_THRESHOLD_MARGIN]
+#                                           [--rel-mean-diff-threshold-margin REL_MEAN_DIFF_THRESHOLD_MARGIN]
+#                                           [--rel-entries-diff-threshold-margin REL_ENTRIES_DIFF_THRESHOLD_MARGIN]
+#                                           [--with-test-chi2]
+#                                           [--with-test-bincont]
+#                                           [--with-test-numentries]
+#                                           [--dir-config DIR_CONFIG]
+#                                           [--dir-config-enable [DIR_CONFIG_ENABLE ...]]
+#                                           [--dir-config-disable [DIR_CONFIG_DISABLE ...]]
+#                                           [--include-dirs [INCLUDE_DIRS ...]]
+#                                           [--add] [--output OUTPUT]
+#
+#optional arguments:
+#  -h, --help            show this help message and exit
+#  -i [INPUT1 ...], --input1 [INPUT1 ...]
+#                        EITHER first set of input files for comparison OR
+#                        first input directory from simulation for comparison
+#  -j [INPUT2 ...], --input2 [INPUT2 ...]
+#                        EITHER second set of input files for comparison OR
+#                        second input directory from simulation for comparison
+#  --chi2-threshold CHI2_THRESHOLD
+#                        Chi2 threshold
+#  --rel-mean-diff-threshold REL_MEAN_DIFF_THRESHOLD
+#                        Threshold of relative difference in mean
+#  --rel-entries-diff-threshold REL_ENTRIES_DIFF_THRESHOLD
+#                        Threshold of relative difference in number of entries
+#  --use-values-as-thresholds USE_VALUES_AS_THRESHOLDS
+#                        Use values from another run as thresholds for this one
+#  --chi2-threshold-margin CHI2_THRESHOLD_MARGIN
+#                        Margin to apply to the chi2 threshold extracted from
+#                        file
+#  --rel-mean-diff-threshold-margin REL_MEAN_DIFF_THRESHOLD_MARGIN
+#                        Margin to apply to the rel_mean_diff threshold
+#                        extracted from file
+#  --rel-entries-diff-threshold-margin REL_ENTRIES_DIFF_THRESHOLD_MARGIN
+#                        Margin to apply to the rel_entries_diff threshold
+#                        extracted from file
+#  --with-test-chi2      run chi2 test
+#  --with-test-bincont   run bin-content test
+#  --with-test-numentries
+#                        run number-of-entries test
+#  --dir-config DIR_CONFIG
+#                        What to take into account in a given directory
+#  --dir-config-enable [DIR_CONFIG_ENABLE ...]
+#                        only enable these top keys in your dir-config
+#  --dir-config-disable [DIR_CONFIG_DISABLE ...]
+#                        disable these top keys in your dir-config (precedence
+#                        over dir-config-enable)
+#  --include-dirs [INCLUDE_DIRS ...]
+#                        only inlcude directories; note that each pattern is
+#                        assumed to start in the top-directory (at the moment
+#                        no regex or *)
+#  --add                 If given and there is already a RelVal in the output
+#                        directory, extracted objects will be added to the
+#                        existing ones
+#  --output OUTPUT, -o OUTPUT
+#                        output directory
 
 import sys
 import argparse
@@ -100,6 +111,10 @@ REL_VAL_SEVERITY_MAP = {v: i for i, v in enumerate(REL_VAL_SEVERITIES)}
 REL_VAL_SEVERITY_COLOR_MAP = {"GOOD": "green", "WARNING": "orange", "NONCRIT_NC": "cornflowerblue", "CRIT_NC": "navy", "BAD": "red"}
 REL_VAL_TEST_NAMES = ["test_chi2", "test_bin_cont", "test_num_entries"]
 REL_VAL_TEST_NAMES_MAP = {v: i for i, v in enumerate(REL_VAL_TEST_NAMES)}
+REL_VAL_TEST_CRITICAL = [True, True, False]
+TEST_SUMMARY_NAME = "test_summary"
+REL_VAL_TEST_NAMES_SUMMARY = REL_VAL_TEST_NAMES + [TEST_SUMMARY_NAME]
+REL_VAL_TEST_NAMES_MAP_SUMMARY = {v: i for i, v in enumerate(REL_VAL_TEST_NAMES_SUMMARY)}
 
 gROOT.SetBatch()
 
@@ -215,7 +230,10 @@ def file_sizes(dirs, threshold):
     return collect_dict
 
 
-def plot_pie_chart_single(summary, out_dir, title):
+def plot_pie_charts(summary, out_dir, title):
+
+    print("==> Plot pie charts <==")
+
     test_n_hist_map = {}
 
     # need to re-arrange the JSON structure abit for per-test result pie charts
@@ -272,7 +290,8 @@ def extract_from_summary(summary, fields):
     return test_histo_value_map
 
 
-def plot_values_single(summary, out_dir, title):
+def plot_values_thresholds(summary, out_dir, title):
+    print("==> Plot values and thresholds <==")
     test_histo_value_map = extract_from_summary(summary, ["value", "threshold"])
 
     for which_test, histos_values_thresolds in test_histo_value_map.items():
@@ -340,9 +359,7 @@ def plot_compare_summaries(summaries, fields, out_dir, *, labels=None):
 
 def plot_summary_grid(summary, flags, include_patterns, output_path):
 
-    if isinstance(summary, str):
-        with open(summary, "r") as f:
-            summary = json.load(f)
+    print("==> Plot summary grid <==")
 
     colors = [None] * len(REL_VAL_SEVERITY_MAP)
     for name, color in REL_VAL_SEVERITY_COLOR_MAP.items():
@@ -362,10 +379,11 @@ def plot_summary_grid(summary, flags, include_patterns, output_path):
             if not include_this:
                 continue
         include_this = not flags
-        collect_flags_per_test = [0] * len(REL_VAL_TEST_NAMES_MAP)
-        collect_annotations_per_test = [""] * len(REL_VAL_TEST_NAMES_MAP)
+        collect_flags_per_test = [0] * len(REL_VAL_TEST_NAMES_MAP_SUMMARY)
+        collect_annotations_per_test = [""] * len(REL_VAL_TEST_NAMES_MAP_SUMMARY)
         for test in batch:
-            if test["test_name"] not in REL_VAL_TEST_NAMES_MAP:
+            test_name = test["test_name"]
+            if test_name not in REL_VAL_TEST_NAMES_MAP_SUMMARY:
                 continue
             if flags and not include_this:
                 for f in flags:
@@ -374,9 +392,10 @@ def plot_summary_grid(summary, flags, include_patterns, output_path):
                         break
 
             res = test["result"]
-            ind = REL_VAL_TEST_NAMES_MAP[test["test_name"]]
-            value_annottaion = f"{test['value']:.2f}" if test["comparable"] else "---"
-            collect_annotations_per_test[ind] = f"{test['threshold']:.2f}; {value_annottaion}"
+            ind = REL_VAL_TEST_NAMES_MAP_SUMMARY[test_name]
+            if ind != len(REL_VAL_TEST_NAMES_MAP):
+                value_annotaion = f"{test['value']:.2f}" if test["comparable"] else "---"
+                collect_annotations_per_test[ind] = f"{test['threshold']:.2f}; {value_annotaion}"
             collect_flags_per_test[ind] = REL_VAL_SEVERITY_MAP[res]
 
         if not include_this:
@@ -393,7 +412,7 @@ def plot_summary_grid(summary, flags, include_patterns, output_path):
     collect_for_grid = [c for _, c in sorted(zip(collect_names, collect_for_grid))]
     collect_annotations = [c for _, c in sorted(zip(collect_names, collect_annotations))]
     collect_names.sort()
-    seaborn.heatmap(collect_for_grid, ax=ax, cmap=cmap, vmin=-0.5, vmax=len(REL_VAL_SEVERITY_MAP) - 0.5, yticklabels=collect_names, xticklabels=REL_VAL_TEST_NAMES, linewidths=0.5, annot=collect_annotations, fmt="")
+    seaborn.heatmap(collect_for_grid, ax=ax, cmap=cmap, vmin=-0.5, vmax=len(REL_VAL_SEVERITY_MAP) - 0.5, yticklabels=collect_names, xticklabels=REL_VAL_TEST_NAMES_SUMMARY, linewidths=0.5, annot=collect_annotations, fmt="")
     cbar = ax.collections[0].colorbar
     cbar.set_ticks(range(len(REL_VAL_SEVERITY_MAP)))
     cbar.set_ticklabels(REL_VAL_SEVERITIES)
@@ -401,41 +420,81 @@ def plot_summary_grid(summary, flags, include_patterns, output_path):
     figure.tight_layout()
     figure.savefig(output_path)
     plt.close(figure)
-    print(f"Written summary grid to {output_path}")
 
 
-def make_generic_histograms_from_log_file(filenames1, filenames2, output_filepath1, output_filepath2, patterns, field_numbers, names):
+def make_single_summary(rel_val_dict, args):
+    """
+    Make the usual summary
+    """
+    def assign_result_flag(is_critical, comparable, passed):
+        result = "GOOD"
+        if is_critical:
+            if not comparable:
+                result = "CRIT_NC"
+            elif not passed:
+                result = "BAD"
+        else:
+            if not comparable:
+                result = "NONCRIT_NC"
+            elif not passed:
+                result = "WARNING"
+        return result
 
-    values1 = [[] for _ in names]
-    values2 = [[] for _ in names]
+    user_thresholds = {}
+    this_summary = {}
+    if args.use_values_as_thresholds:
+        with open(args.use_values_as_thresholds, "r") as f:
+            user_thresholds = json.load(f)
 
-    for filename in filenames1:
-        with open(filename, "r", encoding="utf-8") as f:
-            for line in f:
-                for i, (pattern, field_number) in enumerate(zip(patterns, field_numbers)):
-                    if not re.search(pattern, line):
-                        continue
-                    values1[i].append(float(line.split()[field_number]))
-    for filename in filenames2:
-        with open(filename, "r", encoding="utf-8") as f:
-            for line in f:
-                for i, (pattern, field_number) in enumerate(zip(patterns, field_numbers)):
-                    if not re.search(pattern, line):
-                        continue
-                    values2[i].append(float(line.split()[field_number]))
+    default_thresholds = {"test_chi2": args.chi2_threshold,
+                          "test_bin_cont": args.rel_mean_diff_threshold,
+                          "test_num_entries": args.rel_entries_diff_threshold}
+    margins_thresholds = {"test_chi2": args.chi2_threshold_margin,
+                          "test_bin_cont": args.rel_mean_diff_threshold_margin,
+                          "test_num_entries": args.rel_entries_diff_threshold_margin}
 
-    file1 = TFile(output_filepath1, "RECREATE")
-    for values, name in zip(values1, names):
-        h1 = TH1D(name, "", 1, 0, 1)
-        h1.Fill(0.5, sum(values))
-        h1.Write()
-    file1.Close()
-    file2 = TFile(output_filepath2, "RECREATE")
-    for values, name in zip(values2, names):
-        h2 = TH1D(name, "", 1, 0, 1)
-        h2.Fill(0.5, sum(values))
-        h2.Write()
-    file2.Close()
+    for histo_name, tests in rel_val_dict.items():
+        test_summary = {"test_name": TEST_SUMMARY_NAME,
+                        "value": None,
+                        "threshold": None,
+                        "result": None}
+        is_critical_summary = False
+        passed_summary = True
+        is_comparable_summary = True
+        these_tests = []
+        for t in tests:
+            if t["test_name"] == TEST_SUMMARY_NAME:
+                continue
+            threshold = default_thresholds[t["test_name"]]
+            test_name = t["test_name"]
+            test_id = REL_VAL_TEST_NAMES_MAP[test_name]
+            for ref_test in user_thresholds.get(histo_name, []):
+                if ref_test["test_name"] == test_name:
+                    threshold = ref_test["value"] * margins_thresholds[test_name]
+                    break
+            t["threshold"] = threshold
+
+            comparable = t["comparable"]
+            passed = True
+            is_critical = REL_VAL_TEST_CRITICAL[test_id] or histo_name.find("_ratioFromTEfficiency") != -1
+            if comparable:
+                passed = t["value"] <= threshold
+
+            t["result"] = assign_result_flag(is_critical, comparable, passed)
+
+            is_critical_summary = is_critical or is_critical_summary
+            is_comparable_summary = comparable and is_comparable_summary
+            if is_critical:
+                # only mark potentially as failed if we run over a critical test
+                passed_summary = passed_summary and passed
+            these_tests.append(t)
+
+        test_summary["result"] = assign_result_flag(is_critical_summary, is_comparable_summary, passed_summary)
+        test_summary["comparable"] = is_comparable_summary
+        these_tests.append(test_summary)
+        this_summary[histo_name] = these_tests
+
+    return this_summary
 
 
 def rel_val_files(files1, files2, args, output_dir):
@@ -454,8 +513,6 @@ def rel_val_files(files1, files2, args, output_dir):
 
     if not exists(output_dir):
         makedirs(output_dir)
-    select_critical = "kTRUE" if args.select_critical else "kFALSE"
-    in_thresholds = args.use_values_as_thresholds if args.use_values_as_thresholds else ""
     log_file_extract = join(abspath(output_dir), "extract_and_flatten.log")
     log_file_rel_val = join(abspath(output_dir), "rel_val.log")
     if args.include_dirs:
@@ -485,19 +542,23 @@ def rel_val_files(files1, files2, args, output_dir):
         cmd = f"root -l -b -q {ROOT_MACRO_EXTRACT}{cmd}"
         run_macro(cmd, log_file_extract)
 
-    cmd = f"\\(\\\"{file_1}\\\",\\\"{file_2}\\\",{args.test},{args.chi2_threshold},{args.rel_mean_diff_threshold},{args.rel_entries_diff_threshold},{select_critical},\\\"{abspath(in_thresholds)}\\\"\\)"
+    cmd = f"\\(\\\"{file_1}\\\",\\\"{file_2}\\\",{args.test}\\)"
     cmd = f"root -l -b -q {ROOT_MACRO_RELVAL}{cmd}"
     print("Running RelVal on extracted objects")
     run_macro(cmd, log_file_rel_val)
-    json_path = join(output_dir, "Summary.json")
+    json_path = join(output_dir, "RelVal.json")
+
     if exists(json_path):
         # go through all we found
-        current_summary = None
+        rel_val_summary = None
         with open(json_path, "r") as f:
-            current_summary = json.load(f)
-        plot_pie_chart_single(current_summary, output_dir, "")
-        plot_values_single(current_summary, output_dir, "")
-        plot_summary_grid(current_summary, None, None, join(output_dir, "SummaryTests.png"))
+            rel_val_summary = json.load(f)
+        final_summary = make_single_summary(rel_val_summary, args)
+        with open(join(output_dir, "Summary.json"), "w") as f:
+            json.dump(final_summary, f, indent=2)
+        plot_pie_charts(final_summary, output_dir, "")
+        plot_values_thresholds(final_summary, output_dir, "")
+        plot_summary_grid(final_summary, None, None, join(output_dir, "SummaryTests.png"))
 
     return 0
 
@@ -506,15 +567,10 @@ def rel_val_files_only(args):
     return rel_val_files(args.input1, args.input2, args, args.output)
 
 
-def print_summary(filename, include_patterns=None):
+def map_histos_to_severity(summary, include_patterns=None):
     """
-    Check if any 2 histograms have a given severity level after RelVal
+    Map the histogram names to their severity of the test
     """
-
-    summary = None
-    with open(filename, "r") as f:
-        summary = json.load(f)
-
     test_n_hist_map = {s: [] for i, s in enumerate(REL_VAL_SEVERITIES) if REL_VAL_SEVERITIES_USE_SUMMARY[i]}
 
     # need to re-arrange the JSON structure abit for per-test result pie charts
@@ -531,10 +587,20 @@ def print_summary(filename, include_patterns=None):
         # loop over tests done
         for test in tests:
             test_name = test["test_name"]
-            if test_name != "test_summary":
+            if test_name != TEST_SUMMARY_NAME:
                 continue
             result = test["result"]
             test_n_hist_map[result].append(histo_name)
+
+    return test_n_hist_map
+
+
+def print_summary(summary, include_patterns=None):
+    """
+    Check if any 2 histograms have a given severity level after RelVal
+    """
+
+    test_n_hist_map = map_histos_to_severity(summary, include_patterns)
 
     n_all = sum(len(v) for v in test_n_hist_map.values())
     print(f"\n#####\nNumber of compared histograms: {n_all}\nBased on critical tests, severities are\n")
@@ -542,53 +608,11 @@ def print_summary(filename, include_patterns=None):
         print(f"  {sev}: {len(histos)}")
     print("#####\n")
 
-    return test_n_hist_map
 
-
-def rel_val_log_file(dir1, dir2, files, output_dir, args, patterns, field_numbers, names, *, combine_patterns=None):
-    """
-    RelVal for 2 ROOT files containing a TTree to be compared
-    """
-    # Prepare file paths for TChain
-    to_be_chained1 = []
-    to_be_chained2 = []
-    output_dirs = []
-
-    # possibly combine common files, for instance when they come from different timeframes
-    if combine_patterns:
-        for cp in combine_patterns:
-            chained1 = [join(dir1, hf) for hf in files if cp in hf]
-            chained2 = [join(dir2, hf) for hf in files if cp in hf]
-            if not chained1 or not chained2:
-                continue
-            to_be_chained1.append(chained1)
-            to_be_chained2.append(chained2)
-            output_dirs.append(f"{cp}_dir")
-    else:
-        to_be_chained1 = []
-        to_be_chained2 = []
-        for hf in files:
-            to_be_chained1.append(join(dir1, hf))
-            to_be_chained2.append(join(dir2, hf))
-            output_dirs.append(f"{hf}_dir")
-
-    # paths for chains prepared, output directory names specified, do RelVal
-    for tbc1, tbc2, od in zip(to_be_chained1, to_be_chained2, output_dirs):
-        output_dir_hf = join(output_dir, od)
-        if not exists(output_dir_hf):
-            makedirs(output_dir_hf)
-
-        make_generic_histograms_from_log_file(tbc1, tbc2, join(output_dir_hf, "file1.root"), join(output_dir_hf, "file2.root"), patterns, field_numbers, names)
-        # after we created files containing histograms, they can be compared with the standard RelVal
-        rel_val_files((abspath(join(output_dir_hf, "file1.root")),), (abspath(join(output_dir_hf, "file2.root")),), args, output_dir_hf)
-    return 0
-
-
-def make_summary(in_dir):
+def make_global_summary(in_dir):
     """
     Make a summary per histogram (that should be able to be parsed by Grafana eventually)
     """
-    print("==> Make summary <==")
     file_paths = glob(f"{in_dir}/**/Summary.json", recursive=True)
     summary = {}
 
@@ -654,20 +678,6 @@ def rel_val_sim_dirs(args):
             rel_val_files(in1, in2, args, current_output_dir)
     return 0
 
-def make_new_threshold_file(json_path, out_filepath,threshold_margins):
-    json_in = None
-    with open(json_path, "r") as f:
-        json_in = json.load(f)
-    with open(out_filepath, "w") as f:
-        for histo_name, tests in json_in.items():
-            for t in tests:
-                if not t["comparable"]:
-                    continue
-                if t["test_name"] not in REL_VAL_TEST_NAMES_MAP:
-                    continue
-                ind = REL_VAL_TEST_NAMES_MAP[t['test_name']]
-                f.write(f"{histo_name},{t['test_name']},{t['value']*threshold_margins[ind]}\n")
-
 
 def rel_val(args):
     """
@@ -682,9 +692,6 @@ def rel_val(args):
         args.test = 7
     if not exists(args.output):
         makedirs(args.output)
-    if args.use_values_as_thresholds:
-        out_path = make_new_threshold_file(args.use_values_as_thresholds, join(args.output, "use_thresholds.dat"),[args.chi2_threshold_margin,args.rel_mean_diff_threshold_margin,args.rel_entries_diff_threshold_margin])
-        args.use_values_as_thresholds = join(args.output, "use_thresholds.dat")
     if is_sim_dir(args.input1[0]) and is_sim_dir(args.input2[0]):
         if not args.dir_config:
             print("ERROR: RelVal to be run on 2 directories. Please provide a configuration what to validate.")
@@ -703,9 +710,10 @@ def rel_val(args):
     if not exists(args.output):
         makedirs(args.output)
     func(args)
+    global_summary = make_global_summary(args.output)
     with open(join(args.output, "SummaryGlobal.json"), "w") as f:
-        json.dump(make_summary(args.output), f, indent=2)
-    print_summary(join(args.output, "SummaryGlobal.json"))
+        json.dump(global_summary, f, indent=2)
+    print_summary(global_summary)
     return 0
 
 
@@ -716,10 +724,10 @@ def inspect(args):
     path = args.path
 
     def get_filepath(d):
-        summary_global = join(path, "SummaryGlobal.json")
+        summary_global = join(d, "SummaryGlobal.json")
         if exists(summary_global):
             return summary_global
-        summary = join(path, "Summary.json")
+        summary = join(d, "Summary.json")
         if exists(summary):
             return summary
         print(f"Can neither find {summary_global} nor {summary}. Nothing to work with.")
@@ -730,9 +738,22 @@ def inspect(args):
         if not path:
             return 1
 
-    print_summary(path, args.include_patterns)
+    output_dir = args.output or join(dirname(path), "user_summary")
+    if not exists(output_dir):
+        makedirs(output_dir)
+
+    current_summary = None
+    with open(path, "r") as f:
+        current_summary = json.load(f)
+    summary = make_single_summary(current_summary, args)
+    with open(join(output_dir, "Summary.json"), "w") as f:
+        json.dump(summary, f, indent=2)
+    print_summary(summary)
+
     if args.plot:
-        plot_summary_grid(path, args.flags, args.include_patterns, join(dirname(path), "SummaryTestsUser.png"))
+        plot_pie_charts(summary, output_dir, "")
+        plot_values_thresholds(summary, output_dir, "")
+        plot_summary_grid(summary, args.flags, args.include_patterns, join(output_dir, "SummaryTests.png"))
 
     return 0
 
@@ -761,14 +782,17 @@ def compare(args):
 
     # print the histogram names with different severities per test
     if args.difference:
-        summaries = [join(input, "SummaryGlobal.json") for input in args.input]
-        for i, summary in enumerate(summaries):
+        summaries_json = [join(json_input, "SummaryGlobal.json") for json_input in args.input]
+        summaries = []
+        for i, summary in enumerate(summaries_json):
             if not exists(summary):
                 print(f"WARNING: Cannot find expected {summary}.")
                 return 1
+            with open(summaries_json, "r") as f:
+                summaries.append(json.load(f))
 
         s = "\nCOMPARING RELVAL SUMMARY\n"
-        summaries = [print_summary(summary) for summary in summaries]
+        summaries = [map_histos_to_severity(summary) for summary in summaries]
         print("Histograms with different RelVal results from 2 RelVal runs")
         for severity in REL_VAL_SEVERITY_MAP:
             intersection = list(set(summaries[0][severity]) & set(summaries[1][severity]))
@@ -861,19 +885,21 @@ def main():
     common_file_parser.add_argument("-i", "--input1", nargs="*", help="EITHER first set of input files for comparison OR first input directory from simulation for comparison", required=True)
     common_file_parser.add_argument("-j", "--input2", nargs="*", help="EITHER second set of input files for comparison OR second input directory from simulation for comparison", required=True)
 
+    common_threshold_parser = argparse.ArgumentParser(add_help=False)
+    common_threshold_parser.add_argument("--chi2-threshold", dest="chi2_threshold", type=float, help="Chi2 threshold", default=1.5)
+    common_threshold_parser.add_argument("--rel-mean-diff-threshold", dest="rel_mean_diff_threshold", type=float, help="Threshold of relative difference in mean", default=1.5)
+    common_threshold_parser.add_argument("--rel-entries-diff-threshold", dest="rel_entries_diff_threshold", type=float, help="Threshold of relative difference in number of entries", default=0.01)
+    common_threshold_parser.add_argument("--use-values-as-thresholds", dest="use_values_as_thresholds", help="Use values from another run as thresholds for this one")
+    # The following only take effect for thresholds given via an input file
+    common_threshold_parser.add_argument("--chi2-threshold-margin", dest="chi2_threshold_margin", type=float, help="Margin to apply to the chi2 threshold extracted from file", default=1.0)
+    common_threshold_parser.add_argument("--rel-mean-diff-threshold-margin", dest="rel_mean_diff_threshold_margin", type=float, help="Margin to apply to the rel_mean_diff threshold extracted from file", default=1.0)
+    common_threshold_parser.add_argument("--rel-entries-diff-threshold-margin", dest="rel_entries_diff_threshold_margin", type=float, help="Margin to apply to the rel_entries_diff threshold extracted from file", default=1.0)
+
     sub_parsers = parser.add_subparsers(dest="command")
-    rel_val_parser = sub_parsers.add_parser("rel-val", parents=[common_file_parser])
+    rel_val_parser = sub_parsers.add_parser("rel-val", parents=[common_file_parser, common_threshold_parser])
     rel_val_parser.add_argument("--with-test-chi2", dest="with_test_chi2", action="store_true", help="run chi2 test")
     rel_val_parser.add_argument("--with-test-bincont", dest="with_test_bincont", action="store_true", help="run bin-content test")
     rel_val_parser.add_argument("--with-test-numentries", dest="with_test_numentries", action="store_true", help="run number-of-entries test")
-    rel_val_parser.add_argument("--chi2-threshold", dest="chi2_threshold", type=float, help="Chi2 threshold", default=1.5)
-    rel_val_parser.add_argument("--rel-mean-diff-threshold", dest="rel_mean_diff_threshold", type=float, help="Threshold of relative difference in mean", default=1.5)
-    rel_val_parser.add_argument("--rel-entries-diff-threshold", dest="rel_entries_diff_threshold", type=float, help="Threshold of relative difference in number of entries", default=0.01)
-    rel_val_parser.add_argument("--select-critical", dest="select_critical", action="store_true", help="Select the critical histograms and dump to file")
-    rel_val_parser.add_argument("--use-values-as-thresholds", dest="use_values_as_thresholds", help="Use values from another run as thresholds for this one")
-    rel_val_parser.add_argument("--chi2-threshold-margin", dest="chi2_threshold_margin", type=float, help="Margin to apply to the chi2 threshold extracted from file", default=1.0)
-    rel_val_parser.add_argument("--rel-mean-diff-threshold-margin", dest="rel_mean_diff_threshold_margin", type=float, help="Margin to apply to the rel_mean_diff threshold extracted from file", default=1.0)
-    rel_val_parser.add_argument("--rel-entries-diff-threshold-margin", dest="rel_entries_diff_threshold_margin", type=float, help="Margin to apply to the rel_entries_diff threshold extracted from file", default=1.0)
     rel_val_parser.add_argument("--dir-config", dest="dir_config", help="What to take into account in a given directory")
     rel_val_parser.add_argument("--dir-config-enable", dest="dir_config_enable", nargs="*", help="only enable these top keys in your dir-config")
     rel_val_parser.add_argument("--dir-config-disable", dest="dir_config_disable", nargs="*", help="disable these top keys in your dir-config (precedence over dir-config-enable)")
@@ -882,12 +908,13 @@ def main():
     rel_val_parser.add_argument("--output", "-o", help="output directory", default="rel_val")
     rel_val_parser.set_defaults(func=rel_val)
 
-    inspect_parser = sub_parsers.add_parser("inspect")
+    inspect_parser = sub_parsers.add_parser("inspect", parents=[common_threshold_parser])
     inspect_parser.add_argument("path", help="either complete file path to a Summary.json or SummaryGlobal.json or directory where one of the former is expected to be")
     inspect_parser.add_argument("--plot", action="store_true", help="Plot the summary grid")
     inspect_parser.add_argument("--print", action="store_true", help="Print the summary on the screen")
     inspect_parser.add_argument("--flags", nargs="*", help="extract all objects which have at least one test with this severity flag", choices=list(REL_VAL_SEVERITY_MAP.keys()))
     inspect_parser.add_argument("--include-patterns", dest="include_patterns", nargs="*", help="include objects whose name includes at least one of the given patterns (at the moment no regex or *)")
+    inspect_parser.add_argument("--output", "-o", help="output directory, by default points to directory where the Summary.json was found")
     inspect_parser.set_defaults(func=inspect)
 
     compare_parser = sub_parsers.add_parser("compare", parents=[common_file_parser])


### PR DESCRIPTION
* no longer necessary to run full RelVal if only thresholds are changed ==> makes threshold scan faster and more straightforward

* remove all unused functionality from ROOT macros

* align some functionality in Python script

* allow same threshold args for both rel-val and inspect command