### PR TITLE
TPC residual extraction for debugging purposes

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -213,7 +213,7 @@ fi
 export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow="$MAXBCDIFFTOMASKBIAS_ITS;$EXTRA_ITSRECO_CONFIG;"
 
 # in the ALIGNLEVEL there was inconsistency between the internal errors of sync_misaligned and ITSEXTRAERR
-if [[ $ALIGNLEVEL != 0 ]]; then   
+if [[ $ALIGNLEVEL != 0 ]]; then
  export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow+="$ITSEXTRAERR;"
 fi
 
@@ -323,6 +323,10 @@ if [[ $ADD_CALIB == "1" ]]; then
     export CALIB_TPC_SCDCALIB_SENDTRKDATA=1
     # ad-hoc settings for TPC residual extraction
     export ARGS_EXTRA_PROCESS_o2_calibration_residual_aggregator="--output-type trackParams,unbinnedResid,binnedResid"
+    if [[ $ALIEN_JDL_DEBUGRESIDUALEXTRACTION == "1" ]]; then
+      export ARGS_EXTRA_PROCESS_o2_tpc_scdcalib_interpolation_workflow="--enable-itsonly --tracking-sources ITS,TPC,TRD,TOF,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TRD-TOF"
+      export CONFIG_EXTRA_PROCESS_o2_tpc_scdcalib_interpolation_workflow="scdcalib.maxTracksPerCalibSlot=-1;scdcalib.minPtNoOuterPoint=0.8;scdcalib.minTPCNClsNoOuterPoint=120"
+      export ARGS_EXTRA_PROCESS_o2_trd_global_tracking="--enable-qc"
   fi
   export CALIB_EMC_ASYNC_RECALIB="$ALIEN_JDL_DOEMCCALIB"
   if [[ $ALIEN_JDL_DOTRDVDRIFTEXBCALIB == "1" ]]; then


### PR DESCRIPTION
In order to disable the track selection for the residual extraction.
To be enabled for the reprocessing of low interaction rate runs: https://alice.its.cern.ch/jira/browse/O2-3512
And I am trying them as well for some 500kHz runs to see if we can enable them there as well.
@chiarazampolli would it work like this so that we can ask Catalin to export `ALIEN_JDL_DEBUGRESIDUALEXTRACTION=1` in the jdl? Or how should I add these custom options?