### PR TITLE
ITSreco: Do not use 0.f in config values - just 0.

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -85,6 +85,6 @@ def create_sim_config(args):
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):
         add(config, {"ITSCATrackerParam.trackletsPerClusterLimit": 20,
                      "ITSCATrackerParam.cellsPerClusterLimit": 20,
-                     "ITSVertexerParam.lowMultXYcut2": "0.f"})
+                     "ITSVertexerParam.lowMultXYcut2": "0."})
 
     return config


### PR DESCRIPTION
Fixing an error message "Error in setValue (string) bad lexical cast: source type value could not be interpreted as target" seen in PbPb MC jobs. Most likely the cut setting was then ignored and did not have the targeted effect.