### PR TITLE
print subcommand and Kolmogorov

### DIFF
--- a/RelVal/o2dpg_release_validation.py
+++ b/RelVal/o2dpg_release_validation.py
@@ -279,11 +279,10 @@ def check_flags(tests, flags, flags_summary):
                 for f in flags_summary:
                     if test["result"] == f:
                         return True
-        else:
-            if flags:
-                for f in flags:
-                    if test["result"] == f:
-                        return True
+        elif flags:
+            for f in flags:
+                if test["result"] == f:
+                    return True
     return False
 
 
@@ -988,7 +987,7 @@ def dir_comp(args):
         json.dump(file_sizes_to_json, f, indent=2)
     return 0
 
-def printTable(args):
+def print_table(args):
     """
     Print the filtered histogram names of a Summary.json as list to screen
     """
@@ -1072,7 +1071,7 @@ def main():
 
     print_parser = sub_parsers.add_parser("print", parents=[common_pattern_parser, common_flags_parser])
     print_parser.add_argument("path", help="either complete file path to a Summary.json or SummaryGlobal.json or directory where one of the former is expected to be")
-    print_parser.set_defaults(func=printTable)
+    print_parser.set_defaults(func=print_table)
 
     file_size_parser = sub_parsers.add_parser("file-sizes", parents=[common_file_parser])
     file_size_parser.add_argument("--threshold", type=float, default=0.5, help="threshold for how far file sizes are allowed to diverge before warning")

--- a/RelVal/o2dpg_release_validation.py
+++ b/RelVal/o2dpg_release_validation.py
@@ -113,10 +113,11 @@ REL_VAL_SEVERITIES = ["GOOD", "WARNING", "NONCRIT_NC", "CRIT_NC", "BAD"]
 REL_VAL_SEVERITIES_USE_SUMMARY = [True, False, False, True, True]
 REL_VAL_SEVERITY_MAP = {v: i for i, v in enumerate(REL_VAL_SEVERITIES)}
 REL_VAL_SEVERITY_COLOR_MAP = {"GOOD": "green", "WARNING": "orange", "NONCRIT_NC": "cornflowerblue", "CRIT_NC": "navy", "BAD": "red"}
-REL_VAL_TEST_NAMES = ["chi2", "bin_cont", "num_entries"]
+REL_VAL_TEST_NAMES = ["chi2", "kolmogorov", "num_entries"]
 REL_VAL_TEST_NAMES_MAP = {v: i for i, v in enumerate(REL_VAL_TEST_NAMES)}
 REL_VAL_TEST_CRITICAL = [True, True, False]
-REL_VAL_TEST_DEFAULT_THRESHOLDS = [1.5, 1.5, 0.01]
+REL_VAL_TEST_DEFAULT_THRESHOLDS = [1.5, 0.5, 0.01]
+REL_VAL_TEST_UPPER_LOWER_THRESHOLD = [1, -1, 1]
 REL_VAL_TEST_SUMMARY_NAME = "summary"
 REL_VAL_TEST_NAMES_SUMMARY = REL_VAL_TEST_NAMES + [REL_VAL_TEST_SUMMARY_NAME]
 REL_VAL_TEST_NAMES_MAP_SUMMARY = {v: i for i, v in enumerate(REL_VAL_TEST_NAMES_SUMMARY)}
@@ -590,7 +591,7 @@ def make_single_summary(rel_val_dict, args, output_dir, include_patterns=None, e
             passed = True
             is_critical = REL_VAL_TEST_CRITICAL[test_id] or histo_name.find("_ratioFromTEfficiency") != -1
             if comparable:
-                passed = t["value"] <=  threshold
+                passed = t["value"]*REL_VAL_TEST_UPPER_LOWER_THRESHOLD[REL_VAL_TEST_NAMES_MAP[t["test_name"]]] <=  threshold*REL_VAL_TEST_UPPER_LOWER_THRESHOLD[REL_VAL_TEST_NAMES_MAP[t["test_name"]]]
 
             t["result"] = assign_result_flag(is_critical, comparable, passed)
 


### PR DESCRIPTION
- new `print` subcommand
    - filters with `--include-patterns`, `--exclude-patterns`, `--flags` and `--flags-summary`
    - for the moment prints only names of histograms to screen. More information could be added
- new `--flags-summary` filter also for `inspect` subcommand
    - now uses all filters also for plotting test_values_thresholds_{TESTNAME}.png  (missing before) and pie charts (probably anyhow not useful when using filter on flags)
- switched to ROOT's Kolmogorov test instead of bin_cont test
    - for the moment uses the probability that ROOT returns as a metric. Could also use directly the Kolmogorov distance?
    - still have to find reasonable value for default threshold for the Kolmogorov test