### PR TITLE
async reco: Don't change DPL_PIPELINE_LENGTH on the EPNs, since 1NUMA workflow will be affected

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -5,8 +5,10 @@
 
 export SETENV_NO_ULIMIT=1
 
-# to avoid memory issues
-export DPL_DEFAULT_PIPELINE_LENGTH=16
+# to avoid memory issues - we don't do this on the EPNs, since it can affect the performance
+if [[ $ALIEN_JDL_USEGPUS != 1 ]]; then
+  export DPL_DEFAULT_PIPELINE_LENGTH=16
+fi
 
 # detector list
 if [[ -n $ALIEN_JDL_WORKFLOWDETECTORS ]]; then


### PR DESCRIPTION
@chiarazampolli : On the EPNs with many TFs in flight, we should not mess with the pipeline length.

I am also not sure whether we need this on the GRID, why did you actually set it in the first place? I assume the memory for the metrics might have been quite high otherwise, but I think we don't use them anyway any more.