### PR TITLE
qc workflow: remove compatibility with old O2

### DIFF
--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z "$WORKFLOW" ]] || [[ -z "$GEN_TOPO_MYDIR" && -z "$MYDIR" ]]; then
+if [[ -z "$WORKFLOW" || -z "$GEN_TOPO_MYDIR" ]]; then
   echo This script must be called from the dpl-workflow.sh and not standalone 1>&2
   exit 1
 fi


### PR DESCRIPTION
@martenole : This will require current O2/dev, so we must not bump O2DPG afterwards without also bumping O2 on the EPNs.