### PR TITLE
Adding a log file with the number of files produced by the skimming

### DIFF
--- a/DATA/production/configurations/CTFSkimming/ctf-skim-workflow.sh
+++ b/DATA/production/configurations/CTFSkimming/ctf-skim-workflow.sh
@@ -115,3 +115,6 @@ WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT -b --run"
 PRINT_WORKFLOW=1
 [[ ${WORKFLOWMODE:-} == "print" || "0${PRINT_WORKFLOW:-}" == "01" ]] && echo "#Workflow command:\n\n${WORKFLOW}\n" | sed -e "s/\\\\n/\n/g" -e"s/| */| \\\\\n/g" | eval cat $( [[ ${WORKFLOWMODE:-} == "dds" ]] && echo '1>&2')
 if [[ ${WORKFLOWMODE:-} != "print" ]]; then eval $WORKFLOW; else true; fi
+
+# Adding a log file with the number of skimmed CTFs. If we arrive here, it means that the processing was fine
+ls -l o2_ctf*.root | wc -l > nSkimmedCTFs.log


### PR DESCRIPTION
@catalinristea , @mpuccio , @noferini : this extra file will contain the number of skimmed CTFs at the end of the processing. It is not an info important per se, but we can then trigger the validation of this job on the presence of this file instead of o2_ctf*.root, since we might have none of those when the bcRanges selects nothing in the current job.
Let me know if you have feedback!