### PR TITLE
Prevent two timeframes from having the same seed 

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
@@ -68,7 +68,11 @@ FairGenerator*
   gen->SetForceDecay(kEvtBJpsiDiMuon);
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
   // print debug
   // gen->PrintDebug();
 

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
@@ -31,7 +31,11 @@ GeneratorBeautyToMu_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -
   gen->SetForceDecay(kEvtSemiMuonic);
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
   // print debug
   // gen->PrintDebug();
 

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
@@ -32,7 +32,11 @@ FairGenerator*
   gen->SetForceDecay(kEvtBPsiDiElectron);
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
   // print debug
   // gen->PrintDebug();
 
@@ -62,7 +66,11 @@ FairGenerator*
   gen->SetForceDecay(kEvtBPsiDiMuon);
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
   // print debug
   // gen->PrintDebug();
 

--- a/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
@@ -31,7 +31,11 @@ GeneratorCharmToMu_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2
   gen->SetForceDecay(kEvtSemiMuonic);
   // set random seed
   gen->readString("Random:setSeed on");
-  gen->readString("Random:seed = 0");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
   // print debug
   // gen->PrintDebug();
 


### PR DESCRIPTION
Prevent two timeframes from having the same seed using urandom instead of the pythia random seed method