### PR TITLE
force use of ALICEO2_CCDB_LOCALCACHE

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -1133,10 +1133,13 @@ class WorkflowExecutor:
         psutil.cpu_percent(interval=None)
         os.environ['JOBUTILS_SKIPDONE'] = "ON"
         # a bit ALICEO2+O2DPG specific but for now a convenient place to
-        # restore original behaviour of ALICEO2_CCDB_LOCALCACHE semantics
+        # force presence of ALICEO2_CCDB_LOCALCACHE (needed for MC)
         # TODO: introduce a proper workflow-globalinit section which is defined inside the workflow json
-        if os.environ.get('ALICEO2_CCDB_LOCALCACHE') != None:
-           os.environ['IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE'] = "ON"
+        # TODO: explicitely tell reco workflows where to pickup GRP from disc
+        if os.environ.get('ALICEO2_CCDB_LOCALCACHE') == None:
+           print ("ALICEO2_CCDB_LOCALCACHE not set; setting to default") 
+           os.environ['ALICEO2_CCDB_LOCALCACHE'] = os.getcwd() + "/.ccdb"
+        os.environ['IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE'] = "ON"
 
         errorencountered = False
 


### PR DESCRIPTION
tmprly done in the scheduler before we provide
this as a workflow property