### PR TITLE
Removing metrics by default; possibility to not do the AOD merging th…

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -589,31 +589,33 @@ if [[ $ALIEN_JDL_AODOFF != 1 ]]; then
 	echo "exit code from AO2D check is " $exitcode
 	exit $exitcode
       fi
-      ls AO2D.root > list.list
-      timeStartMerge=`date +%s`
-      time o2-aod-merger --input list.list --output AO2D_merged.root
-      timeEndMerge=`date +%s`
-      timeUsedMerge=$(( $timeUsedMerge+$timeEndMerge-$timeStartMerge ))
-      exitcode=$?
-      echo "exitcode = $exitcode"
-      if [[ $exitcode -ne 0 ]]; then
-	echo "exit code from aod-merger to merge DFs is " $exitcode > validation_error.message
-	echo "exit code from aod-merger to merge DFs is " $exitcode
-	exit $exitcode
-      fi
-      echo "Checking AO2Ds with merged DFs"
-      timeStartCheckMergedAOD=`date +%s`
-      time root -l -b -q '$O2DPG_ROOT/DATA/production/common/readAO2Ds.C("AO2D_merged.root")' > checkAO2D_merged.log
-      timeEndCheckMergedAOD=`date +%s`
-      timeUsedCheckMergedAOD=$(( $timeUsedCheckMergedAOD+$timeEndCheckMergedAOD-$timeStartCheckMergedAOD ))
-      exitcode=$?
-      if [[ $exitcode -ne 0 ]]; then
-	echo "exit code from AO2D with merged DFs check is " $exitcode > validation_error.message
-	echo "exit code from AO2D with merged DFs check is " $exitcode
-	echo "We will keep the AO2Ds with unmerged DFs"
-      else
-	echo "All ok, replacing initial AO2D.root file with the one with merged DFs"
-	mv AO2D_merged.root AO2D.root
+      if [[ -z $ALIEN_JDL_DONOTMERGEAODS ]] || [[ $ALIEN_JDL_DONOTMERGEAODS == 0 ]]; then
+	ls AO2D.root > list.list
+	timeStartMerge=`date +%s`
+	time o2-aod-merger --input list.list --output AO2D_merged.root
+	timeEndMerge=`date +%s`
+	timeUsedMerge=$(( $timeUsedMerge+$timeEndMerge-$timeStartMerge ))
+	exitcode=$?
+	echo "exitcode = $exitcode"
+	if [[ $exitcode -ne 0 ]]; then
+	  echo "exit code from aod-merger to merge DFs is " $exitcode > validation_error.message
+	  echo "exit code from aod-merger to merge DFs is " $exitcode
+	  exit $exitcode
+	fi
+	echo "Checking AO2Ds with merged DFs"
+	timeStartCheckMergedAOD=`date +%s`
+	time root -l -b -q '$O2DPG_ROOT/DATA/production/common/readAO2Ds.C("AO2D_merged.root")' > checkAO2D_merged.log
+	timeEndCheckMergedAOD=`date +%s`
+	timeUsedCheckMergedAOD=$(( $timeUsedCheckMergedAOD+$timeEndCheckMergedAOD-$timeStartCheckMergedAOD ))
+	exitcode=$?
+	if [[ $exitcode -ne 0 ]]; then
+	  echo "exit code from AO2D with merged DFs check is " $exitcode > validation_error.message
+	  echo "exit code from AO2D with merged DFs check is " $exitcode
+	  echo "We will keep the AO2Ds with unmerged DFs"
+	else
+	  echo "All ok, replacing initial AO2D.root file with the one with merged DFs"
+	  mv AO2D_merged.root AO2D.root
+	fi
       fi
       if [[ $ALIEN_JDL_RUNANALYSISQC == 1 ]]; then
 	timeStartAnalysisQC=`date +%s`
@@ -645,8 +647,10 @@ if [[ $ALIEN_JDL_AODOFF != 1 ]]; then
     cd ..
   done
   echo "Time spend in checking initial AODs = $timeUsedCheck s"
-  echo "Time spend in merging AODs = $timeUsedMerge s"
-  echo "Time spend in checking final AODs = $timeUsedCheckMergedAOD s"
+  if [[ -z $ALIEN_JDL_DONOTMERGEAODS ]] || [[ $ALIEN_JDL_DONOTMERGEAODS == 0 ]]; then
+    echo "Time spend in merging AODs = $timeUsedMerge s"
+    echo "Time spend in checking final AODs = $timeUsedCheckMergedAOD s"
+  fi
   if [[ $ALIEN_JDL_RUNANALYSISQC == 1 ]]; then
     echo "Time spend in AnalysisQC = $timeUsedAnalysisQC s"
   else

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -188,13 +188,13 @@ fi
 
 echo "BeamType = $BEAMTYPE"
 
-if [[ $ALIEN_JDL_ENABLEMONITORING == "0" ]]; then
-  export ENABLE_METRICS=0
+if [[ $ALIEN_JDL_ENABLEMONITORING == "1" ]]; then
+  # add the performance metrics
+  export ENABLE_METRICS=1
+  export ARGS_ALL_EXTRA=" --resources-monitoring 50 --resources-monitoring-dump-interval 50"
 else
   # remove monitoring-backend
-  export ENABLE_METRICS=1
-  # add the performance metrics
-  export ARGS_ALL_EXTRA=" --resources-monitoring 50 --resources-monitoring-dump-interval 50"
+  export ENABLE_METRICS=0
 fi
 
 #ALIGNLEVEL=0: before December 2022 alignment, 1: after December 2022 alignment


### PR DESCRIPTION
…at optmizes the DFs

@catalinristea : now the metrics is disabled by default to save time. One can still enable it via JDL env var `ALIEN_JDL_ENABLEMONITORING`.
In addition, the "fake-merging" that we do on each AOD file to improve the DFs handling can now be disabled via `ALIEN_JDL_DONOTMERGEAODS=1`

@davidrohr 