### PR TITLE
Async.: Enable full output of residual aggregator

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -60,7 +60,7 @@ fi
 if [[ $PERIOD == "LHC22s" ]]; then
   # CTP asked to extract their digits
   export ADD_EXTRA_WORKFLOW="o2-ctp-digit-writer"
-    
+
   TPCITSTIMEERR="0.3"
   TPCITSTIMEBIAS="0"
   if [[ $RUNNUMBER -eq 529397 ]]; then
@@ -92,7 +92,7 @@ if [[ $PERIOD == "LHC22s" ]]; then
 fi
 # run-dependent options
 if [[ -f "setenv_run.sh" ]]; then
-    source setenv_run.sh 
+    source setenv_run.sh
 else
     echo "************************************************************"
     echo No ad-hoc run-dependent settings for current async processing
@@ -224,6 +224,8 @@ if [[ $ADD_CALIB == "1" ]]; then
   export CALIB_FT0_TIMEOFFSET=0
   if [[ $DO_TPC_RESIDUAL_EXTRACTION == "1" ]]; then
     export CALIB_TPC_SCDCALIB_SENDTRKDATA=1
+    # ad-hoc settings for TPC residual extraction
+    export ARGS_EXTRA_PROCESS_o2_calibration_residual_aggregator="--output-type trackParams,unbinnedResid,binnedResid"
   fi
   export CALIB_EMC_ASYNC_RECALIB="$ALIEN_JDL_DOEMCCALIB"
   if [[ $ALIEN_JDL_DOTRDVDRIFTEXBCALIB == "1" ]]; then
@@ -232,6 +234,7 @@ if [[ $ADD_CALIB == "1" ]]; then
     export ARGS_EXTRA_PROCESS_o2_trd_global_tracking="--enable-qc"
   fi
 fi
+
 
 # Enabling AOD
 export WORKFLOW_PARAMETERS="AOD,${WORKFLOW_PARAMETERS}"
@@ -250,5 +253,3 @@ if [[ ! -z $QC_JSON_FROM_OUTSIDE ]]; then
     sed -i 's/REPLACE_ME_PASS/'"${PASS}"'/g' $QC_JSON_FROM_OUTSIDE
     sed -i 's/REPLACE_ME_PERIOD/'"${PERIOD}"'/g' $QC_JSON_FROM_OUTSIDE
 fi
-
-

--- a/DATA/production/configurations/2022/LHC22f/apass1_TPCcalib/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1_TPCcalib/setenv_extra.sh
@@ -110,6 +110,9 @@ export ARGS_EXTRA_PROCESS_o2_mft_reco_workflow=" --run-assessment "
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
 
+# ad-hoc settings for TPC residual extraction
+export ARGS_EXTRA_PROCESS_o2_calibration_residual_aggregator="--output-type trackParams,unbinnedResid,binnedResid"
+
 # Enabling AOD
 export WORKFLOW_PARAMETERS="AOD,${WORKFLOW_PARAMETERS}"
 


### PR DESCRIPTION
The `export CALIB_TPC_SCDCALIB_SENDTRKDATA=1 ` is already enabled in the scripts. The full output type is needed now, since its not the default anymore.