### PR TITLE
New calib workflows for ITS

### DIFF
--- a/DATA/production/calib/its-threshold-aggregator.sh
+++ b/DATA/production/calib/its-threshold-aggregator.sh
@@ -13,21 +13,15 @@ CCDBPATH2=""
 if [ $RUNTYPE == "tuning" ] || [ $RUNTYPE == "digital" ] || [ $RUNTYPE == "tuningbb" ]; then
   CCDBPATH1="http://alio2-cr1-flp199.cern.ch:8083"
   CCDBPATH2="http://o2-ccdb.internal"
-elif [ $RUNTYPE == "thrshort" ] || [ $RUNTYPE == "pulselength" ]; then
+else 
   CCDBPATH1="http://o2-ccdb.internal"
-else
-  echo Ccdb paths are empty
 fi
 
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --exit-transition-timeout 20 --proxy-name its-thr-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-thr-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
-if [[ -z $USEEOS ]]; then
-  WORKFLOW+="o2-its-threshold-aggregator-workflow -b $ARGS_ALL | "
-  WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH1\" --sspec-min 0 --sspec-max 0 --name-extention dcs | "
-  if [ $RUNTYPE == "digital" ]; then
-    WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH2\" --sspec-min 1 --sspec-max 1 | "
-  fi
-else
-  WORKFLOW+="o2-its-threshold-aggregator-workflow -b --ccdb-url=\"$CCDBPATH1\" $ARGS_ALL | "
+WORKFLOW+="o2-its-threshold-aggregator-workflow -b $ARGS_ALL | "
+WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH1\" --sspec-min 0 --sspec-max 0 --name-extention dcs | "
+if [ $RUNTYPE == "digital" ]; then
+  WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH2\" --sspec-min 1 --sspec-max 1 | "
 fi
 
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"

--- a/DATA/production/calib/its-threshold-processing.sh
+++ b/DATA/production/calib/its-threshold-processing.sh
@@ -12,21 +12,33 @@ PROXY_INSPEC="A:ITS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 PROXY_OUTSPEC="tunestring:ITS/TSTR;runtype:ITS/RUNT;fittype:ITS/FITT;scantype:ITS/SCANT;chipdonestring:ITS/QCSTR;confdbv:ITS/CONFDBV;PixTypString:ITS/PIXTYP"
 
 CHIPMODBASE=5
+NDECODERS=6
 if [ $RUNTYPE == "digital" ]; then
   CHIPMODBASE=10
 fi
-VCASNRANGE="--min-vcasn 30 --max-vcasn 80"
+if [ $RUNTYPE == "thrfull" ]; then
+  CHIPMODBASE=20
+  NDECODERS=10
+fi
+ADDITIONAL_OPTIONS_DEC=""
+ADDITIONAL_OPTIONS_CAL=""
 if [ $RUNTYPE == "tuningbb" ]; then
-  VCASNRANGE="--min-vcasn 30 --max-vcasn 130"
-fi 
-ENABLEEOS=""
-if [[ -z $USEEOS ]]; then ENABLEEOS="--enable-eos"; fi
+  ADDITIONAL_OPTIONS_CAL="--min-vcasn 30 --max-vcasn 130"
+fi
+if [ $RUNTYPE == "tot1row" ]; then
+  ADDITIONAL_OPTIONS_DEC="--allow-empty-rofs"
+  ADDITIONAL_OPTIONS_CAL="--ninj 10"
+fi
+if [ $RUNTYPE == "totfullfast" ]; then
+  ADDITIONAL_OPTIONS_DEC="--allow-empty-rofs"
+  ADDITIONAL_OPTIONS_CAL="--calculate-slope --charge-a 30 --charge-b 60 --ninj 10"
+fi
 
 WORKFLOW="o2-dpl-raw-proxy --exit-transition-timeout 20 $ARGS_ALL --dataspec \"$PROXY_INSPEC\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,rateLogging=0,transport=shmem\" | "
-WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} --condition-tf-per-query -1 --condition-backend \"http://localhost:8084\" --ignore-dist-stf --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 1  --no-clusters --no-cluster-patterns --pipeline its-stf-decoder:6 --enable-calib-data --digits | "
+WORKFLOW+="o2-itsmft-stf-decoder-workflow ${ARGS_ALL} ${ADDITIONAL_OPTIONS_DEC} --condition-tf-per-query -1 --condition-backend \"http://localhost:8084\" --ignore-dist-stf --configKeyValues \"$ARGS_ALL_CONFIG\" --nthreads 1  --no-clusters --no-cluster-patterns --pipeline its-stf-decoder:${NDECODERS} --enable-calib-data --digits | "
 for i in $(seq 0 $((CHIPMODBASE-1)))
 do
-  WORKFLOW+="o2-its-threshold-calib-workflow -b $VCASNRANGE $ENABLEEOS --enable-single-pix-tag --ccdb-mgr-url=\"http://localhost:8084\" --nthreads 1 --chip-mod-selector $i --chip-mod-base $CHIPMODBASE --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" --meta-type \"calibration\" $ARGS_ALL | "
+  WORKFLOW+="o2-its-threshold-calib-workflow -b ${ADDITIONAL_OPTIONS_CAL} --enable-single-pix-tag --ccdb-mgr-url=\"http://localhost:8084\" --nthreads 1 --chip-mod-selector $i --chip-mod-base $CHIPMODBASE --fittype derivative --output-dir \"/data/calibration\" --meta-output-dir \"/data/epn2eos_tool/epn2eos\" --meta-type \"calibration\" $ARGS_ALL | "
 done
 if workflow_has_parameter QC && has_detector_qc ITS; then
   WORKFLOW+="o2-qc --config consul-json://aliecs.cern.ch:8500/o2/components/qc/ANY/any/its-qc-calibration --local --host epn -b $ARGS_ALL | "

--- a/DATA/production/standalone-calibration.desc
+++ b/DATA/production/standalone-calibration.desc
@@ -10,11 +10,15 @@ ITS-thr-tuning-bb: "O2PDPSuite" reco,40,40,"RUNTYPE=tuningbb production/calib/it
 
 ITS-thr-short: "O2PDPSuite" reco,40,40,"RUNTYPE=thrshort production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=thrshort production/calib/its-threshold-aggregator.sh"
 
-ITS-thr-short-no-eos: "O2PDPSuite" reco,40,40,"USEEOS=0 RUNTYPE=thrshort production/calib/its-threshold-processing.sh" calib,40,"USEEOS=0 RUNTYPE=thrshort production/calib/its-threshold-aggregator.sh"
+ITS-thr-full: "O2PDPSuite" reco,80,80,"RUNTYPE=thrfull production/calib/its-threshold-processing.sh" calib,80,"RUNTYPE=thrfull production/calib/its-threshold-aggregator.sh"
 
 ITS-thr-digital: "O2PDPSuite" reco,40,40,"RUNTYPE=digital production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=digital production/calib/its-threshold-aggregator.sh"
 
 ITS-thr-pulselength: "O2PDPSuite" reco,40,40,"RUNTYPE=pulselength production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=pulselength production/calib/its-threshold-aggregator.sh"
+
+ITS-tot-1row: "O2PDPSuite" reco,40,40,"RUNTYPE=tot1row production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=tot1row production/calib/its-threshold-aggregator.sh"
+
+ITS-tot-fullfast: "O2PDPSuite" reco,40,40,"RUNTYPE=totfullfast production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=totfullfast production/calib/its-threshold-aggregator.sh"
 
 TOF-diagnostic-calibration: "O2PDPSuite" reco,10,10,"SHMSIZE=120376524800 production/calib/tof-standalone-reco.sh" calib,4,"production/calib/tof-diagn-aggregator.sh"
 


### PR DESCRIPTION
New calib workflows for ITS:
- Full threshold scan
- TOT-calibration 1 row (pulse shape scan 2D, 1 row per chip)
- TOT-calibration fast (pulse shape scan 2D, 512 rows per chip)
- removed ITS-thr-short-no-eos

cc @chiarazampolli @shahor02 