### PR TITLE
Adding possibility to re-run EMC calib and TPC residual extraction

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -28,11 +28,16 @@ if has_detector_calib ZDC && has_processing_step ZDC_RECO; then
 else
     CAN_DO_CALIB_ZDC_TDC=0;
 fi
+# for async recalibration
+if has_detector_calib EMC && has_detector_reco EMC && $EPNSYNCMODE != 1; then CAN_DO_CALIB_EMC_ASYNC_RECALIB=1; else CAN_DO_CALIB_EMC_ASYNC_RECALIB=0; fi
 
 # additional individual settings for calibration workflows
 has_detector CTP && export CALIB_TPC_SCDCALIB_CTP_INPUT="--enable-ctp"
 
 if [[ $BEAMTYPE != "cosmic" ]] || [[ $FORCECALIBRATIONS == 1 ]] ; then
+
+  # here we won't deal with calibrations only for async! e.g. EMC_ASYNC_RECALIB; we want that they are always explicitly enabled
+
   # calibrations for primary vertex
   if [[ $CAN_DO_CALIB_PRIMVTX_MEANVTX == 1 ]]; then
     if [[ -z ${CALIB_PRIMVTX_MEANVTX+x} ]]; then CALIB_PRIMVTX_MEANVTX=1; fi
@@ -133,6 +138,8 @@ fi
 ( [[ -z ${CALIB_PHS_L1PHASE} ]] || [[ $CAN_DO_CALIB_PHS_L1PHASE == 0 ]] ) && CALIB_PHS_L1PHASE=0
 ( [[ -z ${CALIB_CPV_GAIN} ]] || [[ $CAN_DO_CALIB_CPV_GAIN == 0 ]] ) && CALIB_CPV_GAIN=0
 ( [[ -z ${CALIB_ZDC_TDC} ]] || [[ $CAN_DO_CALIB_ZDC_TDC == 0 ]] ) && CALIB_ZDC_TDC=0
+# for async:
+( [[ -z ${CALIB_EMC_ASYNC_RECALIB} ]] || [[ $CAN_DO_CALIB_EMC_ASYNC_RECALIB == 0 ]] ) && CALIB_EMC_ASYNC_RECALIB=0
 
 if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_PRIMVTX_MEANVTX = $CALIB_PRIMVTX_MEANVTX" 1>&2
@@ -153,6 +160,8 @@ if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_TPC_SAC = $CALIB_TPC_SAC" 1>&2
   echo "CALIB_CPV_GAIN = $CALIB_CPV_GAIN" 1>&2
   echo "CALIB_ZDC_TDC = $CALIB_ZDC_TDC" 1>&2
+  echo "Calibrations for async:" 1>&2
+  echo "CALIB_EMC_ASYNC_RECALIB = $CALIB_EMC_ASYNC_RECALIB" 1>&2
 fi
 
 # define spec for proxy for TF-based outputs from BARREL

--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -29,7 +29,7 @@ else
     CAN_DO_CALIB_ZDC_TDC=0;
 fi
 # for async recalibration
-if has_detector_calib EMC && has_detector_reco EMC && $EPNSYNCMODE != 1; then CAN_DO_CALIB_EMC_ASYNC_RECALIB=1; else CAN_DO_CALIB_EMC_ASYNC_RECALIB=0; fi
+if has_detector_calib EMC && has_detector_reco EMC && $SYNCMODE != 1; then CAN_DO_CALIB_EMC_ASYNC_RECALIB=1; else CAN_DO_CALIB_EMC_ASYNC_RECALIB=0; fi
 
 # additional individual settings for calibration workflows
 has_detector CTP && export CALIB_TPC_SCDCALIB_CTP_INPUT="--enable-ctp"

--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -122,6 +122,14 @@ echo processing run $RUNNUMBER, from period $PERIOD with $BEAMTYPE collisions an
 echo "Checking current directory content"
 ls -altr
 
+if [[ -n "$ALIEN_JDL_DOEMCCALIB" ]]; then
+  export CALIB_EMC_ASYNC_RECALIB="$ALIEN_JDL_DOEMCCALIB"
+fi
+
+if [[ -n "$ALIEN_JDL_DOTPCRESIDUALEXTRACTION" ]]; then
+  export DO_TPC_RESIDUAL_EXTRACTION="$ALIEN_JDL_DOTPCRESIDUALEXTRACTION"
+fi
+
 if [[ -f "setenv_extra.sh" ]]; then
     source setenv_extra.sh $RUNNUMBER $BEAMTYPE
 else
@@ -181,6 +189,12 @@ if [[ ! -z "$ALIEN_JDL_DDSHMSIZE" ]]; then export DDSHMSIZE=$ALIEN_JDL_DDSHMSIZE
 # keeping AO2D.root QC.root o2calib_tof.root mchtracks.root mchclusters.root
 
 SETTING_ROOT_OUTPUT="ENABLE_ROOT_OUTPUT_o2_mch_reco_workflow= ENABLE_ROOT_OUTPUT_o2_tof_matcher_workflow= ENABLE_ROOT_OUTPUT_o2_aod_producer_workflow= ENABLE_ROOT_OUTPUT_o2_qc= "
+if [[ $DO_EMC_CALIB == "1" ]]; then
+  SETTING_ROOT_OUTPUT+="ENABLE_ROOT_OUTPUT_o2_emcal_emc_offline_calib_workflow= "
+fi
+if [[ $DO_TPC_RESIDUAL_EXTRACTION == "1" ]]; then
+  SETTING_ROOT_OUTPUT+="ENABLE_ROOT_OUTPUT_o2_calibration_residual_aggregator= "
+fi
 
 # to add extra output to always keep
 if [[ -n "$ALIEN_EXTRA_ENABLE_ROOT_OUTPUT" ]]; then
@@ -307,7 +321,9 @@ echo "[INFO (async_pass.sh)] envvars were set to TFDELAYSECONDS ${TFDELAYSECONDS
 # print workflow
 env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=print TFDELAY=$TFDELAYSECONDS ./run-workflow-on-inputlist.sh $INPUT_TYPE list.list > workflowconfig.log
 # run it
-env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=run TFDELAY=$TFDELAYSECONDS ./run-workflow-on-inputlist.sh $INPUT_TYPE list.list
+if [[ "0$RUN_WORKFLOW" != "00" ]]; then
+  env $SETTING_ROOT_OUTPUT IS_SIMULATED_DATA=0 WORKFLOWMODE=run TFDELAY=$TFDELAYSECONDS ./run-workflow-on-inputlist.sh $INPUT_TYPE list.list
+fi
 
 # now extract all performance metrics
 IFS=$'\n'

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -156,6 +156,31 @@ export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.forceZeroField=fal
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
 
+# possibly adding calib steps as done online
+# could be done better, so that more could be enabled in one go
+if [[ $DO_TPC_RESIDUAL_EXTRACTION == "1" ]]; then
+  export WORKFLOW_PARAMETERS="CALIB,CALIB_LOCAL_INTEGRATED_AGGREGATOR,${WORKFLOW_PARAMETERS}"
+  export CALIB_TPC_SCDCALIB_SENDTRKDATA=1
+  export CALIB_PRIMVTX_MEANVTX=0
+  export CALIB_TOF_LHCPHASE=0
+  export CALIB_TOF_CHANNELOFFSETS=0
+  export CALIB_TOF_DIAGNOSTICS=0
+  export CALIB_EMC_BADCHANNELCALIB=0
+  export CALIB_EMC_TIMECALIB=0
+  export CALIB_PHS_ENERGYCALIB=0
+  export CALIB_PHS_BADMAPCALIB=0
+  export CALIB_PHS_TURNONCALIB=0
+  export CALIB_PHS_RUNBYRUNCALIB=0
+  export CALIB_PHS_L1PHASE=0
+  export CALIB_TRD_VDRIFTEXB=0
+  export CALIB_TPC_TIMEGAIN=0
+  export CALIB_TPC_RESPADGAIN=0
+  export CALIB_TPC_VDRIFTTGL=0
+  export CALIB_CPV_GAIN=0
+  export CALIB_ZDC_TDC=0
+  export CALIB_FT0_TIMEOFFSET=0
+fi
+
 # Enabling AOD
 export WORKFLOW_PARAMETERS="AOD,${WORKFLOW_PARAMETERS}"
 


### PR DESCRIPTION
This is to have the possibility to run some calib at async stage. 
I use setenv_calib.sh in conjunction with calib-workflow.sh (in O2, PR being opened) to be allowed to use all the wrokflow-setup etc functionalities. 
I took this PR to also include the switch to attach the residual extraction, which is in the apass1_TPCcalib
@davidrohr : this touches the scripts used also in sync processing, so could you please check?
Pinging also:
@mfasDa 
@ehellbar 
@wiechula 
@catalinristea 