### PR TITLE
MFT QC: Remove async task from sync QC. It is crashing, and anyway not sure if it should be there

### DIFF
--- a/DATA/production/qc-sync/mft-full.json
+++ b/DATA/production/qc-sync/mft-full.json
@@ -88,32 +88,6 @@
         "remoteMachine": "alio2-cr1-qme05.cern.ch",
         "remotePort": "47797",
         "localControl": "odc"
-      },
-      "MFTAsyncTask": {
-        "active": "true",
-        "className" : "o2::quality_control_modules::mft::QcMFTTrackTask",
-        "moduleName": "QcMFT",
-        "detectorName": "MFT",
-        "cycleDurationSeconds": "120",
-        "maxNumberCycles": "-1",
-        "dataSource" : {
-          "type" : "direct",
-          "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0"
-        },
-        "location": "local",
-        "localMachines": [
-          "epn", "localhost"
-        ],
-        "taskParameters" : {
-          "ROFLengthInBC": "594",
-          "MaxTrackROFSize": "10000",
-          "MaxClusterROFSize": "50000",
-          "MaxDuration": "60000",
-          "TimeBinSize": "0.1"
-        },
-        "remoteMachine": "alio2-cr1-qme05.cern.ch",
-        "remotePort": "47796",
-        "localControl": "odc"
       }
     },
     "checks": {
@@ -193,11 +167,6 @@
             "type": "Task",
             "name": "MFTClusterTask",
             "MOs" : ["mClusterOccupancy"]
-          },
-          {
-            "type": "Task",
-            "name": "MFTAsyncTask",
-            "MOs" : ["mTrackROFNEntries"]
           }
         ]
       }


### PR DESCRIPTION
@tomas-herman : Is this async task supposed to be part of the sync QC?
In any case, this task is crashing and breaks the full system test on the EPNs.