### PR TITLE
Extended validity of noise calib object in ccdb to 2 years

### DIFF
--- a/DATA/production/calib/its-noise-aggregator.sh
+++ b/DATA/production/calib/its-noise-aggregator.sh
@@ -18,7 +18,7 @@ if [[ -z $NTHREADS ]] ; then NTHREADS=1; fi
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --proxy-name its-noise-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-noise-input-proxy,method=bind,type=pull,rateLogging=1,transport=zeromq\" | "
 WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-6 --cut-ib 1e-2 --nthreads ${NTHREADSACC} --processing-mode 1 --pipeline its-noise-calibrator:${NITSACCPIPELINES} ${INPTYPE} | "
-WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-6 --cut-ib 1e-2 --nthreads ${NTHREADSNORM} --processing-mode 2 ${INPTYPE} | "
+WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --validity-days 730 --prob-threshold 1e-6 --cut-ib 1e-2 --nthreads ${NTHREADSNORM} --processing-mode 2 ${INPTYPE} | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://o2-ccdb.internal\" --sspec-min 0 --sspec-max 0 | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"http://alio2-cr1-flp199.cern.ch:8083\" --sspec-min 1 --sspec-max 1 --name-extention dcs | "
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"


### PR DESCRIPTION
Hi @shahor02, @mconcas, 
this is a simple modification to the P2 workflow of noise calibration so to have a validity of 2 years for the `NoiseMap` which is pushed to ccdb after a noise calib run. 
As discussed, we don't run a noise calibration very often hence it might well happen that we take data for 6 months with the same list of noisy pixels masked into ITS. In case a new calibration is done and a new object will be pushed to ccdb, you mentioned that the metadata `adjustableEOV = true` will make the proper job in avoiding that the old map (still with a validity of 2 years) will not be considered anymore if a new one appears. 

The modification for the `DeadMap` is instead ongoing in our DCS parser workflow. 