### PR TITLE
Add CTP in production

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -9,7 +9,7 @@ export SETENV_NO_ULIMIT=1
 export DPL_DEFAULT_PIPELINE_LENGTH=16
 
 # detector list
-export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT,MCH,TRD,EMC,PHS,CPV,HMP,ZDC
+export WORKFLOW_DETECTORS=ITS,TPC,TOF,FV0,FT0,FDD,MID,MFT,MCH,TRD,EMC,PHS,CPV,HMP,ZDC,CTP
 
 # ad-hoc settings for CTF reader: we are on the grid, we read the files remotely
 echo "*********************** mode = ${MODE}"


### PR DESCRIPTION
Hi @noferini, @chiarazampolli

Here is the commit to add  CTP to the list of detectors for async reco.
Please review and merge if you find it appropriate.

Mail from Evgeny,
_I am trying to understand what is going on with ctp info in Run3 AO2Ds. According to Roman, ctp readout is available for all runs taken after 24/09/22 16:24 and the ctp reco workflow was ready before that. AO2D producer seems to support CTP info as well. However, I still see zeros in the trigger mask stored in AO2Ds that is supposed to be filled from CTP digits. It seems the reason is that o2-ctp-reco-workflow is not yet included in the reconstruction chain._

Follow-up from Francesco,
_I checked in the dpl-workflow.sh and it seems that the option is already there.
I guess it should be enough to add CTP to the detector list._

Thanks!

Yours, Catalin.
