### PR TITLE
hftodielectronsMCconfiguration

### DIFF
--- a/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+++ b/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
@@ -1,0 +1,47 @@
+// usage (fwdy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_fwdy.ini 
+// usage (midy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_midy.ini 
+//
+//
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
+#include "GeneratorEvtGen.C"
+#include "GeneratorHF.C"
+
+
+FairGenerator*
+GeneratorBeautyToEle_EvtGen(double rapidityMin = -2., double rapidityMax = 2., bool ispp = true, bool verbose = false, TString pdgs = "511;521;531;541;5112;5122;5232;5132;5332;411;421;431;4122;4132;4232;4332")
+{
+  auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
+  gen->setRapidity(rapidityMin,rapidityMax);
+  gen->setPDG(5);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffCBhadrons.cfg");
+  gen->readFile(pathO2table.Data());
+
+
+  gen->setVerbose(verbose);
+  if(ispp) gen->setFormula("1");
+  else gen->setFormula("max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.))");
+  std::string spdg;
+  TObjArray *obj = pdgs.Tokenize(";");
+  gen->SetSizePdg(obj->GetEntriesFast());
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   gen->AddPdg(std::stoi(spdg),i);
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  gen->SetForceDecay(kEvtSemiElectronic);
+  // set random seed
+  gen->readString("Random:setSeed on");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
+  // print debug
+  // gen->PrintDebug();
+
+  return gen;
+}
+

--- a/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
+++ b/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
@@ -1,0 +1,46 @@
+// usage (fwdy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_fwdy.ini 
+// usage (midy) :
+//o2-sim -j 4 -n 10 -g external -t external -m "PIPE ITS TPC" -o sgn --configFile GeneratorHF_bbbar_midy.ini 
+//
+//
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGDQ/EvtGen)
+R__ADD_INCLUDE_PATH($O2DPG_ROOT/MC/config/PWGHF/external/generator)
+#include "GeneratorEvtGen.C"
+#include "GeneratorHF.C"
+
+
+FairGenerator*
+GeneratorCharmToEle_EvtGen(double rapidityMin = -2., double rapidityMax = 2., bool ispp = true, bool verbose = false, TString pdgs = "411;421;431;4122;4132;4232;4332")
+{
+  auto gen = new o2::eventgen::GeneratorEvtGen<o2::eventgen::GeneratorHF>();
+  gen->setRapidity(rapidityMin,rapidityMax);
+  gen->setPDG(4);
+  TString pathO2table = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGDQ/pythia8/decayer/switchOffChadrons.cfg");
+  gen->readFile(pathO2table.Data());
+
+  gen->setVerbose(verbose);
+  if(ispp) gen->setFormula("1");
+  else gen->setFormula("max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.))");
+  std::string spdg;
+  TObjArray *obj = pdgs.Tokenize(";");
+  gen->SetSizePdg(obj->GetEntriesFast());
+  for(int i=0; i<obj->GetEntriesFast(); i++) {
+   spdg = obj->At(i)->GetName();
+   gen->AddPdg(std::stoi(spdg),i);
+   printf("PDG %d \n",std::stoi(spdg));
+  }
+  gen->SetForceDecay(kEvtSemiElectronic);
+  // set random seed
+  gen->readString("Random:setSeed on");
+  uint random_seed;
+  unsigned long long int random_value = 0; 
+  ifstream urandom("/dev/urandom", ios::in|ios::binary);
+  urandom.read(reinterpret_cast<char*>(&random_value), sizeof(random_seed));
+  gen->readString(Form("Random:seed = %d", random_value % 900000001));
+  // print debug
+  // gen->PrintDebug();
+
+  return gen;
+}
+

--- a/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
@@ -1,0 +1,22 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+funcName = GeneratorBeautyToEle_EvtGen(-1.5,1.5,true)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
@@ -1,0 +1,22 @@
+### The setup uses an external event generator
+### This part sets the path of the file and the function call to retrieve it
+
+[GeneratorExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
+funcName = GeneratorCharmToEle_EvtGen(-1.5,1.5)
+
+### The external generator derives from GeneratorPythia8.
+### This part configures the bits of the interface: configuration and user hooks
+
+[GeneratorPythia8]
+config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
+
+### The setup uses an external even generator trigger which is
+### defined in the following file and it is retrieved and configured
+### according to the specified function call
+
+[TriggerExternal]
+fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
@@ -1,0 +1,12 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13500. 		# GeV
+
+### processes
+#HardQCD:hardccbar on		# scatterings g-g / q-qbar -> c-cbar
+HardQCD:hardbbbar on		# scatterings g-g / q-qbar -> b-bbar
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.	

--- a/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
@@ -1,0 +1,37 @@
+### main
+
+Main:timesAllowErrors 2000
+#allow more errors in the pythia.
+
+
+### beams
+Beams:idA 2212				# proton
+Beams:idB 2212 				# proton
+Beams:eCM 13500. 			# GeV
+
+### processes
+# HardQCD:hardccbar on      # ccbar production
+SoftQCD:inelastic = on
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+### switch on color reconnection in mode 2 (https://arxiv.org/pdf/1505.01681.pdf) 
+Tune:pp = 14
+ColourReconnection:mode = 1
+ColourReconnection:allowDoubleJunRem = off
+ColourReconnection:m0 = 0.3
+ColourReconnection:allowJunctions = on
+ColourReconnection:junctionCorrection = 1.20
+ColourReconnection:timeDilationMode = 2
+ColourReconnection:timeDilationPar = 0.18
+StringPT:sigma = 0.335
+StringZ:aLund = 0.36
+StringZ:bLund = 0.56
+StringFlav:probQQtoQ = 0.078
+StringFlav:ProbStoUD = 0.2
+StringFlav:probQQ1toQQ0join = 0.0275,0.0275,0.0275,0.0275
+MultiPartonInteractions:pT0Ref = 2.15
+BeamRemnants:remnantMode = 1
+BeamRemnants:saturation =5


### PR DESCRIPTION
Dear all, 

this pull request is meant for the preparation of enhanced dielectrons MC from correlated heavy-flavour hadron decays. 

For charms, we would prefer to use inelastic pythia 8 with the colour reconnection mode 2, since it reproduced better the amount of baryons, relevant for DCAee templates.

For beauty, to save CPU, we would switch on only the bbbar process. If this is a problem, we can go back to the already existing pythia8 configuration for hf (both ccbar and bbbar) cfg.

We are opened to any comments....

Best regards,

Raphaelle 