### PR TITLE
Fixes for qc-workflow.sh

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -190,6 +190,17 @@ if [[ -z "${WORKFLOW_DETECTORS_CTF+x}" ]] || [[ "0$WORKFLOW_DETECTORS_CTF" == "0
 if [[ "0$WORKFLOW_DETECTORS_FLP_PROCESSING" == "0ALL" ]]; then export WORKFLOW_DETECTORS_FLP_PROCESSING=$WORKFLOW_DETECTORS; fi
 if [[ -z "$WORKFLOW_PARAMETERS" ]]; then export WORKFLOW_PARAMETERS=; fi
 
+if [[ ! -z $WORKFLOW_DETECTORS_EXCLUDE_QC ]]; then
+  for i in $(echo $WORKFLOW_DETECTORS_EXCLUDE_QC | sed "s/,/ /g"); do
+    export WORKFLOW_DETECTORS_QC=$(echo $WORKFLOW_DETECTORS_QC | sed -e "s/,$i,/,/g" -e "s/^$i,//" -e "s/,$i"'$'"//" -e "s/^$i"'$'"//")
+  done
+fi
+if [[ ! -z $WORKFLOW_DETECTORS_EXCLUDE_CALIB ]]; then
+  for i in $(echo $WORKFLOW_DETECTORS_EXCLUDE_CALIB | sed "s/,/ /g"); do
+    export WORKFLOW_DETECTORS_CALIB=$(echo $WORKFLOW_DETECTORS_CALIB | sed -e "s/,$i,/,/g" -e "s/^$i,//" -e "s/,$i"'$'"//" -e "s/^$i"'$'"//")
+  done
+fi
+
 if [[ -z "$TFLOOP" ]];        then export TFLOOP=0; fi                    # loop over timeframes
 if [[ -z "$NTIMEFRAMES" ]];   then export NTIMEFRAMES=-1; fi              # max number of time frames to process, <=0 : unlimited
 if [[ -z "$CTFDICT_NTF" ]];   then export CTFDICT_NTF=100; fi             # auto-save CTF dictionary after each CTFDICT_NTF TFs (if > 0)

--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -191,12 +191,12 @@ if [[ "0$WORKFLOW_DETECTORS_FLP_PROCESSING" == "0ALL" ]]; then export WORKFLOW_D
 if [[ -z "$WORKFLOW_PARAMETERS" ]]; then export WORKFLOW_PARAMETERS=; fi
 
 if [[ ! -z $WORKFLOW_DETECTORS_EXCLUDE_QC ]]; then
-  for i in $(echo $WORKFLOW_DETECTORS_EXCLUDE_QC | sed "s/,/ /g"); do
+  for i in ${WORKFLOW_DETECTORS_EXCLUDE_QC//,/ }; do
     export WORKFLOW_DETECTORS_QC=$(echo $WORKFLOW_DETECTORS_QC | sed -e "s/,$i,/,/g" -e "s/^$i,//" -e "s/,$i"'$'"//" -e "s/^$i"'$'"//")
   done
 fi
 if [[ ! -z $WORKFLOW_DETECTORS_EXCLUDE_CALIB ]]; then
-  for i in $(echo $WORKFLOW_DETECTORS_EXCLUDE_CALIB | sed "s/,/ /g"); do
+  for i in ${WORKFLOW_DETECTORS_EXCLUDE_CALIB//,/ }; do
     export WORKFLOW_DETECTORS_CALIB=$(echo $WORKFLOW_DETECTORS_CALIB | sed -e "s/,$i,/,/g" -e "s/^$i,//" -e "s/,$i"'$'"//" -e "s/^$i"'$'"//")
   done
 fi

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -158,10 +158,10 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
 
   # GLO QC: VTX and ITSTPC_MTCH
   if has_detectors_reco ITS && has_detector_matching PRIMVTX; then
-    add_QC_JSON GLO $QC_JSON_GLO_VTX
+    add_QC_JSON GLO_PRIMVTX $QC_JSON_GLO_VTX
   fi
   if has_detectors_reco ITS TPC && has_detector_matching ITSTPC; then
-    add_QC_JSON GLO $QC_JSON_GLO_ITSTPC_MTCH
+    add_QC_JSON GLO_ITSTPC $QC_JSON_GLO_ITSTPC_MTCH
   fi
 
   # PID QC

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -149,14 +149,14 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     add_QC_JSON matchTOF ${QC_JSON_TOF_MATCH}
   fi
 
-  for i in $(echo $LIST_OF_DETECTORS | sed "s/,/ /g"); do
+  for i in ${LIST_OF_DETECTORS//,/ }; do
     DET_JSON_FILE="QC_JSON_$i"
     if has_detector_qc $i && [ ! -z "${!DET_JSON_FILE}" ]; then
       add_QC_JSON $i ${!DET_JSON_FILE}
     fi
   done
 
-  for i in $(echo $LIST_OF_GLORECO | sed "s/,/ /g"); do
+  for i in ${LIST_OF_GLORECO//,/ }; do
     DET_JSON_FILE="QC_JSON_GLO_$i"
     if has_matching_qc $i && [ ! -z "${!DET_JSON_FILE}" ]; then
       if [[ $i == "PRIMVTX" ]] && ! has_detector_reco ITS; then continue; fi
@@ -166,8 +166,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
   done
 
   # PID QC
-  for i in $(echo $LIST_OF_PID | sed "s/,/ /g"); do
-    PIDDETFORFILE=$(echo $i | sed "s/-//g")
+  for i in ${LIST_OF_PID//,/ }; do
+    PIDDETFORFILE=${i//-/}
     PID_JSON_FILE="QC_JSON_PID_$PIDDETFORFILE"
     if has_pid_qc $i && [ ! -z "${!PID_JSON_FILE}" ]; then
       add_QC_JSON pid$i ${!PID_JSON_FILE}

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -56,8 +56,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=consul://o2/components/qc/ANY/any/cpv-physics-qcmn-epn
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=consul://o2/components/qc/ANY/any/trd-full-qcmn-nopulseheight-epn
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=consul://o2/components/qc/ANY/any/phos-raw-clusters-epn
-    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_GLO=consul://o2/components/qc/ANY/any/glo-vtx-qcmn-epn
-    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_GLO=consul://o2/components/qc/ANY/any/glo-itstpc-mtch-qcmn-epn
+    [[ -z "$QC_JSON_GLO_PRIMVTX" ]] && QC_JSON_GLO_PRIMVTX=consul://o2/components/qc/ANY/any/glo-vtx-qcmn-epn
+    [[ -z "$QC_JSON_GLO_ITSTPC" ]] && QC_JSON_GLO_ITSTPC=consul://o2/components/qc/ANY/any/glo-itstpc-mtch-qcmn-epn
     if [[ -z "$QC_JSON_TOF_MATCH" ]]; then
       if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
         QC_JSON_TOF_MATCH=consul://o2/components/qc/ANY/any/tof-qcmn-match-itstpctrdtof
@@ -87,8 +87,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=$O2DPG_ROOT/DATA/production/qc-sync/cpv.json
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=$O2DPG_ROOT/DATA/production/qc-sync/phs.json
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=$O2DPG_ROOT/DATA/production/qc-sync/trd.json
-    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_GLO=$O2DPG_ROOT/DATA/production/qc-sync/glo-vtx-qcmn-epn.json
-    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_GLO=$O2DPG_ROOT/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
+    [[ -z "$QC_JSON_GLO_PRIMVTX" ]] && QC_JSON_GLO_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-sync/glo-vtx-qcmn-epn.json
+    [[ -z "$QC_JSON_GLO_ITSTPC" ]] && QC_JSON_GLO_ITSTPC=$O2DPG_ROOT/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
     if [[ -z "$QC_JSON_TOF_MATCH" ]]; then
       if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
         QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-sync/itstpctrdtof.json
@@ -111,8 +111,8 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=$O2DPG_ROOT/DATA/production/qc-async/phs.json
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=$O2DPG_ROOT/DATA/production/qc-async/trd.json
     # the following two ($QC_JSON_PRIMVTX and $QC_JSON_ITSTPC) replace $QC_JSON_GLO for async processing
-    [[ -z "$QC_JSON_GLO_VTX" ]] && QC_JSON_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-async/primvtx.json
-    [[ -z "$QC_JSON_GLO_ITSTPC_MTCH" ]] && QC_JSON_ITSTPC=$O2DPG_ROOT/DATA/production/qc-async/itstpc.json
+    [[ -z "$QC_JSON_GLO_PRIMVTX" ]] && QC_JSON_GLO_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-async/primvtx.json
+    [[ -z "$QC_JSON_GLO_ITSTPC" ]] && QC_JSON_GLO_ITSTPC=$O2DPG_ROOT/DATA/production/qc-async/itstpc.json
     [[ -z "$QC_JSON_TOF_MATCH" ]] && QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-async/itstpctof.json
     [[ -z "$QC_JSON_PID_FT0TOF" ]] && QC_JSON_PID_FT0TOF=$O2DPG_ROOT/DATA/production/qc-async/pidft0tof.json
     [[ -z "$QC_JSON_GLOBAL" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-async/qc-global.json # this must be last
@@ -156,13 +156,14 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     fi
   done
 
-  # GLO QC: VTX and ITSTPC_MTCH
-  if has_detectors_reco ITS && has_detector_matching PRIMVTX; then
-    add_QC_JSON GLO_PRIMVTX $QC_JSON_GLO_VTX
-  fi
-  if has_detectors_reco ITS TPC && has_detector_matching ITSTPC; then
-    add_QC_JSON GLO_ITSTPC $QC_JSON_GLO_ITSTPC_MTCH
-  fi
+  for i in $(echo $LIST_OF_GLORECO | sed "s/,/ /g"); do
+    DET_JSON_FILE="QC_JSON_GLO_$i"
+    if has_matching_qc $i && [ ! -z "${!DET_JSON_FILE}" ]; then
+      if [[ $i == "PRIMVTX" ]] && ! has_detector_reco ITS; then continue; fi
+      if [[ $i == "ITSTPC" ]] && ! has_detectors_reco ITS TPC; then continue; fi
+      add_QC_JSON GLO_$i ${!DET_JSON_FILE}
+    fi
+  done
 
   # PID QC
   for i in $(echo $LIST_OF_PID | sed "s/,/ /g"); do


### PR DESCRIPTION
@chiarazampolli @knopers8 : QC tasks should not be added solely by the presense of the detector, but only if requested in the list of QC tasks. Note that the default list of QC tasks is the list available detectors + $LIST_OF_GLORECO.