### PR TITLE
fix tof qc jsons to include TRD when available

### DIFF
--- a/DATA/production/qc-async/itstpctofwtrd.json
+++ b/DATA/production/qc-async/itstpctofwtrd.json
@@ -1,0 +1,55 @@
+{
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ccdb-test.cern.ch:8080",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
+      },
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
+      },
+      "monitoring" : {
+        "url" : "infologger:///debug?qc"
+      },
+      "consul" : {
+        "url" : ""
+      },
+      "conditionDB" : {
+        "url" : "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks" : {
+      "MatchingTOF" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::TOFMatchedTracks",
+        "moduleName" : "QcTOF",
+        "detectorName" : "TOF",
+        "cycleDurationSeconds" : "60",
+        "maxNumberCycles" : "-1",
+        "dataSource" : {
+          "type" : "direct",
+          "query_comment" : "checking every matched track",
+          "query" : "tofcluster:TOF/CLUSTERS/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;matchITSTPCTOF:TOF/MTC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0;trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0;trackTPCTRD:TRD/MATCH_TPC/0;trigTPCTRD:TRD/TRGREC_TPC/0;matchTPCTRDTOF:TOF/MTC_TPCTRD/0"
+        },
+        "taskParameters" : {
+          "GID" : "TPC,TPC-TOF,ITS-TPC,ITS-TPC-TOF,ITS-TPC-TRD,ITS-TPC-TRD-TOF,TPC-TRD,TPC-TRD-TOF",
+          "verbose" : "false",
+          "minPtCut" : "0.3f",
+          "etaCut" : "0.8f",
+          "minNTPCClustersCut" : "60",
+          "minDCACut" : "100.f",
+          "minDCACutY" : "10.f",
+          "grpFileName" : "o2sim_grp.root",
+          "geomFileName" : "o2sim_geometry-aligned.root"
+        },
+        "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF.root",
+        "" : "For debugging, path to the file where to save. If empty or missing it won't save."
+      }
+    }
+  },
+         "dataSamplingPolicies" : []
+}

--- a/DATA/production/qc-async/pidft0tofwtrd.json
+++ b/DATA/production/qc-async/pidft0tofwtrd.json
@@ -1,0 +1,62 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "ccdb-test.cern.ch:8080",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": ""
+            },
+            "conditionDB": {
+                "url": "ccdb-test.cern.ch:8080"
+            },
+            "infologger": {
+                "": "Configuration of the Infologger (optional).",
+                "filterDiscardDebug": "false",
+                "": "Set to true to discard debug and trace messages (default: false)",
+                "filterDiscardLevel": "21",
+                "": "Message at this level or above are discarded (default: 21 - Trace)"
+            }
+        },
+        "tasks": {
+            "TaskFT0TOF": {
+                "active": "true",
+                "className": "o2::quality_control_modules::pid::TaskFT0TOF",
+                "moduleName": "QcTOF",
+                "detectorName": "TOF",
+                "cycleDurationSeconds": "10",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query_comment": "checking every matched track",
+                    "query" : "tofcluster:TOF/CLUSTERS/0;recpoints:FT0/RECPOINTS/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;matchITSTPCTOF:TOF/MTC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0;trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0;trackTPCTRD:TRD/MATCH_TPC/0;trigTPCTRD:TRD/TRGREC_TPC/0;matchTPCTRDTOF:TOF/MTC_TPCTRD/0"
+                },
+                "taskParameters": {
+                    "GID" : "TPC,TPC-TOF,ITS-TPC,ITS-TPC-TOF,ITS-TPC-TRD,ITS-TPC-TRD-TOF,TPC-TRD,TPC-TRD-TOF",
+                    "verbose": "false",
+                    "minPtCut": "0.3f",
+                    "etaCut": "0.8f",
+                    "minNTPCClustersCut": "60",
+                    "useFT0": "true",
+                    "minDCACut": "100.f",
+                    "minDCACutY": "10.f",
+                    "grpFileName": "o2sim_grp.root",
+                    "geomFileName": "o2sim_geometry-aligned.root"
+                },
+                "": "For debugging, path to the file where to save. If empty or missing it won't save."
+            }
+        }
+    },
+    "dataSamplingPolicies": []
+}

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -115,8 +115,20 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     # the following two ($QC_JSON_PRIMVTX and $QC_JSON_ITSTPC) replace $QC_JSON_GLO for async processing
     [[ -z "$QC_JSON_GLO_PRIMVTX" ]] && QC_JSON_GLO_PRIMVTX=$O2DPG_ROOT/DATA/production/qc-async/primvtx.json
     [[ -z "$QC_JSON_GLO_ITSTPC" ]] && QC_JSON_GLO_ITSTPC=$O2DPG_ROOT/DATA/production/qc-async/itstpc.json
-    [[ -z "$QC_JSON_TOF_MATCH" ]] && QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-async/itstpctof.json
-    [[ -z "$QC_JSON_PID_FT0TOF" ]] && QC_JSON_PID_FT0TOF=$O2DPG_ROOT/DATA/production/qc-async/pidft0tof.json
+    if [[ -z "$QC_JSON_TOF_MATCH" ]]; then
+      if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
+        QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-async/itstpctofwtrd.json
+      elif has_tof_matching_source ITS-TPC; then
+        QC_JSON_TOF_MATCH=$O2DPG_ROOT/DATA/production/qc-async/itstpctof.json
+      fi
+    fi
+    if [[ -z "$QC_JSON_PID_FT0TOF" ]]; then
+      if has_tof_matching_source ITS-TPC && has_tof_matching_source ITS-TPC-TRD; then
+        QC_JSON_PID_FT0TOF=$O2DPG_ROOT/DATA/production/qc-async/pidft0tofwtrd.json
+      elif has_tof_matching_source ITS-TPC; then
+        QC_JSON_PID_FT0TOF=$O2DPG_ROOT/DATA/production/qc-async/pidft0tof.json
+      fi
+    fi
     [[ -z "$QC_JSON_GLOBAL" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-async/qc-global.json # this must be last
   fi
 


### PR DESCRIPTION
This is to use TRD tracks in TOF matching and PID QC (when available).
@ercolessi @njacazio 
