### PR TITLE
Change additiona errors + correct logging

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -260,7 +260,8 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
   if [[ $PERIOD == "LHC22s" ]]; then
     INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC-0} # in this way, only TPC/Calib/CorrectionMaps is applied, and we know that for 22s it is the same as TPC/Calib/CorrectionMapsRef; note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
   fi
-  # in MC, we set it to a negative value to disable completely the corrections; note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
+  # in MC, we set it to a negative value to disable completely the corrections (not yet operational though, please check O2);
+  # note that if ALIEN_JDL_INSTIRFORTPC is set, it has precedence
   if [[ $ALIEN_JDL_LPMPRODUCTIONTYPE == "MC" ]]; then
     INST_IR_FOR_TPC=${ALIEN_JDL_INSTIRFORTPC--1}
   fi
@@ -273,7 +274,8 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
     echo "Passed valued for scaling is zero, only TPC/Calib/CorrectionMaps will be applied"
     export TPC_CORR_SCALING+=" --corrmap-lumi-inst $INST_IR_FOR_TPC "
   elif [[ $INST_IR_FOR_TPC -lt 0 ]]; then # do not apply any correction
-    echo "Passed valued for scaling is smaller than zero, we will not apply any correction"
+    echo "Passed valued for scaling is smaller than zero, no scaling will be applied"
+    echo "NOTA BENE: In the future, this value will signal to not apply any correction at all, which is not operational yet (but please check, as it depends on O2)"
     export TPC_CORR_SCALING+=" --corrmap-lumi-inst $INST_IR_FOR_TPC "
   elif [[ $INST_IR_FOR_TPC == "CTPCCDB" ]]; then # using what we have in the CCDB CTP counters, extracted at the beginning of the script
     echo "Using CTP CCDB which gave the mean IR of the run at the beginning of the script ($RUN_IR Hz)"
@@ -307,7 +309,8 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
 fi
 
 # adding additional cluster errors
-TPCEXTRAERR=";GPU_rec_tpc.clusterError2AdditionalY=0.01;GPU_rec_tpc.clusterError2AdditionalZ=0.0225;"
+# the values below should be squared, but the validation of those values (0.01 and 0.0225) is ongoing
+TPCEXTRAERR=";GPU_rec_tpc.clusterError2AdditionalY=0.1;GPU_rec_tpc.clusterError2AdditionalZ=0.15;"
 TRACKTUNETPC="$TPCEXTRAERR"
 
 # combining parameters


### PR DESCRIPTION
@wiechula , @noferini , @shahor02 , @miranov25, @aschmah, as discussed at the meeting today. 
Here the effect of the different additional errors:
TPC tracks:
![compSettings_GLO_den_2_plots](https://github.com/AliceO2Group/O2DPG/assets/18655040/1b309129-1ed8-44c0-ba0e-1d847b34065d)
ITSTPC matched tracks:
![compSettings_GLO_num_2_plots](https://github.com/AliceO2Group/O2DPG/assets/18655040/848f09ca-e281-480d-895f-bb36c5a488bb)
Efficiency:
![compSettings_GLO_eff_2_plots](https://github.com/AliceO2Group/O2DPG/assets/18655040/7b417bc5-5c15-4a17-9639-7fd06e1a902f)
Ratios:
![compSettings_GLO_ratio_den_num_eff_2_plots](https://github.com/AliceO2Group/O2DPG/assets/18655040/49b44584-36a6-4ce7-8147-4eadfbe42c52)

Since the value 0.1 and 0.15 were better QC'ed, it was decided at the meeting today (https://indico.cern.ch/event/1286650/) to keep them instead of those that should have been used (0.01 and 0.0225, i.e. square of 0.1 and 0.15).




