### PR TITLE
merging TTrees from DF_<...> subdirectories in AO2D files

### DIFF
--- a/RelVal/ExtractAndFlatten.C
+++ b/RelVal/ExtractAndFlatten.C
@@ -2,8 +2,9 @@
 #include <string>
 #include <vector>
 
-void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::string const& basedOnTree = "", std::string const& currentPrefix = "", std::vector<std::string>* includeDirs = nullptr);
+void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::vector<TList*>& treeList, std::string const& basedOnTree = "", std::string const& currentPrefix = "", std::vector<std::string>* includeDirs = nullptr);
 void ExtractTree(TTree* tree, TDirectory* outDir, std::string const& basedOnTree = "", std::string const& currentPrefix = "");
+void AddTree(TTree* tree, std::vector<TList*>& treeList);
 void ExtractFromMonitorObjectCollection(o2::quality_control::core::MonitorObjectCollection* o2MonObjColl, TDirectory* outDir, std::string const& currentPrefix = "");
 void WriteHisto(TH1* obj, TDirectory* outDir, std::string const& currentPrefix = "");
 void WriteProfile(TProfile* obj, TDirectory* outDir, std::string const& currentPrefix = "");
@@ -57,7 +58,18 @@ void ExtractAndFlatten(std::string const& filename, std::string const& outputFil
     return;
   }
   TFile extractedFile(outputFilename.c_str(), "UPDATE");
-  ExtractAndFlattenDirectory(&inFile, &extractedFile, basedOnTree, "", includeDirs);
+  std::vector<TList*> treeList;
+  ExtractAndFlattenDirectory(&inFile, &extractedFile, treeList, basedOnTree, "", includeDirs);
+
+  for(std::vector<TList*>::iterator list = treeList.begin(); list != treeList.end(); ++list) {
+    TTree* mergedTree = TTree::MergeTrees((*list));
+    if (mergedTree){
+      ExtractTree(mergedTree, &extractedFile, basedOnTree, "DF_merged");
+    } else {
+      std::cerr << "WARNING: Empty TTree " << (*list)->First()->GetName()  << ", skipping." << "\n";
+    }
+  }
+  
   inFile.Close();
   extractedFile.Close();
 }
@@ -109,7 +121,7 @@ bool checkIncludePath(std::string thisPath, std::vector<std::string>*& includeDi
 }
 
 // Read from a given input directory and write everything found there (including sub directories) to a flat output directory
-void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::string const& basedOnTree, std::string const& currentPrefix, std::vector<std::string>* includeDirs)
+void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::vector<TList*>& treeList ,std::string const& basedOnTree, std::string const& currentPrefix, std::vector<std::string>* includeDirs)
 {
 
   if (!checkIncludePath(inDir->GetPath(), includeDirs)) {
@@ -121,7 +133,7 @@ void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::stri
     auto obj = key->ReadObj();
     if (auto nextInDir = dynamic_cast<TDirectory*>(obj)) {
       // recursively scan TDirectory
-      ExtractAndFlattenDirectory(nextInDir, outDir, basedOnTree, currentPrefix + nextInDir->GetName() + "_", includeDirs);
+      ExtractAndFlattenDirectory(nextInDir, outDir, treeList, basedOnTree, currentPrefix + nextInDir->GetName() + "_", includeDirs);
     } else if (auto qcMonitorCollection = dynamic_cast<o2::quality_control::core::MonitorObjectCollection*>(obj)) {
       auto qcMonPath = std::string(inDir->GetPath()) + "/" + qcMonitorCollection->GetName();
       auto includeDirsCache = includeDirs;
@@ -130,13 +142,32 @@ void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::stri
       }
       ExtractFromMonitorObjectCollection(qcMonitorCollection, outDir, currentPrefix);
     } else if (auto tree = dynamic_cast<TTree*>(obj)) {
-      ExtractTree(tree, outDir, basedOnTree, currentPrefix);
+      if (currentPrefix.rfind("DF_", 0) == 0) {
+        AddTree(tree, treeList);
+      }
+      else {
+        ExtractTree(tree, outDir, basedOnTree, currentPrefix);
+      }
     } else {
       if (!WriteObject(obj, outDir, currentPrefix)) {
         std::cerr << "Cannot handle object " << obj->GetName() << " which is of class " << key->GetClassName() << "\n";
       }
     }
   }
+}
+
+void AddTree(TTree* tree, std::vector<TList*>& treeList)
+{
+  for(std::vector<TList*>::iterator list = treeList.begin(); list != treeList.end(); ++list) {
+    if (!std::strcmp(tree->GetName(),(*list)->First()->GetName())){
+      (*list)->Add(tree);
+      return;
+    }
+  }
+  TList* newList = new TList;
+  newList->Add(tree);
+  treeList.push_back(newList);
+  return;
 }
 
 void ExtractTree(TTree* tree, TDirectory* outDir, std::string const& basedOnTree, std::string const& currentPrefix)


### PR DESCRIPTION
ExtractAndFlatten now detects DF_<...> substructure in AO2D files, and then merges all TTrees with the same name from different subdirectories into one DF_merged_... object.

Crashes on some AO2Ds (e.g. LHC21k6). Seem to be those that have two trees with the same name (why?),  o2mcparticle_001;1 and o2mcparticle_001;2

