### PR TITLE
Add extra TPCITSTIMEERR=0.2 mus in ALIGNLEVEL=1 mode

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -197,6 +197,7 @@ if [[ $ALIGNLEVEL == 0 ]]; then
 elif [[ $ALIGNLEVEL == 1 ]]; then
   ERRIB="100e-8"
   ERROB="100e-8"
+  [[ -z $TPCITSTIMEERR ]] && TPCITSTIMEERR="0.2"
   export ITS_CONFIG=" --tracking-mode async"
 fi
 


### PR DESCRIPTION
The TOF matching to ITS-TPC before was done with 30 sigma track time error window which is an overkill. Now it is changed to 4 sigma (configurable) but due to ITS-TPC time shift we may lost some matches. The effect is especially stronge with the new alignment and reducer ITS syst error which leads to smaller nominal time error. To account for that, we extend the TPCITSTIMERROR (used so far only in pbpb) to pp (but with 0.2 mus instead of 0.3). Also the PVertexing profits from this extra error.