### PR TITLE
Do not produce plots on each update in EMC QC postprocessing

### DIFF
--- a/DATA/production/qc-postproc-async/emc.json
+++ b/DATA/production/qc-postproc-async/emc.json
@@ -39,7 +39,7 @@
                 "moduleName": "QualityControl",
                 "detectorName": "EMC",
                 "resumeTrend": "false",
-                "producePlotsOnUpdate": "true",
+                "producePlotsOnUpdate": "false",
                 "dataSources": [
                     {
                         "type": "repository",

--- a/DATA/production/qc-postproc-async/emc.json
+++ b/DATA/production/qc-postproc-async/emc.json
@@ -253,7 +253,7 @@
                 "moduleName": "QualityControl",
                 "detectorName": "EMC",
                 "resumeTrend": "false",
-                "producePlotsOnUpdate": "true",
+                "producePlotsOnUpdate": "false",
                 "dataSources": [
                     {
                         "type": "repository",


### PR DESCRIPTION
With the concerned value set to `true`, we save a new plot to QCDB for each new point in the plots (each `update` trigger). It is completely enough if we upload the plots only at `finalize`. cc @mfasDa 