### PR TITLE
add delay in tof digit reader

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1056,7 +1056,7 @@ for tf in range(1, NTIMEFRAMES + 1):
      ### TOF
      addQCPerTF(taskName='tofDigitsQC',
                 needs=[getDigiTaskName("TOF")],
-                readerCommand='${O2_ROOT}/bin/o2-tof-reco-workflow --input-type digits --output-type none',
+                readerCommand='${O2_ROOT}/bin/o2-tof-reco-workflow --reader-delay 3 --input-type digits --output-type none',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tofdigits.json',
                 objectsFile='tofDigitsQC.root')
 

--- a/MC/config/QC/json/tofdigits.json
+++ b/MC/config/QC/json/tofdigits.json
@@ -122,7 +122,7 @@
       "samplingConditions": [
         {
           "condition": "random",
-          "fraction": "0.1",
+          "fraction": "1.0",
           "seed": "1234"
         }
       ],


### PR DESCRIPTION
This is to introduce a delay of 3 s  in TOF digit reader since majority of QC digit are empty in the last MC production (digit reader too fast wrt QC init)