### PR TITLE
MFT: add clustersrofs to query in MFT track task

### DIFF
--- a/DATA/production/qc-async/mft.json
+++ b/DATA/production/qc-async/mft.json
@@ -64,7 +64,7 @@
         "dataSource": {
           "type": "direct",
           "query_comment" : "100% sampling",
-          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0"
+          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clustersrofs:MFT/CLUSTERSROF/0"
         },
         "taskParameters": {
           "ROFLengthInBC": "594",

--- a/DATA/production/qc-sync/mft-full.json
+++ b/DATA/production/qc-sync/mft-full.json
@@ -107,7 +107,7 @@
         "maxNumberCycles": "-1",
         "dataSource" : {
           "type" : "direct",
-          "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0"
+          "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clustersrofs:MFT/CLUSTERSROF/0"
         },
         "location": "local",
         "localMachines": [

--- a/MC/config/QC/json/mft-tracks.json
+++ b/MC/config/QC/json/mft-tracks.json
@@ -35,7 +35,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0"
+          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clustersrofs:MFT/CLUSTERSROF/0"
         },
         "taskParameters" : {
           "ROFLengthInBC": "594",


### PR DESCRIPTION
Add `clustersrofs:MFT/CLUSTERSROF/0` to query in MFT track task in view of https://github.com/AliceO2Group/QualityControl/pull/1742 