### PR TITLE
update MCH pp settings

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -350,7 +350,7 @@ fi
 
 # ad-hoc settings for MCH
 if [[ $BEAMTYPE == "pp" ]]; then
-  export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+=";MCHClustering.lowestPadCharge=15;MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6;MCHDigitFilter.timeOffset=126"
+  export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+=";MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6"
 fi
 
 # possibly adding calib steps as done online


### PR DESCRIPTION
The default parameters for clustering and time offset have been tuned and updated in O2.
Only the tracking parameters still need a special settings for pp, in particular because MCH is not yet aligned.