### PR TITLE
MCH: add async qc

### DIFF
--- a/DATA/production/qc-async/mch-digits.json
+++ b/DATA/production/qc-async/mch-digits.json
@@ -1,0 +1,65 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "localhost:6464",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": ""
+            },
+            "conditionDB": {
+                "url": ""
+            }
+        },
+        "tasks": {
+            "MCHDigits": {
+                "active": "true",
+                "taskName": "Digits",
+                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskDigits",
+                "moduleName": "QcMuonChambers",
+                "detectorName": "MCH",
+                "cycleDurationSeconds": "60",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "digits:MCH/DIGITS/0"
+                },
+                "taskParameters": {
+                    "Diagnostic": "false"
+                }
+            }
+        },
+        "checks": {
+            "MCHDigits": {
+                "active": "true",
+                "checkName": "Digits",
+                "className": "o2::quality_control_modules::muonchambers::PhysicsCheck",
+                "moduleName": "QcMuonChambers",
+                "policy": "OnAny",
+                "detectorName": "MCH",
+                "checkParameters": {
+                    "MinOccupancy": "0.00001",
+                    "MaxOccupancy": "10.0"
+                },
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "MCHDigits",
+                        "MOs": "all"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/DATA/production/qc-async/mch-reco.json
+++ b/DATA/production/qc-async/mch-reco.json
@@ -1,0 +1,71 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "localhost:6464",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": ""
+            },
+            "conditionDB": {
+                "url": ""
+            }
+        },
+        "tasks": {
+            "MCHRofs": {
+                "active": "true",
+                "taskName": "ROFs",
+                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskRofs",
+                "moduleName": "QcMuonChambers",
+                "detectorName": "MCH",
+                "cycleDurationSeconds": "300",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "digits:MCH/DIGITS;rofs:MCH/DIGITROFS"
+                }
+            },
+            "MCHPreclusters": {
+                "active": "true",
+                "taskName": "Preclusters",
+                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskPreclusters",
+                "moduleName": "QcMuonChambers",
+                "detectorName": "MCH",
+                "cycleDurationSeconds": "540",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "preclusters:MCH/PRECLUSTERS/0;preclusterdigits:MCH/PRECLUSTERDIGITS/0"
+                }
+            }
+        },
+        "checks": {
+            "MCHPreclusters": {
+                "active": "true",
+                "checkName": "Preclusters",
+                "className": "o2::quality_control_modules::muonchambers::PhysicsPreclustersCheck",
+                "moduleName": "QcMuonChambers",
+                "detectorName": "MCH",
+                "policy": "OnAny",
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "MCHPreclusters",
+                        "MOs": "all"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -1,0 +1,45 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "localhost:6464",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": ""
+            },
+            "conditionDB": {
+                "url": ""
+            }
+        },
+        "tasks": {
+            "MCHTracks": {
+                "active": "true",
+                "taskName": "Tracks",
+                "className": "o2::quality_control_modules::muon::TracksTask",
+                "moduleName": "QcMUONCommon",
+                "detectorName": "MCH",
+                "cycleDurationSeconds": "180",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;mchgeo:GLO/Config/0?lifetime=condition&ccdb-path=GLO/Config/GeometryAligned"
+                },
+                "taskParameters": {
+                    "maxTracksPerTF": "600",
+                    "GID": "MCH"
+                }
+            }
+        }
+    }
+}

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -135,12 +135,12 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_EMC" ]] && QC_JSON_EMC=$O2DPG_ROOT/DATA/production/qc-async/emc.json
     [[ -z "$QC_JSON_MID" ]] && QC_JSON_MID=$O2DPG_ROOT/DATA/production/qc-async/mid.json
     if [[ -z "$QC_JSON_MCH" ]]; then
-      QC_JSON_MCH=$O2DPG_ROOT/DATA/production/qc-async/mch-digits.json
+      add_QC_JSON MCH_DIGITS $O2DPG_ROOT/DATA/production/qc-async/mch-digits.json
       if has_processing_step "MCH_RECO"; then
         add_QC_JSON MCH_RECO $O2DPG_ROOT/DATA/production/qc-async/mch-reco.json
       fi
       if has_track_source "MCH"; then
-        add_QC_JSON MCH_TRACK $O2DPG_ROOT/DATA/production/qc-async/mch-tracks.json
+        add_QC_JSON MCH_TRACKS $O2DPG_ROOT/DATA/production/qc-async/mch-tracks.json
       fi
     fi
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=$O2DPG_ROOT/DATA/production/qc-async/cpv.json
@@ -227,7 +227,7 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     if [[ "0$QC_REDIRECT_MERGER_TO_LOCALHOST" == "01" ]]; then
       sed -i.bak -E 's/( *)"remoteMachine" *: *".*"(,?) *$/\1"remoteMachine": "127.0.0.1"\2/' $MERGED_JSON_FILENAME
       unlink $MERGED_JSON_FILENAME.bak
-      QC_CONFIG_OVERRIDE+="qc.config.database.host=localhost:6464;"
+      QC_CONFIG_OVERRIDE+="qc.config.database.host=ccdb-test.cern.ch:8080;"
     fi
 
     if [[ "0$GEN_TOPO_QC_OVERRIDE_CCDB_SERVER" != "0" ]]; then

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -10,6 +10,31 @@ if [[ ! -z $GEN_TOPO_QC_JSON_FILE ]]; then
   flock 101 || exit 1
 fi
 
+FETCHTMPDIR=$(mktemp -d -t GEN_TOPO_DOWNLOAD_JSON-XXXXXX)
+
+JSON_FILES=
+OUTPUT_SUFFIX=
+
+add_QC_JSON() {
+  if [[ ${2} =~ ^consul://.* ]]; then
+    TMP_FILENAME=$FETCHTMPDIR/$1.$RANDOM.$RANDOM.json
+    curl -s -o $TMP_FILENAME "http://alio2-cr1-hv-aliecs.cern.ch:8500/v1/kv/${2/consul:\/\//}?raw"
+    if [[ $? != 0 ]]; then
+      echo "Error fetching QC JSON $2"
+      exit 1
+    fi
+  else
+    TMP_FILENAME=$2
+  fi
+  JSON_FILES+=" $TMP_FILENAME"
+  jq -rM '""' > /dev/null < $TMP_FILENAME
+  if [[ $? != 0 ]]; then
+    echo "Invalid QC JSON $2" 1>&2
+    exit 1
+  fi
+  OUTPUT_SUFFIX+="-$1"
+}
+
 QC_CONFIG=
 QC_CONFIG_OVERRIDE=
 if [[ -z $QC_JSON_FROM_OUTSIDE && ! -z $GEN_TOPO_QC_JSON_FILE && -f $GEN_TOPO_QC_JSON_FILE ]]; then
@@ -109,6 +134,15 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     [[ -z "$QC_JSON_FDD" ]] && QC_JSON_FDD=$O2DPG_ROOT/DATA/production/qc-async/fdd.json
     [[ -z "$QC_JSON_EMC" ]] && QC_JSON_EMC=$O2DPG_ROOT/DATA/production/qc-async/emc.json
     [[ -z "$QC_JSON_MID" ]] && QC_JSON_MID=$O2DPG_ROOT/DATA/production/qc-async/mid.json
+    if [[ -z "$QC_JSON_MCH" ]]; then
+      QC_JSON_MCH=$O2DPG_ROOT/DATA/production/qc-async/mch-digits.json
+      if has_processing_step "MCH_RECO"; then
+        add_QC_JSON MCH_RECO $O2DPG_ROOT/DATA/production/qc-async/mch-reco.json
+      fi
+      if has_track_source "MCH"; then
+        add_QC_JSON MCH_TRACK $O2DPG_ROOT/DATA/production/qc-async/mch-tracks.json
+      fi
+    fi
     [[ -z "$QC_JSON_CPV" ]] && QC_JSON_CPV=$O2DPG_ROOT/DATA/production/qc-async/cpv.json
     [[ -z "$QC_JSON_PHS" ]] && QC_JSON_PHS=$O2DPG_ROOT/DATA/production/qc-async/phs.json
     [[ -z "$QC_JSON_TRD" ]] && QC_JSON_TRD=$O2DPG_ROOT/DATA/production/qc-async/trd.json
@@ -136,31 +170,7 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     echo This script must be run via the gen_topo scripts, or a GEN_TOPO_WORKDIR must be provided where merged JSONS are stored 1>&2
     exit 1
   fi
-
-  FETCHTMPDIR=$(mktemp -d -t GEN_TOPO_DOWNLOAD_JSON-XXXXXX)
-
-  add_QC_JSON() {
-    if [[ ${2} =~ ^consul://.* ]]; then
-      TMP_FILENAME=$FETCHTMPDIR/$1.$RANDOM.$RANDOM.json
-      curl -s -o $TMP_FILENAME "http://alio2-cr1-hv-aliecs.cern.ch:8500/v1/kv/${2/consul:\/\//}?raw"
-      if [[ $? != 0 ]]; then
-        echo "Error fetching QC JSON $2"
-        exit 1
-      fi
-    else
-      TMP_FILENAME=$2
-    fi
-    JSON_FILES+=" $TMP_FILENAME"
-    jq -rM '""' > /dev/null < $TMP_FILENAME
-    if [[ $? != 0 ]]; then
-      echo "Invalid QC JSON $2" 1>&2
-      exit 1
-    fi
-    OUTPUT_SUFFIX+="-$1"
-  }
-
-  JSON_FILES=
-  OUTPUT_SUFFIX=
+ 
 
   # TOF matching
   if has_detector_qc TOF && [[ $WORKFLOW_DETECTORS_QC =~ (^|,)"TOF_MATCH"(,|$) ]] && [ ! -z "$QC_JSON_TOF_MATCH" ]; then
@@ -217,7 +227,7 @@ elif [[ -z $QC_JSON_FROM_OUTSIDE ]]; then
     if [[ "0$QC_REDIRECT_MERGER_TO_LOCALHOST" == "01" ]]; then
       sed -i.bak -E 's/( *)"remoteMachine" *: *".*"(,?) *$/\1"remoteMachine": "127.0.0.1"\2/' $MERGED_JSON_FILENAME
       unlink $MERGED_JSON_FILENAME.bak
-      QC_CONFIG_OVERRIDE+="qc.config.database.host=ccdb-test.cern.ch:8080;"
+      QC_CONFIG_OVERRIDE+="qc.config.database.host=localhost:6464;"
     fi
 
     if [[ "0$GEN_TOPO_QC_OVERRIDE_CCDB_SERVER" != "0" ]]; then


### PR DESCRIPTION
This PR introduces the long overdue async part of the QC for MCH.

Note that I've moved the `add_QC_JSON` up in the `qc-workflow.sh` script in order to be able to use it in the async part to construct the MCH part from parts.

@aferrero2707 FYI