### PR TITLE
[EMCAL-917] Add analysis-level QA tasks for EMCAL

### DIFF
--- a/MC/config/analysis_testing/json/analyses_config.json
+++ b/MC/config/analysis_testing/json/analyses_config.json
@@ -247,6 +247,26 @@
                       "o2-analysis-pid-tpc-full",
                       "o2-analysis-pid-tof-base",
                       "o2-analysis-pid-tof-full"]
+        },
+        {
+            "name": "EMCAL",
+            "enabled": true,
+            "expected_output": ["AnalysisResults.root"],
+            "config" : {
+                "data": "json://${O2DPG_ROOT}/MC/config/analysis_testing/json/analysis-testing-data.json"
+            },
+            "tasks": ["o2-analysis-je-emc-eventselection-qa",
+                      "o2-analysis-je-emc-cellmonitor",
+                      "o2-analysis-je-emcal-correction-task",
+                      "o2-analysis-je-emc-clustermonitor",
+                      "o2-analysis-je-emc-tmmonitor",
+                      "o2-analysis-timestamp",
+                      "o2-analysis-track-propagation",
+                      "o2-analysis-trackselection",
+                      "o2-analysis-event-selection", 
+                      "o2-analysis-pid-tpc-full",
+                      "o2-analysis-pid-tpc-base"
+            ]
         }
     ]
 }

--- a/MC/config/analysis_testing/json/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/analysis-testing-data.json
@@ -244,6 +244,10 @@
     "pid-tr": "-1",
     "useNetworkCorrection": "0"
   },
+  "pid-multiplicity": {
+    "processIU": "0",
+    "processStandard": "1"
+  },
   "track-extension": {
     "processRun2": "false",
     "processRun3": "true"
@@ -266,5 +270,116 @@
     "produceFBextendedTable": "true",
     "ptMax": "1e+10",
     "ptMin": "0.100000001"
+  },
+  "emcal-correction-task": {
+    "nonlinearityFunction": "DATA_TestbeamFinal_NoScale",
+    "logWeight": "4.5",
+    "exoticCellMinAmplitude": "4",
+    "clusterDefinition": "kV3Default",
+    "useWeightExotic": "0",
+    "disableNonLin": "0",
+    "exoticCellDiffTime": "1e+06",
+    "exoticCellInCrossMinAmplitude": "0.1",
+    "maxMatchingDistance": "0.4",
+    "exoticCellFraction": "0.97",
+    "hasShaperCorrection": "1",
+    "isMC": "0",
+    "hasPropagatedTracks": "0",
+    "processFull": "1",
+    "selectedCellType": "1",
+    "processStandalone": "0",
+    "processMCFull": "0"
+  },
+  "cell-monitor": {
+    "minCellTimeMain": "-50",
+    "maxCellTimeMain": "100",
+    "minCellAmplitudeTimeHists": "0.3",
+    "vetoBCID": "",
+    "selectBCID": "all",
+    "minCellAmplitude": "0"
+  },
+  "EMCClusterMonitorTaskAmbiguous": {
+    "clustertime-binning": {
+      "values": [
+        1500,
+        -600,
+        900
+      ]
+    },
+    "processCollisions": "0",
+    "doEventSel": "0",
+    "processAmbiguous": "1",
+    "clusterDefinition": "10",
+    "numclusters-binning": {
+      "values": [
+        201,
+        -0.5,
+        200.5
+      ]
+    },
+    "vetoBCID": "",
+    "selectBCID": "all",
+    "vertexCut": "-1"
+  },
+  "EMCClusterMonitorTask": {
+    "clustertime-binning": {
+      "values": [
+        1500,
+        -600,
+        900
+      ]
+    },
+    "processCollisions": "1",
+    "doEventSel": "0",
+    "processAmbiguous": "0",
+    "clusterDefinition": "10",
+    "numclusters-binning": {
+      "values": [
+        201,
+        -0.5,
+        200.5
+      ]
+    },
+    "vetoBCID": "",
+    "selectBCID": "all",
+    "vertexCut": "-1"
+  },
+  "emc-tmmonitor": {
+    "clustertime-binning": {
+      "values": [
+        1500,
+        -600,
+        900
+      ]
+    },
+    "doEventSel": "0",
+    "maxTime": "20",
+    "clusterDefinition": "10",
+    "minM02": "0.1",
+    "vetoBCID": "",
+    "processCollisions": "1",
+    "hasPropagatedTracks": "1",
+    "usePionRejection": "0",
+    "minTime": "-25",
+    "tpcNsigmaPion": {
+      "values": [
+        -3,
+        3
+      ]
+    },
+    "selectBCID": "all",
+    "tpcNsigmaElectron": {
+      "values": [
+        -1,
+        3
+      ]
+    },
+    "vertexCut": "-1",
+    "tpcNsigmaBack": {
+      "values": [
+        -10,
+        -4
+      ]
+    }
   }
 }


### PR DESCRIPTION
Tasks:

(minimal)
- EMCAL event selection
- EMCAL cell monitor

(optional)
- EMCAL cluster monitor
- EMCAL track matching monitor

Including dependencies (i.e. correction tasks).
Track matching and event selection QA will
likely not be portable to the async QC. Several
histos in the cell monitor are too heavy for the
QC framework.