### PR TITLE
Async pass: Support list input not as list.list from current folder

### DIFF
--- a/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/async_pass.sh
@@ -34,6 +34,10 @@ elif [[ "${1##*.}" == "xml" ]]; then
     sed -rn 's/.*turl="([^"]*)".*/\1/p' $1 > list.list
     export MODE="remote"
     shift
+elif [[ $1 != "list.list" && "${1##*.}" == "list" ]]; then
+    cp $1 list.list
+    export MODE="remote"
+    shift
 fi
 
 if [[ -f list.list ]]; then


### PR DESCRIPTION
@chiarazampolli : This supports other file list files with `.list` extension, also from other folders, as argument.
Was kind of convenient for me for testing.

Another comment is: shouldn't we move async_pass.sh to a proper directory, not inside `2022/LHC22f/apass1`, since now I think we use this script for everything.