### PR TITLE
Making script flexible to run on non-EPN or EPN GRID env, and on TFs

### DIFF
--- a/DATA/production/configurations/2021/ctf_recreation/ctf_recreation.sh
+++ b/DATA/production/configurations/2021/ctf_recreation/ctf_recreation.sh
@@ -111,7 +111,6 @@ ls -altr
 
 rm -f /dev/shm/*
 
-unset WORKFLOW_PARAMETER
 export WORKFLOW_PARAMETERS=CTF
 if [[ -f "setenv_extra_ctf_recreation_$DETCONFIG.sh" ]]; then
     source setenv_extra_ctf_recreation_$DETCONFIG.sh 

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -128,7 +128,6 @@ export ARGS_EXTRA_PROCESS_o2_fv0_reco_workflow="--fv0-reconstructor"
 
 # ad-hoc settings for MFT
 export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.forceZeroField=false;MFTTracking.FullClusterScan=false;$MAXBCDIFFTOMASKBIAS_MFT"
-export ARGS_EXTRA_PROCESS_o2_mft_reco_workflow="$ARGS_EXTRA_PROCESS_mft_reco_workflow --run-assessment "
 
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -9,7 +9,7 @@ export SETENV_NO_ULIMIT=1
 export DPL_DEFAULT_PIPELINE_LENGTH=16
 
 # detector list
-export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT,MCH,TRD,EMC,PHS,CPV
+export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT,MCH,TRD,EMC,PHS,CPV,HMP,ZDC
 
 # ad-hoc settings for CTF reader: we are on the grid, we read the files remotely
 echo "*********************** mode = ${MODE}"


### PR DESCRIPTION
@catalinristea , this is what we discussed. 
@catalinristea , @davidrohr , @shahor02 : I also added the possibility to use the same script for starting the reco from TFs, depending again on an ALIEN variable:
```
+if [[ -n $ALIEN_INPUT_TYPE ]] && [[ "$ALIEN_INPUT_TYPE" == "TFs" ]]; then
+  unset WORKFLOW_PARAMETER
+  export WORKFLOW_PARAMETERS=CTF
+  INPUT_TYPE=TF
+  export TPC_CONVERT_LINKZS_TO_RAW=1
+else
+  INPUT_TYPE=CTF
+fi
...
 # reco and matching
 # print workflow
-env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=print TFDELAY=$TFDELAYSECONDS NTIMEFRAMES=-1 ./run-workflow-on-inputlist.sh CTF list.list > workflowconfig.log
+env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=print TFDELAY=$TFDELAYSECONDS NTIMEFRAMES=-1 ./run-workflow-on-inputlist.sh $INPUT_TYPE list.list > workflowconfig.log
 # run it
-env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=run TFDELAY=$TFDELAYSECONDS NTIMEFRAMES=-1 ./run-workflow-on-inputlist.sh CTF list.list
+env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=run TFDELAY=$TFDELAYSECONDS NTIMEFRAMES=-1 ./run-workflow-on-inputlist.sh $INPUT_TYPE list.list
```
What I am not sure, though, is whether then the various settings would need a different tuning. 
If so, we could have that in a different PR, provided the rest is fine with you. 
