### PR TITLE
Use --TPCuseCCDB only once

### DIFF
--- a/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
+++ b/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
@@ -134,9 +134,6 @@ if [ ! "$?" == "0" ]; then
   exit 1
 fi
 
-# -- DO AD-HOC ADJUSTMENTS TO WORKFLOWS (UNTIL THIS CAN BE DONE NATIVELY) --
-sed -i 's/--onlyDet TPC/--onlyDet TPC --TPCuseCCDB/' workflow.json # enables CCDB during TPC digitization
-
 # -- RUN THE MC WORKLOAD TO PRODUCE AOD --
 
 export FAIRMQ_IPC_PREFIX=./

--- a/MC/run/ANCHOR/2022/JUN/pass1/anchorMC.sh
+++ b/MC/run/ANCHOR/2022/JUN/pass1/anchorMC.sh
@@ -126,9 +126,6 @@ if [ ! "$?" == "0" ]; then
 fi
 
 
-# -- DO AD-HOC ADJUSTMENTS TO WORKFLOWS (UNTIL THIS CAN BE DONE NATIVELY) --
-sed -i 's/--onlyDet TPC/--onlyDet TPC --TPCuseCCDB/' workflow.json # enables CCDB during TPC digitization
-
 # -- RUN THE MC WORKLOAD TO PRODUCE AOD --
 
 export FAIRMQ_IPC_PREFIX=./


### PR DESCRIPTION
Option now already present by default, cannot be set twice