### PR TITLE
[EMCAL-756] Enable meson candidate histograms

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -58,7 +58,9 @@
           "clusterizerGradientCut": "0.03",
           "clusterizerMinTime": "-300.",
           "clusterizerMaxTime": "300.",
-          "clusterizerMaxTimeDelta": "1000."
+          "clusterizerMaxTimeDelta": "1000.",
+          "hasInvMassMesons": "true",
+          "mesonClustersRejectExotics": 1
         }
       }
     }


### PR DESCRIPTION
Enable 2-photon invariant mass histogram for
pi0/eta candidates