### PR TITLE
[EMCAL-756] Define taskName for EMCAL async QC tasks

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -23,8 +23,9 @@
       }
     },
     "tasks": {
-      "CellTask": {
+      "CellTaskEMCAL": {
         "active": "true",
+        "taskName": "CellTask",
         "className": "o2::quality_control_modules::emcal::CellTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",
@@ -35,8 +36,9 @@
           "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0"
         }
       },
-      "ClusterTask": {
+      "ClusterTaskEMCAL": {
         "active": "true",
+        "taskName": "ClusterTask",
         "className": "o2::quality_control_modules::emcal::ClusterTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",


### PR DESCRIPTION
Use taskName to prevent EMCAL QC task for being
shadowed:
- Define taskName with expected task names
- Add tag "EMCAL" to task name in key