### PR TITLE
fixed mother/daughter track IDs when joining  lists of particles

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorCocktail.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCocktail.C
@@ -33,15 +33,16 @@ class GeneratorCocktail_class : public Generator
       int nPart = mParticles.size();
       g->importParticles();
       for (auto p : g->getParticles()) {
-        if (p.GetFirstMother() > -1)
-          p.SetFirstMother(p.GetFirstMother() + nPart);
-        if (p.GetSecondMother() > -1)
-          p.SetLastMother(p.GetSecondMother() + nPart);
-        if (p.GetFirstDaughter() > -1)
-          p.SetFirstDaughter(p.GetFirstDaughter() + nPart);
-        if (p.GetLastDaughter() > -1)
-          p.SetLastDaughter(p.GetLastDaughter() + nPart);
         mParticles.push_back(p);
+        auto& pEdit = mParticles.back();
+        if (pEdit.GetFirstMother() > -1)
+          pEdit.SetFirstMother(pEdit.GetFirstMother() + nPart);
+        if (pEdit.GetSecondMother() > -1)
+          pEdit.SetLastMother(pEdit.GetSecondMother() + nPart);
+        if (pEdit.GetFirstDaughter() > -1)
+          pEdit.SetFirstDaughter(pEdit.GetFirstDaughter() + nPart);
+        if (pEdit.GetLastDaughter() > -1)
+          pEdit.SetLastDaughter(pEdit.GetLastDaughter() + nPart);
       }
       g->clearParticles();
     }
@@ -53,6 +54,11 @@ class GeneratorCocktail_class : public Generator
     for (int in = 0; in < ntimes; in++)
       mEntries->push_back(gen);
     return;
+  };
+
+  std::vector<Generator*>* getGenerators()
+  {
+    return mEntries;
   };
 
  private:

--- a/MC/config/PWGDQ/external/generator/GeneratorCocktail.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCocktail.C
@@ -30,9 +30,19 @@ class GeneratorCocktail_class : public Generator
   bool importParticles() override
   {
     for (auto& g : *mEntries) {
+      int nPart = mParticles.size();
       g->importParticles();
-      for (auto& p : g->getParticles())
+      for (auto p : g->getParticles()) {
+        if (p.GetFirstMother() > -1)
+          p.SetFirstMother(p.GetFirstMother() + nPart);
+        if (p.GetSecondMother() > -1)
+          p.SetLastMother(p.GetSecondMother() + nPart);
+        if (p.GetFirstDaughter() > -1)
+          p.SetFirstDaughter(p.GetFirstDaughter() + nPart);
+        if (p.GetLastDaughter() > -1)
+          p.SetLastDaughter(p.GetLastDaughter() + nPart);
         mParticles.push_back(p);
+      }
       g->clearParticles();
     }
     return true;


### PR DESCRIPTION
The mother/daughter track IDs get messed up when the list of particles from different generators in the vector of generators of the cocktail are joined at importParticles(). Should be shifted according to the position in new (full) list of particles. Please check if this makes sense.