### PR TITLE
Global init section for MC graph workflows

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -490,6 +490,13 @@ class WorkflowExecutor:
       self.args=args
       self.workflowfile = workflowfile
       self.workflowspec = load_json(workflowfile)
+      self.globalenv = self.extract_global_environment(self.workflowspec) # initialize global environment settings
+      print ("The global environment is ", self.globalenv)
+      for e in self.globalenv:
+        if os.environ.get(e, None) == None:
+           print ("Applying key ", str(e))
+           os.environ[e] = str(self.globalenv[e])
+
       self.workflowspec = filter_workflow(self.workflowspec, args.target_tasks, args.target_labels)
 
       if not self.workflowspec['stages']:
@@ -574,6 +581,21 @@ class WorkflowExecutor:
              pass
 
        exit (1)
+
+
+    def extract_global_environment(self, workflowspec):
+        """Checks if the workflow contains a dedicated init task
+           defining a global environment. Extract information and remove from workflowspec.
+        """
+        init_index = 0 # this has to be the first task in the workflow
+        globalenv = {}
+        if workflowspec['stages'][init_index]['name'] == '__global_init_task__':
+          env = workflowspec['stages'][init_index].get('env', None)
+          if env != None:
+            globalenv = { e : env[e] for e in env } 
+          del workflowspec['stages'][init_index]
+
+        return globalenv
 
     def getallrequirements(self, t):
         l=[]
@@ -1131,15 +1153,6 @@ class WorkflowExecutor:
         starttime = time.perf_counter()
         psutil.cpu_percent(interval=None)
         os.environ['JOBUTILS_SKIPDONE'] = "ON"
-        # a bit ALICEO2+O2DPG specific but for now a convenient place to
-        # force presence of ALICEO2_CCDB_LOCALCACHE (needed for MC)
-        # TODO: introduce a proper workflow-globalinit section which is defined inside the workflow json
-        # TODO: explicitely tell reco workflows where to pickup GRP from disc
-        if os.environ.get('ALICEO2_CCDB_LOCALCACHE') == None:
-           print ("ALICEO2_CCDB_LOCALCACHE not set; setting to default") 
-           os.environ['ALICEO2_CCDB_LOCALCACHE'] = os.getcwd() + "/.ccdb"
-        os.environ['IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE'] = "ON"
-
         errorencountered = False
 
         def speedup_ROOT_Init():

--- a/MC/bin/o2dpg_workflow_utils.py
+++ b/MC/bin/o2dpg_workflow_utils.py
@@ -45,7 +45,7 @@ def update_workflow_resource_requirements(workflow, n_workers):
 
 
 def createTask(name='', needs=[], tf=-1, cwd='./', lab=[], cpu=1, relative_cpu=None, mem=500, n_workers=8):
-    """create and attach new task
+    """Creates and new task. A task is a dictionary/class with typically the following attributes
 
     Args:
         name: str
@@ -80,6 +80,18 @@ def createTask(name='', needs=[], tf=-1, cwd='./', lab=[], cpu=1, relative_cpu=N
              'cwd' : cwd }
 
 
+def createGlobalInitTask(envdict):
+    """Returns a special task that is recognized by the executor as
+       a task whose environment section is to be globally applied to all tasks of
+       a workflow.
+
+       envdict: dictionary of environment variables and values to be globally applied to all tasks
+    """
+    t = createTask(name = '__global_init_task__')
+    t['cmd'] = 'NO-COMMAND'
+    t['env'] = envdict
+    return t
+
 def summary_workflow(workflow):
     print("=== WORKFLOW SUMMARY ===\n")
     print(f"-> There are {len(workflow)} tasks")
@@ -95,7 +107,7 @@ def dump_workflow(workflow, filename):
             name of the output file
     """
 
-    # Sanity checks
+    # Sanity checks on list of tasks
     check_workflow(workflow)
     taskwrapper_string = "${O2_ROOT}/share/scripts/jobutils2.sh; taskwrapper"
     # prepare for dumping, deepcopy to detach from this instance
@@ -109,7 +121,6 @@ def dump_workflow(workflow, filename):
         s['cmd'] = trimString(s['cmd'])
     # make the final dict to be dumped
     dump_workflow = {"stages": dump_workflow}
-
     filename = make_workflow_filename(filename)
     
     with open(filename, 'w') as outfile:

--- a/MC/doc/WorkflowRunner.md
+++ b/MC/doc/WorkflowRunner.md
@@ -90,6 +90,10 @@ While a workflow may be written by hand, it's more pratical to have it programma
 
 In fact such a create script could be seen as the **actual succession of former `dpg_sim.sh`**.
 
+A special task with name '__global_init_task__' can be defined as the first task of the workflow.
+The environment information of this task will be used by the runtime engine to propagate global environment variables
+to all other/normal tasks of the workflow.
+
 # Workflow example:
 
 A workflow doing a common background simulation, followed by 2 timeframes of signal MC, digitization, reconstruction and AOD might look like this graphically:


### PR DESCRIPTION
Introducing a mechanism allowing to define
global environment variable that should be used in all tasks of a MC workflow.

This is done by defining a special task '__global_init_task__' which is parsed by the runtime engine. This task will not do anything else than defining environment variables for the moment.