### PR TITLE
Do not use --condition-not-after for QC

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -995,7 +995,7 @@ for tf in range(1, NTIMEFRAMES + 1):
        task['cmd'] = f'{readerCommand} | o2-qc --config {configFilePath}' + \
                      f' --local-batch ../{qcdir}/{objectsFile}' + \
                      f' --override-values "qc.config.Activity.number={args.run};qc.config.Activity.periodName={args.productionTag};qc.config.Activity.start={args.timestamp}"' + \
-                     ' ' + getDPL_global_options()
+                     ' ' + getDPL_global_options(ccdbbackend=False)
        # Prevents this task from being run for multiple TimeFrames at the same time, thus trying to modify the same file.
        task['semaphore'] = objectsFile
        workflow['stages'].append(task)


### PR DESCRIPTION
QC does not have this argument. Seen on alibi nightlies:
```
[ERROR] error parsing options of o2-qc: unrecognised option '--condition-not-after'
```