### PR TITLE
Revert "Reenable logging for QC log files"

### DIFF
--- a/DATA/production/qc-sync/qc-global-epn.json
+++ b/DATA/production/qc-sync/qc-global-epn.json
@@ -23,10 +23,7 @@
       },
       "infologger": {
         "filterDiscardDebug": "true",
-        "filterDiscardLevel": "1",
-        "filterDiscardFile": "../../qc-_ID_.log",
-        "filterRotateMaxBytes": "100000000",
-        "filterRotateMaxFiles": "2"
+        "filterDiscardLevel": "1"
       }
     }
   }


### PR DESCRIPTION
This reverts commit 8e5c89e701ccce473e35ff5d99d1c8707e8bb0c4.

Still produces excessive log files