### PR TITLE
[O2-3636] Disable low-multiplicity seeds in PbPb

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -85,6 +85,6 @@ def create_sim_config(args):
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):
         add(config, {"ITSCATrackerParam.trackletsPerClusterLimit": 20,
                      "ITSCATrackerParam.cellsPerClusterLimit": 20,
-                     "ITSVertexerParam.lowMultXYcut2": 0.f})
+                     "ITSVertexerParam.lowMultXYcut2": "0.f"})
 
     return config

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -84,6 +84,7 @@ def create_sim_config(args):
     # deal with larger combinatorics
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):
         add(config, {"ITSCATrackerParam.trackletsPerClusterLimit": 20,
-                     "ITSCATrackerParam.cellsPerClusterLimit": "20"})
+                     "ITSCATrackerParam.cellsPerClusterLimit": 20,
+                     "ITSVertexerParam.lowMultXYcut2": 0.f})
 
     return config


### PR DESCRIPTION
For the moment I will disable the softening of the cut on `nContributors` implemented in https://github.com/AliceO2Group/AliceO2/pull/10568 for PbPb. This is done by constraining the XY distance of low mult vertices to be `0.f`.

This should restore former behaviour (pre-19 Frebruary 2023)