### PR TITLE
use default MCH parameters for PbPb

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -315,8 +315,11 @@ if [[ $BEAMTYPE == "pp" || $PERIOD == "LHC22s" ]]; then
 else
   export CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.MFTRadLength=0.084;$MAXBCDIFFTOMASKBIAS_MFT"
 fi
+
 # ad-hoc settings for MCH
-export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=15;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
+if [[ $BEAMTYPE == "pp" ]]; then
+  export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow="MCHClustering.lowestPadCharge=15;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
+fi
 
 # possibly adding calib steps as done online
 # could be done better, so that more could be enabled in one go


### PR DESCRIPTION
Hello @chiarazampolli ,
Since the PbPb apass5 will be done with a recent O2 version (if I understood correctly), it can use the default reconstruction parameters, which have been updated recently (#10927).