### PR TITLE
Adding some statistics after processing

### DIFF
--- a/DATA/production/common/getStat.sh
+++ b/DATA/production/common/getStat.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# script to extract statistics from job
+
+PVs=0
+CTFsFilesProcessedMsg=$(grep "CTFReader stops processing," $1)
+nCTFsFilesOK=`echo $CTFsFilesProcessedMsg | sed 's/.*processing, \([0-9]*\) .*/\1/'`
+nCTFsFilesInspected=`grep alien_cp $1 | grep -v ALARM | grep -v non-zero | wc -l`
+nCTFsProcessed=`grep "Read CTF" $1 | tail -1 | sed 's/^.*Read CTF \([0-9]*\).*$/\1/'`
+while read -r line; do
+  currentPVs=`echo $line | sed 's/^.*Found \([0-9]*\) PVs.*/\1/'`
+  PVs=$((PVs + currentPVs))
+done < <(grep "Found" $1 | grep "PVs")
+
+echo CTFsFilesProcessedMsg = $CTFsFilesProcessedMsg
+echo nCTFsFilesInspected = $nCTFsFilesInspected
+echo nCTFsFilesOK = $nCTFsFilesOK
+echo nCTFsProcessed = $nCTFsProcessed
+echo PVs = $PVs
+
+touch ${nCTFsFilesInspected}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}_$1_stat.txt
+

--- a/DATA/production/common/getStat.sh
+++ b/DATA/production/common/getStat.sh
@@ -1,22 +1,36 @@
 #!/bin/bash
 
 # script to extract statistics from job
+# $1 is the file to parse
+# $2 is the (possible) extension
 
 PVs=0
 CTFsFilesProcessedMsg=$(grep "CTFReader stops processing," $1)
 nCTFsFilesOK=`echo $CTFsFilesProcessedMsg | sed 's/.*processing, \([0-9]*\) .*/\1/'`
 nCTFsFilesInspected=`grep alien_cp $1 | grep -v ALARM | grep -v non-zero | wc -l`
+nCTFsFilesFailed=`grep "FileFetcher: non-zero exit code [0-9]*" $1 | wc -l`
 nCTFsProcessed=`grep "Read CTF" $1 | tail -1 | sed 's/^.*Read CTF \([0-9]*\).*$/\1/'`
-while read -r line; do
-  currentPVs=`echo $line | sed 's/^.*Found \([0-9]*\) PVs.*/\1/'`
-  PVs=$((PVs + currentPVs))
-done < <(grep "Found" $1 | grep "PVs")
+nCTFsProcessed=$((nCTFsProcessed + 1))
+
+if [[ $nCTFsFilesInspected != $((nCTFsFilesFailed + nCTFsFilesOK)) ]]; then
+  echo "Something went wrong with parsing the log file: CTF files inspected ($nCTFsFilesInspected) is not the sum of those successfully processed ($nCTFsFilesOK) and those that failed ($nCTFsFilesFailed)"
+else
+  while read -r line; do
+    currentPVs=`echo $line | sed 's/^.*Found \([0-9]*\) PVs.*/\1/'`
+    PVs=$((PVs + currentPVs))
+  done < <(grep "Found" $1 | grep "PVs")
+fi
 
 echo CTFsFilesProcessedMsg = $CTFsFilesProcessedMsg
 echo nCTFsFilesInspected = $nCTFsFilesInspected
 echo nCTFsFilesOK = $nCTFsFilesOK
+echo nCTFsFilesFailed = $nCTFsFilesFailed
 echo nCTFsProcessed = $nCTFsProcessed
 echo PVs = $PVs
 
-touch ${nCTFsFilesInspected}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}_$1_stat.txt
+if [[ -n $2 ]]; then
+  touch ${nCTFsFilesInspected}_${nCTFsFilesFailed}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}_${2}.stat
+fi
+
+touch ${nCTFsFilesInspected}_${nCTFsFilesFailed}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}.stat
 

--- a/DATA/production/common/getStat.sh
+++ b/DATA/production/common/getStat.sh
@@ -29,8 +29,8 @@ echo nCTFsProcessed = $nCTFsProcessed
 echo PVs = $PVs
 
 if [[ -n $2 ]]; then
-  touch ${nCTFsFilesInspected}_${nCTFsFilesFailed}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}_${2}.stat
+  touch ${nCTFsFilesInspected}_${nCTFsFilesOK}_${nCTFsFilesFailed}_${nCTFsProcessed}_${PVs}_${2}.stat
 fi
 
-touch ${nCTFsFilesInspected}_${nCTFsFilesFailed}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}.stat
+touch ${nCTFsFilesInspected}_${nCTFsFilesOK}_${nCTFsFilesFailed}_${nCTFsProcessed}_${PVs}.stat
 

--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -444,7 +444,7 @@ else
 	exit $exitcode
       fi
       mv latest.log latest_reco_1.log
-      ./$STATSCRIPT latest_reco_1.log
+      ./$STATSCRIPT latest_reco_1.log reco_1
     fi
   fi
 
@@ -473,18 +473,21 @@ else
 	exit $exitcode
       fi
       mv latest.log latest_reco_2.log
-      ./$STATSCRIPT latest_reco_2.log
+      ./$STATSCRIPT latest_reco_2.log reco_2
       # let's compare to previous step
       if [[ -f latest_reco_1.log ]]; then
-	nCTFsFilesInspected_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_1.log_stat.txt | sed 's/\(^[0-9]*\)_.*/\1/'`
-	nCTFsFilesOK_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_1.log_stat.txt | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
-	nCTFsProcessed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_1.log_stat.txt | sed 's/^[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
-	nCTFsFilesInspected_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_2.log_stat.txt | sed 's/\(^[0-9]*\)_.*/\1/'`
-	nCTFsFilesOK_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_2.log_stat.txt | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
-	nCTFsProcessed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_latest_reco_2.log_stat.txt | sed 's/^[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
-	if [[ $nCTFsFilesInspected_step1 != $nCTFsFilesInspected_step2 ]] || [[ $nCTFsFilesOK_step1 != $nCTFsFilesOK_step2 ]] || [[ $nCTFsProcessed_step1 != $nCTFsProcessed_step2 ]]; then
+	nCTFsFilesInspected_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/\(^[0-9]*\)_.*/\1/'`
+	nCTFsFilesFailed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesOK_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsProcessed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
+	nCTFsFilesInspected_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/\(^[0-9]*\)_.*/\1/'`
+	nCTFsFilesFailed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesOK_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsProcessed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/^[0-9]*_[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
+	if [[ $nCTFsFilesInspected_step1 != $nCTFsFilesInspected_step2 ]] || [[ $nCTFsFilesFailed_step1 != $nCTFsFilesFailed_step2 ]] || [[ $nCTFsFilesOK_step1 != $nCTFsFilesOK_step2 ]] || [[ $nCTFsProcessed_step1 != $nCTFsProcessed_step2 ]]; then
 	  echo "Inconsistency between step 1 and step 2 in terms of number of CTFs (files or single CTFs) found:"
 	  echo "nCTFsFilesInspected_step1 = $nCTFsFilesInspected_step1, nCTFsFilesInspected_step2 = $nCTFsFilesInspected_step2"
+	  echo "nCTFsFilesFailed_step1 = $nCTFsFilesFailed_step1, nCTFsFilesFailed_step2 = $nCTFsFilesFailed_step2"
 	  echo "nCTFsFilesOK_step1 = $nCTFsFilesOK_step1, nCTFsFilesOK_step2 = $nCTFsFilesOK_step2"
 	  echo "nCTFsProcessed_step1 = $nCTFsProcessed_step1, nCTFsProcessed_step2 = $nCTFsProcessed_step2"
 	  echo "Inconsistency between step 1 and step 2 in terms of number of CTFs (files or single CTFs) found:" > validation_error.message

--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -477,18 +477,18 @@ else
       # let's compare to previous step
       if [[ -f latest_reco_1.log ]]; then
 	nCTFsFilesInspected_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/\(^[0-9]*\)_.*/\1/'`
-	nCTFsFilesFailed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
-	nCTFsFilesOK_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesOK_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesFailed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
 	nCTFsProcessed_step1=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
 	nCTFsFilesInspected_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/\(^[0-9]*\)_.*/\1/'`
-	nCTFsFilesFailed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
-	nCTFsFilesOK_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesOK_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_1.stat | sed 's/^[0-9]*_\([0-9]*\)_.*/\1/'`
+	nCTFsFilesFailed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/^[0-9]*_[0-9]*_\([0-9]*\)_.*/\1/'`
 	nCTFsProcessed_step2=`ls [0-9]*_[0-9]*_[0-9]*_[0-9]*_[0-9]*_reco_2.stat | sed 's/^[0-9]*_[0-9]*_[0-9]*_\([0-9]*\).*/\1/'`
 	if [[ $nCTFsFilesInspected_step1 != $nCTFsFilesInspected_step2 ]] || [[ $nCTFsFilesFailed_step1 != $nCTFsFilesFailed_step2 ]] || [[ $nCTFsFilesOK_step1 != $nCTFsFilesOK_step2 ]] || [[ $nCTFsProcessed_step1 != $nCTFsProcessed_step2 ]]; then
 	  echo "Inconsistency between step 1 and step 2 in terms of number of CTFs (files or single CTFs) found:"
 	  echo "nCTFsFilesInspected_step1 = $nCTFsFilesInspected_step1, nCTFsFilesInspected_step2 = $nCTFsFilesInspected_step2"
-	  echo "nCTFsFilesFailed_step1 = $nCTFsFilesFailed_step1, nCTFsFilesFailed_step2 = $nCTFsFilesFailed_step2"
 	  echo "nCTFsFilesOK_step1 = $nCTFsFilesOK_step1, nCTFsFilesOK_step2 = $nCTFsFilesOK_step2"
+	  echo "nCTFsFilesFailed_step1 = $nCTFsFilesFailed_step1, nCTFsFilesFailed_step2 = $nCTFsFilesFailed_step2"
 	  echo "nCTFsProcessed_step1 = $nCTFsProcessed_step1, nCTFsProcessed_step2 = $nCTFsProcessed_step2"
 	  echo "Inconsistency between step 1 and step 2 in terms of number of CTFs (files or single CTFs) found:" > validation_error.message
 	  echo "nCTFsFilesInspected_step1 = $nCTFsFilesInspected_step1, nCTFsFilesInspected_step2 = $nCTFsFilesInspected_step2" > validation_error.message


### PR DESCRIPTION
@costing @catalinristea 
This will produce an empty file named as follows:

${nCTFsFilesInspected}_${nCTFsFilesOK}_${nCTFsProcessed}_${PVs}_$1_stat.txt

where:
nCTFsFilesInspected = number of CTFs files for which "alien_cp" was called; this is 0 in case a local file(s) is (are) used;
nCTFsFilesOK = number of CTFs files that were successfully processed
nCTFsProcessed = number of single CTFs that were processed (not files, but CTFs!)
PVs = number of reconstructed prim vertices (can be interesting also for @shahor02 )
$1 = argument passed: it is the log file that is parsed to obtain the above. We need it since in case the wf is split, CTFs are read 2x, so I cannot use stdout. 

E.g., from a local test:

0_1_4_27792_latest_reco_1.log_stat.txt

I use these numbers also in case of split wf to compare that the first step where we read CTFs for the first time reads the same number of files/ctfs as the second (of course, it could still be that the files are different, but let's hope not).

@noferini , @davidrohr , FYI.

@catalinristea : you need to add "*stat.txt" to the output file list in the JDLs to have these.

