### PR TITLE
merging TTrees form AO2D files

### DIFF
--- a/RelVal/ExtractAndFlatten.C
+++ b/RelVal/ExtractAndFlatten.C
@@ -2,8 +2,9 @@
 #include <string>
 #include <vector>
 
-void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::string const& basedOnTree = "", std::string const& currentPrefix = "", std::vector<std::string>* includeDirs = nullptr);
+void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::vector<TList*>& treeList, std::string const& basedOnTree = "", std::string const& currentPrefix = "", std::vector<std::string>* includeDirs = nullptr);
 void ExtractTree(TTree* tree, TDirectory* outDir, std::string const& basedOnTree = "", std::string const& currentPrefix = "");
+void AddTree(TTree* tree, std::vector<TList*>& treeList);
 void ExtractFromMonitorObjectCollection(o2::quality_control::core::MonitorObjectCollection* o2MonObjColl, TDirectory* outDir, std::string const& currentPrefix = "");
 void WriteHisto(TH1* obj, TDirectory* outDir, std::string const& currentPrefix = "");
 void WriteProfile(TProfile* obj, TDirectory* outDir, std::string const& currentPrefix = "");
@@ -57,7 +58,18 @@ void ExtractAndFlatten(std::string const& filename, std::string const& outputFil
     return;
   }
   TFile extractedFile(outputFilename.c_str(), "UPDATE");
-  ExtractAndFlattenDirectory(&inFile, &extractedFile, basedOnTree, "", includeDirs);
+  std::vector<TList*> treeList;
+  ExtractAndFlattenDirectory(&inFile, &extractedFile, treeList, basedOnTree, "", includeDirs);
+
+  for(std::vector<TList*>::iterator list = treeList.begin(); list != treeList.end(); ++list) {
+    TTree* mergedTree = TTree::MergeTrees((*list));
+    if (mergedTree){
+      ExtractTree(mergedTree, &extractedFile, basedOnTree, "DF_merged");
+    } else {
+      std::cerr << "WARNING: Empty TTree " << (*list)->First()->GetName()  << ", skipping." << "\n";
+    }
+  }
+  
   inFile.Close();
   extractedFile.Close();
 }
@@ -109,7 +121,7 @@ bool checkIncludePath(std::string thisPath, std::vector<std::string>*& includeDi
 }
 
 // Read from a given input directory and write everything found there (including sub directories) to a flat output directory
-void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::string const& basedOnTree, std::string const& currentPrefix, std::vector<std::string>* includeDirs)
+void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::vector<TList*>& treeList ,std::string const& basedOnTree, std::string const& currentPrefix, std::vector<std::string>* includeDirs)
 {
 
   if (!checkIncludePath(inDir->GetPath(), includeDirs)) {
@@ -121,7 +133,7 @@ void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::stri
     auto obj = key->ReadObj();
     if (auto nextInDir = dynamic_cast<TDirectory*>(obj)) {
       // recursively scan TDirectory
-      ExtractAndFlattenDirectory(nextInDir, outDir, basedOnTree, currentPrefix + nextInDir->GetName() + "_", includeDirs);
+      ExtractAndFlattenDirectory(nextInDir, outDir, treeList, basedOnTree, currentPrefix + nextInDir->GetName() + "_", includeDirs);
     } else if (auto qcMonitorCollection = dynamic_cast<o2::quality_control::core::MonitorObjectCollection*>(obj)) {
       auto qcMonPath = std::string(inDir->GetPath()) + "/" + qcMonitorCollection->GetName();
       auto includeDirsCache = includeDirs;
@@ -130,13 +142,32 @@ void ExtractAndFlattenDirectory(TDirectory* inDir, TDirectory* outDir, std::stri
       }
       ExtractFromMonitorObjectCollection(qcMonitorCollection, outDir, currentPrefix);
     } else if (auto tree = dynamic_cast<TTree*>(obj)) {
-      ExtractTree(tree, outDir, basedOnTree, currentPrefix);
+      if (currentPrefix.rfind("DF_", 0) == 0) {
+        AddTree(tree, treeList);
+      }
+      else {
+        ExtractTree(tree, outDir, basedOnTree, currentPrefix);
+      }
     } else {
       if (!WriteObject(obj, outDir, currentPrefix)) {
         std::cerr << "Cannot handle object " << obj->GetName() << " which is of class " << key->GetClassName() << "\n";
       }
     }
   }
+}
+
+void AddTree(TTree* tree, std::vector<TList*>& treeList)
+{
+  for(std::vector<TList*>::iterator list = treeList.begin(); list != treeList.end(); ++list) {
+    if (!std::strcmp(tree->GetName(),(*list)->First()->GetName())){
+      (*list)->Add(tree);
+      return;
+    }
+  }
+  TList* newList = new TList;
+  newList->Add(tree);
+  treeList.push_back(newList);
+  return;
 }
 
 void ExtractTree(TTree* tree, TDirectory* outDir, std::string const& basedOnTree, std::string const& currentPrefix)

--- a/RelVal/o2dpg_release_validation.py
+++ b/RelVal/o2dpg_release_validation.py
@@ -336,7 +336,8 @@ def plot_values_thresholds(summary, out_dir, title, include_patterns=None, exclu
     test_histo_value_map = extract_from_summary(summary, ["value", "threshold"], include_patterns, exclude_patterns)
 
     for which_test, histos_values_thresolds in test_histo_value_map.items():
-
+        if which_test == REL_VAL_TEST_SUMMARY_NAME:
+            continue
         figure, ax = plt.subplots(figsize=(20, 20))
         ax.plot(range(len(histos_values_thresolds["histograms"])), histos_values_thresolds["value"], label="values", marker="x")
         ax.plot(range(len(histos_values_thresolds["histograms"])), histos_values_thresolds["threshold"], label="thresholds", marker="o")
@@ -365,6 +366,8 @@ def plot_compare_summaries(summaries, fields, out_dir, *, labels=None, include_p
         labels = [f"summary_{i}" for i, _ in enumerate(summaries)]
 
     for test_name in test_names:
+        if test_name == REL_VAL_TEST_SUMMARY_NAME:
+            continue
         histogram_names_intersection = []
         # First we figure out the intersection of histograms ==> histograms in common
         for test_histo_value_map in test_histo_value_maps:
@@ -1001,7 +1004,6 @@ def main():
     inspect_parser = sub_parsers.add_parser("inspect", parents=[common_threshold_parser, common_pattern_parser])
     inspect_parser.add_argument("path", help="either complete file path to a Summary.json or SummaryGlobal.json or directory where one of the former is expected to be")
     inspect_parser.add_argument("--plot", action="store_true", help="Plot the summary grid")
-    inspect_parser.add_argument("--print", action="store_true", help="Print the summary on the screen")
     inspect_parser.add_argument("--flags", nargs="*", help="extract all objects which have at least one test with this severity flag", choices=list(REL_VAL_SEVERITY_MAP.keys()))
     inspect_parser.add_argument("--output", "-o", help="output directory, by default points to directory where the Summary.json was found")
     inspect_parser.set_defaults(func=inspect)


### PR DESCRIPTION
- removed `--print` option from `inspect` command
- removed empty plot test_values_thresholds_summary.png
- implemented merging of trees from different DF_\<number>  subdirectories in AO2D files at the histogram level (instead of first merging the trees and then writing it to a histogram)
                  -  advantage: Merging many trees from many DF directories can become very large. Writing each tree immediately to a histogram and then adding only the histograms avoids this problem.
                  - disadvantage: The first DF directory sets the binning and the histogram range for all following trees. Most physical distributions should be very similar in the different DFs, so it should not be a problem. But e.g. for IndexTables this can for sure cut away some parts of later trees, but I think it is anyhow questionable how much sense it makes to merge IndexTables from different DFs, write them to a histogram and then do a shape comparison of that histogram with another one from another AO2D. 