### PR TITLE
Script that allows to use TPC calibration

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -253,16 +253,16 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
   # enabling TPC calibration scaling
   # the default is to use CTP, unless specified differently in the JDL...
   INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC-CTP}
-  #...but for 2022 data, where we will rely on different settings depending on the period
+  #...but for 2022 data, where we will rely on different settings depending on the period; note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
   if [[ $ALIEN_JDL_LPMANCHORYEAR == "2022" ]]; then
-    INST_IR_FOR_TPC="CTPCCDB"
+    INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC-CTPCCDB}
   fi
   if [[ $PERIOD == "LHC22s" ]]; then
-    INST_IR_FOR_TPC=0 # in this way, only TPC/Calib/CorrectionMaps is applied, and we know that for 22s it is the same as TPC/Calib/CorrectionMapsRef
+    INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC-0} # in this way, only TPC/Calib/CorrectionMaps is applied, and we know that for 22s it is the same as TPC/Calib/CorrectionMapsRef; note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
   fi
-  # in MC, we set it to a negative value to disable completely the corrections
+  # in MC, we set it to a negative value to disable completely the corrections; note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
   if [[ $ALIEN_JDL_LPMPRODUCTIONTYPE == "MC" ]]; then
-    INST_IR_FOR_TPC="-1"
+    INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC--1}
   fi
 
   # now we set the options


### PR DESCRIPTION
The TPC calibration rescaling will be applied only if:
```
if [[ -z $ALIEN_JDL_DONOTAPPLYTPCSPDCALIBRATION ]] || [[ $ALIEN_JDL_DONOTAPPLYTPCSPDCALIBRATION != 1 ]]
```
which means that it will be ON by default. In this case, there will also be no TPCCLUSTERSHIFT.
@shahor02 , if you could check this PR, it would be very good.
I took at starting point the setenv_extra_v1.sh script in O2-3701.
One further remark: in the script we set:
```
TPCEXTRAERR=";GPU_rec_tpc.clusterError2AdditionalY=0.1;GPU_rec_tpc.clusterError2AdditionalZ=0.15;"
```
but according to @wiechula , it should have been:
```
TPCEXTRAERR=";GPU_rec_tpc.clusterError2AdditionalY=0.01;GPU_rec_tpc.clusterError2AdditionalZ=0.0225;"
```
i.e. the square of the values. @wiechula said to keep as in the tests done in O2-3701, but we might want to change it. 

One more comment: the scaling is disabled if we are in MC. But if we are in MC, it can be used provided that ```$ALIEN_JDL_SIMULATEDISTORTIONSINMC == 1```

And one question: what about 22s? and the low IR 22cdef, and 22q? Should I disable the scaling e.g. setting by hand:
```
--corrmap-lumi-inst 0
```
? Then only the reference map would be used.
