### PR TITLE
Update MFTTracking param on setenv_extra.sh

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -228,7 +228,7 @@ export ARGS_EXTRA_PROCESS_o2_fv0_reco_workflow="--fv0-reconstructor"
 #...
 
 # ad-hoc settings for MFT
-export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.forceZeroField=false;MFTTracking.FullClusterScan=false;$MAXBCDIFFTOMASKBIAS_MFT"
+export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.RBins=20;MFTTracking.PhiBins=20;$MAXBCDIFFTOMASKBIAS_MFT"
 
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -228,8 +228,11 @@ export ARGS_EXTRA_PROCESS_o2_fv0_reco_workflow="--fv0-reconstructor"
 #...
 
 # ad-hoc settings for MFT
-export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.RBins=20;MFTTracking.PhiBins=20;$MAXBCDIFFTOMASKBIAS_MFT"
-
+if [[ $BEAMTYPE == "pp" || $PERIOD == "LHC22s" ]]; then
+  export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.RBins=20;MFTTracking.PhiBins=20;MFTTracking.MFTRadLength=0.084;$MAXBCDIFFTOMASKBIAS_MFT"
+else  
+  export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.MFTRadLength=0.084;$MAXBCDIFFTOMASKBIAS_MFT"
+fi
 # ad-hoc settings for MCH
 export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=20;MCHClustering.defaultClusterResolution=0.4;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
 


### PR DESCRIPTION
- Reduce number of cluster bins used for track-finding optimization. This increases MFT acceptance with a slight increase in reconstruction CPU cost.
- Remove obsolete configurations (which are defaults and should not change any more)
