### PR TITLE
Update and extend testing

### DIFF
--- a/MC/bin/tests/embedding_test.sh
+++ b/MC/bin/tests/embedding_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# A example workflow MC->RECO->AOD doing signal-background embedding, meant
+# to study embedding speedups.
+# Background events are reused across timeframes.
+#
+
+# make sure O2DPG + O2 is loaded
+[ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 1
+
+# ----------- LOAD UTILITY FUNCTIONS --------------------------
+. ${O2_ROOT}/share/scripts/jobutils.sh
+
+# ----------- START ACTUAL JOB  -----------------------------
+
+NSIGEVENTS=${NSIGEVENTS:-20}
+NTIMEFRAMES=${NTIMEFRAMES:-5}
+NWORKERS=${NWORKERS:-8}
+NBKGEVENTS=${NBKGEVENTS:-20}
+MODULES="--skipModules ZDC"
+SIMENGINE=${SIMENGINE:-TGeant4}
+PYPROCESS=${PYPROCESS:-ccbar} #ccbar, bbar, ...
+SEED=${SEED:+-seed $SEED}
+
+export ALICEO2_CCDB_LOCALCACHE=$PWD/.ccdb
+
+# create workflow
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 5020 -col pp -gen pythia8 -proc ${PYPROCESS} \
+                                           -colBkg PbPb -genBkg pythia8 -procBkg "heavy_ion" \
+                                           -tf ${NTIMEFRAMES} -nb ${NBKGEVENTS}              \
+                                           -ns ${NSIGEVENTS} -e ${SIMENGINE}                 \
+                                           -j ${NWORKERS} --embedding -interactionRate 50000 \
+                                           --include-analysis -run 310000 ${SEED}

--- a/test/common/kine_tests/test_generic_kine.C
+++ b/test/common/kine_tests/test_generic_kine.C
@@ -1,0 +1,39 @@
+int test_generic_kine()
+{
+    std::string path{"o2sim_Kine.root"};
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie())
+    {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++)
+    {
+        tree->GetEntry(i);
+        int iTrack{};
+        int nToBeDone{};
+        for (auto &track : *tracks)
+        {
+            iTrack++;
+            if (track.getToBeDone()) {
+                nToBeDone++;
+            }
+
+            if (!o2::mcgenstatus::isEncoded(track.getStatusCode())) {
+                std::cerr << "Track " << iTrack << " has invalid status encoding, make sure you set the status code correctly (see https://aliceo2group.github.io/simulation/docs/generators/).\n";
+                return 1;
+            }
+        }
+        if (nToBeDone == 0) {
+            std::cerr << "Event " << i << " has no particles marked to be transported. Make sure they are marked correctly (see https://aliceo2group.github.io/simulation/docs/generators/).\n";
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/test/common/utils/utils.sh
+++ b/test/common/utils/utils.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#
+# Test utility functionality
+#
+
+remove_artifacts()
+{
+    [[ "${KEEP_ONLY_LOGS}" == "1" ]] && find . -type f ! -name '*.log' -and ! -name "*serverlog*" -and ! -name "*mergerlog*" -and ! -name "*workerlog*" -delete
+}
+
+
+get_changed_files()
+{
+    # in the Github CIs, there are env variables that give us the base and head hashes,
+    # so use them if they are there
+    # Otherwise, we go a few steps back
+    local hash_base_user=${O2DPG_TEST_HASH_BASE:-"HEAD~1"}
+    local hash_head_user=${O2DPG_TEST_HASH_HEAD:-"HEAD"}
+    local hash_base=${ALIBUILD_BASE_HASH:-${hash_base_user}}
+    local hash_head=${ALIBUILD_HEAD_HASH:-${hash_head_user}}
+
+    # check if unstaged changes and ALIBUILD_HEAD_HASH not set, in that case compare to unstaged
+    # if there are unstaged changes and no head from user, leave blank
+    [[ ! -z "$(git diff)" && -z ${ALIBUILD_HEAD_HASH+x} && -z ${O2DPG_TEST_HASH_HEAD+x} ]] && hash_head=""
+    # if there are unstaged changes and no base from user, set to HEAD
+    [[ ! -z "$(git diff)" && -z ${ALIBUILD_HEAD_HASH+x} && -z ${O2DPG_TEST_HASH_BASE+x} ]] && hash_base="HEAD"
+    git diff --diff-filter=AMR --name-only ${hash_base} ${hash_head}
+}
+
+
+get_workflow_creation_from_script()
+{
+    # Get the part in the script which creates a workflow as one line
+    local wf_script=${1}
+    # look for the line where the workflow is created
+    local look_for="o2dpg_sim_workflow.py"
+    # assemble the whole line which in the file might contain continuation "\"
+    local string_wo_line_breaks=
+    while read -r line ; do
+        [[ "${line}" == *"${look_for}"* ]] && has_started=1
+        [[ "${has_started}" != "1" ]] && continue
+        string_wo_line_breaks+=${line%%\\}
+        [[ "${line}" == *"\\"* ]] && string_wo_line_breaks+=" "
+        [[ "${line}" != *"\\"* ]] && break
+    done < ${wf_script}
+    echo ${string_wo_line_breaks}
+}
+
+make_wf_creation_script()
+{
+    # We only want the WF creation, no runner or anything else
+
+    # The policy
+    # Extract everything including the first appearance of the sim workflow creation; then stop
+    # This assumes that the WF creation is not enclosed between if-else or in another ""scope"
+    # in
+    local full_wf_script=${1}
+    # out
+    local out_script=${2}
+
+    # do not execute the runner
+    local look_for="o2dpg_sim_workflow.py"
+    # make sure we find the runner line, if the runner name has changed, we don't execute the script at all
+    local has_no_wf=1
+
+    while read -r line ; do
+        [[ "${line}" == *"${look_for}"* ]] && has_no_wf=0
+        [[ "${has_no_wf}" == "0" ]] && break
+        echo "${line}" >> ${out_script}
+    done < ${full_wf_script}
+
+    echo "$(get_workflow_creation_from_script ${full_wf_script})" >> ${out_script}
+    return ${has_no_wf}
+}
+
+
+print_error_logs()
+{
+    local search_dir=${1}
+    local search_pattern="TASK-EXIT-CODE: ([1-9][0-9]*)|[Ss]egmentation violation|[Ee]xception caught|\[FATAL\]|uncaught exception|\(int\) ([1-9][0-9]*)"
+    local error_files=$(find ${search_dir} -maxdepth 4 -type f \( -name "*.log" -or -name "*serverlog*" -or -name "*workerlog*" -or -name "*mergerlog*" \) | xargs grep -l -E "${search_pattern}" | sort)
+    for ef in ${error_files} ; do
+        echo_red "Error found in log $(realpath ${ef})"
+        # print the match plus additional 10 lines
+        grep -n -A 10 -B 10 -E "${search_pattern}" ${ef}
+    done
+}

--- a/test/run_workflow_tests.sh
+++ b/test/run_workflow_tests.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+
+# The test parent dir to be cretaed in current directory
+TEST_PARENT_DIR_PWG="o2dpg_tests/workflows_pwgs"
+TEST_PARENT_DIR_BIN="o2dpg_tests/workflows_bin"
+
+# a global counter for tests
+TEST_COUNTER=0
+
+# unified names of log files
+LOG_FILE_WF="o2dpg-test-wf.log"
+
+# Prepare some colored output
+SRED="\033[0;31m"
+SGREEN="\033[0;32m"
+SEND="\033[0m"
+
+
+echo_green()
+{
+    echo -e "${SGREEN}$@${SEND}"
+}
+
+
+echo_red()
+{
+    echo -e "${SRED}$@${SEND}"
+}
+
+get_git_repo_directory()
+{
+    local repo=
+    if [[ -d .git ]] ; then
+        pwd
+    else
+        repo=$(git rev-parse --git-dir 2> /dev/null)
+    fi
+    [[ "${repo}" != "" ]] && repo=${repo%%/.git}
+    echo ${repo}
+}
+
+
+get_all_workflows()
+{
+    # Collect also those INI files for which the test has been changed
+    local repo_dir_head=${REPO_DIR}
+    local grep_dir=${1}
+    local all_workflows=$(find ${repo_dir_head} -name "*.sh" | grep "${grep_dir}")
+    echo ${all_workflows}
+}
+
+
+test_single_wf()
+{
+    local wf_script=${1}
+    make_wf_creation_script ${wf_script} ${wf_script_local}
+    local has_wf_script_local=${?}
+    echo -n "Test ${TEST_COUNTER}: ${wfs}"
+    [[ "${has_wf_script_local}" != "0" ]] && { echo "No WF creation in script ${wfs} ##########" ; return 1 ; }
+    # Check if there is an "exit" other than the usual
+    # [ ! "${O2DPG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 1
+    # like ones.
+    # This is not perfect but might prevent us from running into some checks the WF script does before launching the WF creation
+    [[ "$(grep exit ${wf_script_local} | grep -v "This needs")" != "" ]] && { echo -e -n "\nFound \"exit\" in ${wfs} so will not test automatically" ; return 0 ; }
+    # one single test
+    echo "Test ${wf_line} from ${wfs}" > ${LOG_FILE_WF}
+    bash ${wf_script_local} >> ${LOG_FILE_WF} 2>&1
+    local ret_this=${?}
+    [[ "${ret_this}" != "0" ]] && echo "[FATAL]: O2DPG_TEST Workflow creation failed" >> ${LOG_FILE_WF}
+    return ${ret_this}
+}
+
+run_workflow_creation()
+{
+    local wf_scripts=${@}
+    local RET=0
+    local wf_script_local="wf.sh"
+
+    for wfs in ${wf_scripts} ; do
+        local wf_line=$(get_workflow_creation_from_script ${wfs})
+        [[ "${wf_line}" == "" ]] && continue
+
+        ((TEST_COUNTER++))
+
+        local test_dir=${TEST_COUNTER}_$(basename ${wfs})_dir
+        rm -rf ${test_dir} 2> /dev/null
+        mkdir ${test_dir}
+        pushd ${test_dir} > /dev/null
+            test_single_wf ${wfs}
+            local ret_this=${?}
+            [[ "${ret_this}" != "0" ]] && RET=${ret_this}
+        popd > /dev/null
+        if [[ "${ret_this}" != "0" ]] ; then
+            echo_red " -> FAILED"
+        else
+            echo_green " -> PASSED"
+        fi
+    done
+
+    return ${RET}
+}
+
+collect_changed_pwg_wf_files()
+{
+    # Collect all INI files which have changed
+    local wf_scripts=$(get_changed_files | grep ".sh$" | grep "MC/run")
+    for wfs in ${wf_scripts} ; do
+        [[ "${WF_FILES}" == *"${wfs}"* ]] && continue || WF_FILES+=" ${wfs} "
+    done
+}
+
+echo
+echo "##############################"
+echo "# Run O2DPG workflow testing #"
+echo "##############################"
+echo
+
+REPO_DIR=${O2DPG_TEST_REPO_DIR:-$(get_git_repo_directory)}
+if [[ ! -d ${REPO_DIR}/.git ]] ; then
+    echo_red "Directory \"${REPO_DIR}\" is not a git repository."
+    exit 1
+fi
+
+if [[ -z ${O2DPG_ROOT+x} ]] ; then
+    echo_red "O2DPG is not loaded, probably other packages are missing as well in this environment."
+    exit 1
+fi
+
+# source the utilities
+source ${REPO_DIR}/test/common/utils/utils.sh
+
+# Do the initial steps in the source dir where we have the full git repo
+pushd ${REPO_DIR} > /dev/null
+
+# flag if anything changed in the sim workflow bin dir
+changed_wf_bin=$(get_changed_files | grep MC/bin)
+
+# collect what has changed for PWGs
+collect_changed_pwg_wf_files
+
+# get realpaths for all changes
+wf_files_tmp=${WF_FILES}
+WF_FILES=
+for wf_tmp in ${wf_files_tmp} ; do
+    # convert to full path so that we can find it from anywhere
+    WF_FILES+="$(realpath ${wf_tmp}) "
+done
+
+# go back to where we came from
+popd > /dev/null
+REPO_DIR=$(realpath ${REPO_DIR})
+
+# Now, do the trick:
+# We just use the source dir since O2DPG's installation is basically just a copy of the whole repo.
+# This makes sense in particular for local testing but also in the CI it works in the same way. We could do
+#         [[ -z {ALIBUILD_HEAD_HASH+x} ]] && export O2DPG_ROOT=${REPO_DIR}
+# but let's do the same for both local and CI consistently
+export O2DPG_ROOT=${REPO_DIR}
+
+
+########
+# PWGs #
+########
+# prepare our local test directory for PWG tests
+rm -rf ${TEST_PARENT_DIR_PWG} 2>/dev/null
+mkdir -p ${TEST_PARENT_DIR_PWG} 2>/dev/null
+pushd ${TEST_PARENT_DIR_PWG} > /dev/null
+
+# global return code for PWGs
+ret_global_pwg=0
+if [[ "${changed_wf_bin}" != "" ]] ; then
+    # Run all the PWG related WF creations, hence overwrite what was collected by collect_changed_pwg_wf_files eal=rlier
+    WF_FILES=$(get_all_workflows "MC/run/.*/")
+    echo
+fi
+
+# Test what we found
+if [[ "${WF_FILES}" != "" ]] ; then
+    echo "### Test PWG-related workflow creation ###"
+    echo
+    run_workflow_creation ${WF_FILES}
+    ret_global_pwg=${?}
+    echo
+fi
+
+
+# return to where we came from
+popd > /dev/null
+
+####################
+# sim workflow bin #
+####################
+# prepare our local test directory for bin tests
+rm -rf ${TEST_PARENT_DIR_BIN} 2>/dev/null
+mkdir -p ${TEST_PARENT_DIR_BIN} 2>/dev/null
+pushd ${TEST_PARENT_DIR_BIN} > /dev/null
+
+# global return code for PWGs
+ret_global_bin=0
+if [[ "${changed_wf_bin}" != "" ]] ; then
+    echo "### Test bin-related workflow creation ###"
+    echo
+    # Run all the bin test WF creations
+    run_workflow_creation $(get_all_workflows "MC/bin/tests")
+    ret_global_bin=${?}
+    echo
+fi
+
+# return to where we came from
+popd > /dev/null
+
+# final printing of log files of failed tests
+# For PWG workflows, this triggers only a warning at the moment
+if [[ "${ret_global_pwg}" != "0" ]] ; then
+    echo
+    echo "#####################################"
+    echo "# WARNING for PWG-related workflows #"
+    echo "#####################################"
+    echo
+    print_error_logs ${TEST_PARENT_DIR_PWG}
+fi
+
+# However, if a central test fails, exit code will be !=0
+if [[ "${ret_global_bin}" != "0" ]] ; then
+    echo
+    echo "###################################"
+    echo "# ERROR for bin-related workflows #"
+    echo "###################################"
+    echo
+    print_error_logs ${TEST_PARENT_DIR_BIN}
+    exit ${ret_global_bin}
+fi
+
+echo
+echo_green "All required workflow tests successful"
+echo


### PR DESCRIPTION
* general

  * outsource some common functionality
  * add workflow test script

* generator testing

  * remove Pythia8 (was placeholder until now) for OmegaC but keep test for external

  * small fixes

* workflow testing test/run_workflow_tests.sh

  * test all workflow creations found in MC/run/*/*.sh

  * extract lines up to including o2dpg_sim_workflow.py and run that

  * do not test if there is any "exit" which might indicate an additional user condition which is at the moment not easy to understand automatically. --> needs refinement

  * failing PWG-related tests are for now treated as warnings

  * additional test in MC/bin/tests which is required to pass