### PR TITLE
Added params to ITS jsons

### DIFF
--- a/DATA/production/qc-async/its.json
+++ b/DATA/production/qc-async/its.json
@@ -42,7 +42,7 @@
           "nThreads": "1",
 	  "nBCbins" : "103",
 	  "dicttimestamp" : "0",
-          "publishDetailedSummary": "0",
+          "publishDetailedSummary": "1",
 	  "publishSummary1D": "0"
         },
 	"grpGeomRequest" : {
@@ -78,7 +78,8 @@
           "NtracksMAX"  : "5000",
           "doTTree": "0",
 	  "nBCbins" : "103",
-	  "dicttimestamp" : 0
+	  "dicttimestamp" : 0,
+	  "doNorm": "1"
         }
       }
     },

--- a/DATA/production/qc-sync/its.json
+++ b/DATA/production/qc-sync/its.json
@@ -43,7 +43,8 @@
           "nThreads": "1",
           "nBCbins" : "103",
           "dicttimestamp" : "0",
-          "publishSummary1D": "0"
+          "publishSummary1D": "0",
+	  "publishDetailedSummary": "0"
         },
 	"grpGeomRequest" : {
           "geomRequest": "Aligned",
@@ -83,7 +84,8 @@
           "NtracksMAX"  : "100",
           "doTTree": "0",
           "nBCbins" : "103",
-          "dicttimestamp" : 0
+          "dicttimestamp" : 0,
+	  "doNorm": "1"
         },
         "localMachines": [
           "localhost", "epn"

--- a/MC/config/QC/json/its-clusters-tracks-qc.json
+++ b/MC/config/QC/json/its-clusters-tracks-qc.json
@@ -42,8 +42,9 @@
           "layer": "1111111",
           "nThreads": "1",
 	  "nBCbins" : "103",
-	  "dicttimestamp" : 0
-	  "publishSummary1D": "0"
+	  "dicttimestamp" : "0",
+	  "publishSummary1D": "0",
+	  "publishDetailedSummary": "1"
         },
 	"grpGeomRequest" : {
           "geomRequest": "Aligned",
@@ -76,7 +77,8 @@
           "NtracksMAX"  : "5000",
           "doTTree": "0",
 	  "nBCbins" : "103",
-	  "dicttimestamp" : "0"
+	  "dicttimestamp" : "0",
+	  "doNorm": "1"
         }
       }
     },


### PR DESCRIPTION
Added:

- Param "publishDetailedSummary" which allows to publish more detailed hitmaps for qc async only (=1 for qc async) 
- Param "doNorm" equal to 1 which allows to normalize by n vertices --> no change here wrt what done before but behind doNorm there are now different normalization options. 

cc @chiarazampolli 