### PR TITLE
Add QC task for ITS clusters and tracks to MC scripts

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -88,6 +88,7 @@ def include_all_QC_finalization(ntimeframes, standalone, run, productionTag):
   add_QC_finalization('tofDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/tofdigits.json')
   add_QC_finalization('TOFMatchWithTRDQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/tofMatchedTracks_AllTypes_direct_MC.json')
   add_QC_finalization('ITSTrackSimTask', 'json://${O2DPG_ROOT}/MC/config/QC/json/its-mc-tracks-qc.json')
+  add_QC_finalization('ITSTracksClusters', 'json://${O2DPG_ROOT}/MC/config/QC/json/its-clusters-tracks-qc.json')
   if isActive('FT0') and isActive('TRD'):
      add_QC_finalization('tofft0PIDQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/pidft0tof.json')
   elif isActive('FT0'):

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1212,6 +1212,11 @@ for tf in range(1, NTIMEFRAMES + 1):
                 needs=[ITSRECOtask['name']],
                 readerCommand='o2-global-track-cluster-reader --track-types "ITS" --cluster-types "ITS"',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/its-mc-tracks-qc.json')
+     
+     addQCPerTF(taskName='ITSTracksClusters',
+                needs=[ITSRECOtask['name']],
+                readerCommand='o2-global-track-cluster-reader --track-types "ITS" --cluster-types "ITS"',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/its-clusters-tracks-qc.json')
 
    #secondary vertexer
    svfinder_threads = ' --threads 1 '

--- a/MC/config/QC/json/its-clusters-tracks-qc.json
+++ b/MC/config/QC/json/its-clusters-tracks-qc.json
@@ -35,8 +35,8 @@
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "compclus"
+          "type": "direct",
+          "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0;patterns:ITS/PATTERNS/0"
         },
         "taskParameters": {
           "layer": "1111111",
@@ -66,8 +66,8 @@
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "tracks"
+          "type": "direct",
+          "query": "Verticesrof:ITS/VERTICESROF/0;Vertices:ITS/VERTICES/0;tracks:ITS/TRACKS/0;rofs:ITS/ITSTrackROF/0;clustersrof:ITS/CLUSTERSROF/0;compclus:ITS/COMPCLUSTERS/0;patterns:ITS/PATTERNS/0;clusteridx:ITS/TRACKCLSID/0"
         },
         "taskParameters": {
           "runNumberPath": "",
@@ -147,35 +147,5 @@
         ]
       }
     }
-  },
-  "dataSamplingPolicies": [
-    {
-      "id": "compclus",
-      "active": "true",
-      "machines": [],
-      "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0;patterns:ITS/PATTERNS/0",
-      "samplingConditions": [
-        {
-          "condition": "random",
-          "fraction": "1",
-          "seed": "1441"
-        }
-      ],
-      "blocking": "false"
-    },
-    {
-      "id": "tracks",
-      "active": "true",
-      "machines": [],
-      "query": "Verticesrof:ITS/VERTICESROF/0;Vertices:ITS/VERTICES/0;tracks:ITS/TRACKS/0;rofs:ITS/ITSTrackROF/0;clustersrof:ITS/CLUSTERSROF/0;compclus:ITS/COMPCLUSTERS/0;patterns:ITS/PATTERNS/0;clusteridx:ITS/TRACKCLSID/0",
-      "samplingConditions": [
-        {
-          "condition": "random",
-          "fraction": "1",
-          "seed": "1441"
-        }
-      ],
-      "blocking": "false"
-    }
-  ]
+  } 
 }

--- a/MC/config/QC/json/its-mc-tracks-qc.json
+++ b/MC/config/QC/json/its-mc-tracks-qc.json
@@ -26,7 +26,7 @@
       }
     },
     "tasks" : {
-      "Tracks" : {
+      "TracksMc" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::its::ITSTrackSimTask",
         "moduleName" : "QcITS",


### PR DESCRIPTION
Hi @catalinristea and @JianLIUhep this is what discussed via email: add the ITS QC cluster and track to MC productions so that we will be able to check if MC anchoring will be done correctly (cc @chiarazampolli )

I have the following crash when testing the code (run the script `O2DPG_pp_minbias.sh`) on lxplus with the PDPSuite of 25/04 but it does not seem to be related to this code modification:
```
#0  0x00007ff66e822659 in waitpid () from /lib64/libc.so.6
#1  0x00007ff66e79ff62 in do_system () from /lib64/libc.so.6
#2  0x00007ff66e7a0311 in system () from /lib64/libc.so.6
#3  0x00007ff66f573f9c in TUnixSystem::Exec (shellcmd=<optimized out>, this=0x1f79fd0) at /jenkins/workspace/DailyBuilds/AdHocO2Physics/daily-tags.pYGZGfKgjt/SOURCES/ROOT/v6-28-02/v6-28-02/core/unix/src/TUnixSystem.cxx:2104
#4  TUnixSystem::StackTrace (this=0x1f79fd0) at /jenkins/workspace/DailyBuilds/AdHocO2Physics/daily-tags.pYGZGfKgjt/SOURCES/ROOT/v6-28-02/v6-28-02/core/unix/src/TUnixSystem.cxx:2395
#5  0x00007ff676b3a6cb in FairLogger::LogFatalMessage () at /jenkins/workspace/DailyBuilds/AdHocO2Physics/daily-tags.pYGZGfKgjt/SOURCES/FairRoot/v18.4.9/v18.4.9/fairtools/FairLogger.cxx:195
#6  0x00007ff670b4d386 in std::function<void ()>::operator()() const (this=0x7ff670b6bb40 <fair::Logger::fFatalCallback>) at /jenkins/workspace/build-any-ib/sw/20156477/1/slc7_x86-64/GCC-Toolchain/v12.2.0-alice1-5/include/c++/12.2.0/bits/std_function.h:587
#7  fair::Logger::~Logger (this=0x7ffda53c4b10, __in_chrg=<optimized out>) at /jenkins/workspace/build-any-ib/sw/20156477/1/SOURCES/FairLogger/v1.11.1/v1.11.1/logger/Logger.cxx:276
#8  0x00007ff676d790e5 in o2::ccdb::CcdbApi::initTGrid (this=0x219f0f0) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/slc7_x86-64/FairLogger/v1.11.1-13/include/fairlogger/Logger.h:310
#9  0x00007ff676d80af7 in o2::ccdb::CcdbApi::loadFileToMemory (this=0x219f0f0, dest=..., path=..., localHeaders=0x0) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/CCDB/src/CcdbApi.cxx:1666
#10 0x00007ff676d81c19 in o2::ccdb::CcdbApi::navigateURLsAndLoadFileToMemory (this=0x219f0f0, dest=..., curl_handle=0x49d70b0, url=..., headers=0x7ffda53c6b30) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/CCDB/src/CcdbApi.cxx:1631
#11 0x00007ff676d8204b in o2::ccdb::CcdbApi::loadFileToMemory (this=0x219f0f0, dest=..., path=..., metadata=..., timestamp=1546730800000, headers=0x7ffda53c6b30, etag=..., createdNotAfter=..., createdNotBefore=..., considerSnapshot=false) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/CCDB/src/CcdbApi.cxx:1506
#12 0x00007ff676d83714 in o2::ccdb::CcdbApi::retrieveBlob (this=0x219f0f0, path=..., targetdir=..., metadata=..., timestamp=timestamp
entry=1546730800000, preservePath=preservePath
entry=true, localFileName=..., createdNotAfter=..., createdNotBefore=...) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/CCDB/src/CcdbApi.cxx:703
#13 0x0000000000414c9a in anchor_GRPs (opts=..., paths=...) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/slc7_x86-64/GCC-Toolchain/v12.2.0-alice1-5/include/c++/12.2.0/bits/basic_string.tcc:238
#14 0x00000000004157cd in create_MeanVertexObject (opts=...) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/DataFormats/Parameters/src/GRPTool.cxx:240
#15 0x0000000000415a4a in create_GRPs (opts=...) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/DataFormats/Parameters/src/GRPTool.cxx:294
#16 0x0000000000411344 in main (argc=15, argv=0x7ffda53c9e08) at /jenkins/workspace/DailyBuilds/DailyO2Physics/daily-tags.4h7eWPnKNm/SOURCES/O2/nightly-20230425/rc/nightly-20230425/DataFormats/Parameters/src/GRPTool.cxx:635
~                  
```