### PR TITLE
ITS jsons: Added option for normalization of track angular distribution

### DIFF
--- a/DATA/production/qc-async/its.json
+++ b/DATA/production/qc-async/its.json
@@ -69,7 +69,8 @@
           "NtracksMAX"  : "5000",
           "doTTree": "0",
 	  "nBCbins" : "103",
-	  "dicttimestamp" : 0
+	  "dicttimestamp" : "0",
+	  "doNorm" : "1"
         }
       }
     },

--- a/DATA/production/qc-sync/its.json
+++ b/DATA/production/qc-sync/its.json
@@ -74,7 +74,8 @@
           "NtracksMAX"  : "100",
           "doTTree": "0",
           "nBCbins" : "103",
-          "dicttimestamp" : 0
+          "dicttimestamp" : "0",
+	  "doNorm" : "1"
         },
         "localMachines": [
           "localhost", "epn"

--- a/MC/config/QC/json/its-clusters-tracks-qc.json
+++ b/MC/config/QC/json/its-clusters-tracks-qc.json
@@ -67,7 +67,8 @@
           "NtracksMAX"  : "5000",
           "doTTree": "0",
 	  "nBCbins" : "103",
-	  "dicttimestamp" : "0"
+	  "dicttimestamp" : "0",
+	  "doNorm" : "1"
         }
       }
     },


### PR DESCRIPTION
Hi @chiarazampolli, 
this PR has to go with PR1676 (https://github.com/AliceO2Group/QualityControl/pull/1676). 
This does not change anything for the async processing of pp/Pb-Pb runs, it is only relevant online for cosmics. 
Thanks