### PR TITLE
TPC SCD correction from unbinned residuals

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -329,7 +329,7 @@ if [[ $ADD_CALIB == "1" ]]; then
     export CALIB_TPC_SCDCALIB_SENDTRKDATA=1
     export ARGS_EXTRA_PROCESS_o2_tpc_scdcalib_interpolation_workflow="--enable-itsonly --tracking-sources ITS,TPC,TRD,TOF,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TRD-TOF"
     # ad-hoc settings for TPC residual extraction
-    export ARGS_EXTRA_PROCESS_o2_calibration_residual_aggregator="--output-type trackParams,unbinnedResid,binnedResid"
+    export ARGS_EXTRA_PROCESS_o2_calibration_residual_aggregator="--output-type trackParams,unbinnedResid"
     if [[ $ALIEN_JDL_DEBUGRESIDUALEXTRACTION == "1" ]]; then
       export CONFIG_EXTRA_PROCESS_o2_tpc_scdcalib_interpolation_workflow="scdcalib.maxTracksPerCalibSlot=-1;scdcalib.minPtNoOuterPoint=0.8;scdcalib.minTPCNClsNoOuterPoint=120"
       export ARGS_EXTRA_PROCESS_o2_trd_global_tracking="--enable-qc"

--- a/DATA/production/configurations/asyncCalib/createCorrectionMap.sh
+++ b/DATA/production/configurations/asyncCalib/createCorrectionMap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create correction maps for a list of input files.
-# The scripts assumes to get as input parameters 
+# The scripts assumes to get as input parameters
 # - the xml collection of the o2tpc_residuals*.root files created for a single run
 # - the pattern of the calibration interval extracted by the 'createJobList.sh' macro.
 # It creates an two output files
@@ -27,7 +27,6 @@ fileList=inputFileList.txt
 voxResOutFile=TPCDebugVoxRes_${mergePattern}.root
 splineOutFile=TPCFastTransform_${mergePattern}.root
 
-[[ -z "${ALIEN_JDL_MAPCREATORARGS}" ]] && ALIEN_JDL_MAPCREATORARGS='--configKeyValues "scdcalib.maxSigY=2;scdcalib.maxSigZ=2"'
 [[ -z "${ALIEN_JDL_MAPKNOTSY}" ]] && ALIEN_JDL_MAPKNOTSY=10
 [[ -z "${ALIEN_JDL_MAPKNOTSZ}" ]] && ALIEN_JDL_MAPKNOTSZ=20
 
@@ -42,7 +41,7 @@ fi
 echo "Creating residual map for $nLines input files"
 
 # ===| create tree with residuals |=============================================
-cmd="o2-tpc-static-map-creator $ALIEN_JDL_MAPCREATORARGS --residuals-infiles ${fileList} --outfile ${voxResOutFile} &> residuals.log"
+cmd="root.exe -q -x -l -n $O2_ROOT/share/macro/staticMapCreator.C'(\"${fileList}\", ${ALIEN_JDL_LPMRUNNUMBER}, \"${voxResOutFile}\")' &> residuals.log"
 echo "running: '$cmd'"
 if [[ $ALIEN_JDL_DONTEXTRACTTPCCALIB != "1" ]]; then
   eval $cmd


### PR DESCRIPTION
Don't merge yet please!
In principle this should be all that is needed to skip writing the binned residuals and create the map directly from the unbinned ones. 
It requires https://github.com/AliceO2Group/AliceO2/pull/10736 to be merged first and I am not sure if the run number is known from `ALIEN_JDL_LPMRUNNUMBER` which I just assumed?