### PR TITLE
Send CTP digits required by RecoContainer logic

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -167,7 +167,10 @@ if [[ -z $CALIBDATASPEC_BARREL_TF ]]; then
   # TPC
   if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "unbinnedTPCResiduals:GLO/UNBINNEDRES/0"; fi
   if [[ $CALIB_TPC_SCDCALIB == 1 ]] && [[ 0$CALIB_TPC_SCDCALIB_SENDTRKDATA == "01" ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "tpcInterpTrkData:GLO/TRKDATA/0"; fi
-  if [[ $CALIB_TPC_SCDCALIB == 1 ]] && [[ $CALIB_TPC_SCDCALIB_CTP_INPUT == "--enable-ctp" ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "lumi:CTP/LUMI/0"; fi
+  if [[ $CALIB_TPC_SCDCALIB == 1 ]] && [[ $CALIB_TPC_SCDCALIB_CTP_INPUT == "--enable-ctp" ]]; then
+    add_semicolon_separated CALIBDATASPEC_BARREL_TF "lumi:CTP/LUMI/0"
+    add_semicolon_separated CALIBDATASPEC_BARREL_TF "ctpdigi:CTP/DIGITS/0"
+  fi
   if [[ $CALIB_TPC_VDRIFTTGL == 1 ]]; then add_semicolon_separated CALIBDATASPEC_BARREL_TF "tpcvdtgl:GLO/TPCITS_VDTGL/0"; fi
 
   # TRD


### PR DESCRIPTION
I tested only with local aggregator and there it was fine. Now with the proxy the CTP/DIGITS input is missing which is required when using the RecoContainer logic for loading the CTP input:
https://github.com/AliceO2Group/AliceO2/blob/7a344162ae2735fa5f436bb48248b588e3e861b5/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx#L403-L412
