### PR TITLE
MCH: temp fix for QC ASYNC

### DIFF
--- a/DATA/production/qc-async/mch-digits.json
+++ b/DATA/production/qc-async/mch-digits.json
@@ -6,7 +6,8 @@
                 "host": "localhost:6464",
                 "username": "not_applicable",
                 "password": "not_applicable",
-                "name": "not_applicable"
+                "name": "not_applicable",
+                "maxObjectSize": "12582912"
             },
             "Activity": {
                 "number": "42",
@@ -26,39 +27,18 @@
             "MCHDigits": {
                 "active": "true",
                 "taskName": "Digits",
-                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskDigits",
+                "className": "o2::quality_control_modules::muonchambers::DigitsTask",
                 "moduleName": "QcMuonChambers",
                 "detectorName": "MCH",
-                "cycleDurationSeconds": "60",
+                "cycleDurationSeconds": "300",
                 "maxNumberCycles": "-1",
                 "dataSource": {
                     "type": "direct",
-                    "query": "digits:MCH/DIGITS/0"
+                    "query": "digits:MCH/DIGITS"
                 },
                 "taskParameters": {
                     "Diagnostic": "false"
                 }
-            }
-        },
-        "checks": {
-            "MCHDigits": {
-                "active": "true",
-                "checkName": "Digits",
-                "className": "o2::quality_control_modules::muonchambers::PhysicsCheck",
-                "moduleName": "QcMuonChambers",
-                "policy": "OnAny",
-                "detectorName": "MCH",
-                "checkParameters": {
-                    "MinOccupancy": "0.00001",
-                    "MaxOccupancy": "10.0"
-                },
-                "dataSource": [
-                    {
-                        "type": "Task",
-                        "name": "MCHDigits",
-                        "MOs": "all"
-                    }
-                ]
             }
         }
     }

--- a/DATA/production/qc-async/mch-errors.json
+++ b/DATA/production/qc-async/mch-errors.json
@@ -24,7 +24,7 @@
         },
         "tasks": {
             "MCHErrors": {
-                "active": "false",
+                "active": "true",
                 "taskName": "Errors",
                 "className": "o2::quality_control_modules::muonchambers::ErrorTask",
                 "moduleName": "QcMuonChambers",

--- a/DATA/production/qc-async/mch-reco.json
+++ b/DATA/production/qc-async/mch-reco.json
@@ -23,10 +23,9 @@
             }
         },
         "tasks": {
-            "MCHRofs": {
+            "Rofs": {
                 "active": "true",
-                "taskName": "ROFs",
-                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskRofs",
+                "className": "o2::quality_control_modules::muonchambers::RofsTask",
                 "moduleName": "QcMuonChambers",
                 "detectorName": "MCH",
                 "cycleDurationSeconds": "300",
@@ -34,37 +33,38 @@
                 "dataSource": {
                     "type": "direct",
                     "query": "digits:MCH/DIGITS;rofs:MCH/DIGITROFS"
+                },
+                "taskParameters": {
+                    "Diagnostic": "false"
                 }
             },
             "MCHPreclusters": {
                 "active": "true",
                 "taskName": "Preclusters",
-                "className": "o2::quality_control_modules::muonchambers::PhysicsTaskPreclusters",
+                "className": "o2::quality_control_modules::muonchambers::PreclustersTask",
                 "moduleName": "QcMuonChambers",
                 "detectorName": "MCH",
-                "cycleDurationSeconds": "540",
+                "cycleDurationSeconds": "300",
                 "maxNumberCycles": "-1",
                 "dataSource": {
                     "type": "direct",
                     "query": "preclusters:MCH/PRECLUSTERS/0;preclusterdigits:MCH/PRECLUSTERDIGITS/0"
                 }
-            }
-        },
-        "checks": {
-            "MCHPreclusters": {
+            },
+            "FRofs": {
                 "active": "true",
-                "checkName": "Preclusters",
-                "className": "o2::quality_control_modules::muonchambers::PhysicsPreclustersCheck",
+                "className": "o2::quality_control_modules::muonchambers::RofsTask",
                 "moduleName": "QcMuonChambers",
                 "detectorName": "MCH",
-                "policy": "OnAny",
-                "dataSource": [
-                    {
-                        "type": "Task",
-                        "name": "MCHPreclusters",
-                        "MOs": "all"
-                    }
-                ]
+                "cycleDurationSeconds": "300",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "digits:MCH/F-DIGITS;rofs:MCH/TC-F-DIGITROFS"
+                },
+                "taskParameters": {
+                    "Diagnostic": "false"
+                }
             }
         }
     }

--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -19,7 +19,7 @@
                 "url": ""
             },
             "conditionDB": {
-                "url": ""
+                "url": "https://alice-ccdb.cern.ch"
             }
         },
         "tasks": {


### PR DESCRIPTION
This is a temporary measure to allow MCH async QC to at least  _not_ crash and produce _some_ histograms that can be used to assess async reco quality.

We still miss the post-processing part though. That will be added in another PR.

@csuire @aferrero2707 