### PR TITLE
Make variable known for gen topo even if empty

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -29,7 +29,7 @@ if has_detector_calib ZDC && has_processing_step ZDC_RECO; then CAN_DO_CALIB_ZDC
 if has_detector_calib EMC && has_detector_reco EMC && [[ $SYNCMODE != 1 ]]; then CAN_DO_CALIB_EMC_ASYNC_RECALIB=1; else CAN_DO_CALIB_EMC_ASYNC_RECALIB=0; fi
 
 # additional individual settings for calibration workflows
-has_detector CTP && export CALIB_TPC_SCDCALIB_CTP_INPUT="--enable-ctp"
+if has_detector CTP; then export CALIB_TPC_SCDCALIB_CTP_INPUT="--enable-ctp"; else export CALIB_TPC_SCDCALIB_CTP_INPUT=""; fi
 
 if [[ $BEAMTYPE != "cosmic" ]] || [[ ${FORCECALIBRATIONS:-} == 1 ]] ; then
 


### PR DESCRIPTION
I tested on prod, not on staging. On staging there is no CTP that's why I did not spot this in my test...