### PR TITLE
Option to use pregenerated collision context in simulation

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -148,8 +148,7 @@ class Graph:
  
             # increment in-degree of destination vertex by 1
             self.indegree[dest] = self.indegree[dest] + 1
- 
- 
+
 # Recursive function to find all topological orderings of a given DAG
 def findAllTopologicalOrders(graph, path, discovered, N, allpaths, maxnumber=1):
     if len(allpaths) >= maxnumber:


### PR DESCRIPTION
This introduces the possibility (using argument --pregenCollContext) to generate the collision/timeframe structure **before** the signal transport simulation, instead of the other way around.

This makes sure that, in particular for low interaction rates, a dynamic number of events per timeframe can be simulated.

I assume this mode will become the standard at some point.

Note that the scheme does not yet work with embedding.

Also applying a new limit to constrain TPC digits to within the timeframe limits (to prevent crashes in TPC clusterization).