### PR TITLE
switch off hf-hadron decays in pythia8

### DIFF
--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
@@ -15,6 +15,8 @@ FairGenerator*
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin, rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if (ispp)
@@ -51,6 +53,8 @@ FairGenerator*
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin, rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if (ispp)

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
@@ -16,6 +16,8 @@ GeneratorBeautyToMu_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin,rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if(ispp) gen->setFormula("1");

--- a/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
@@ -15,6 +15,8 @@ FairGenerator*
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin, rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if (ispp)
@@ -49,6 +51,8 @@ FairGenerator*
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin, rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if (ispp)

--- a/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
@@ -12,6 +12,8 @@ FairGenerator*
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin, rapidityMax);
   gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffBplus.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if (ispp)

--- a/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+++ b/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
@@ -16,6 +16,8 @@ GeneratorCharmToMu_EvtGenFwdY(double rapidityMin = -4.3, double rapidityMax = -2
   auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
   gen->setRapidity(rapidityMin,rapidityMax);
   gen->setPDG(4);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffChadrons.cfg");
+  gen->readFile(pathO2table.Data());
 
   gen->setVerbose(verbose);
   if(ispp) gen->setFormula("1");

--- a/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/switchOffBhadrons.cfg
@@ -1,0 +1,11 @@
+#switch off b-hadron decays
+
+511:mayDecay  off	# B0
+521:mayDecay  off	# B+
+531:mayDecay  off	# B_s0
+541:mayDecay  off	# B_c+
+5112:mayDecay off	# Sigma_b-
+5122:mayDecay off	# Lambda_b0
+5132:mayDecay off	# Xi_b-
+5232:mayDecay off	# Xi_b0
+5332:mayDecay off	# Omega_b-

--- a/MC/config/PWGDQ/pythia8/decayer/switchOffBplus.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/switchOffBplus.cfg
@@ -1,0 +1,3 @@
+#switch off bplus decays
+
+521:mayDecay  off	# B+

--- a/MC/config/PWGDQ/pythia8/decayer/switchOffChadrons.cfg
+++ b/MC/config/PWGDQ/pythia8/decayer/switchOffChadrons.cfg
@@ -1,0 +1,8 @@
+#switch off c-hadron decays
+
+411:mayDecay  off	# D+
+421:mayDecay  off	# D0
+431:mayDecay  off	# D_s
+4122:mayDecay off	# Lambda_c
+4232:mayDecay off	# Xi_c
+4332:mayDecay off	# Omega_c


### PR DESCRIPTION
These changes should fix the issue spotted by Giacomo in the JIRA ticket here: https://alice.its.cern.ch/jira/browse/O2-2794 
b-hadron decays were not properly switched off in pythia8, so they were decayed twice (first by Pythia "naturally", then by EvtGen in the forced decay modes). The issue also affects non-prompt jpsi barrel+muons (JIRA O2-2793 and O2-2792) and c,b -> muons (JIRA O2-3022) productions, so the proposed changes should fix all of them.