### PR TITLE
TRD noise workflow

### DIFF
--- a/DATA/testing/detectors/TRD/trd-noise.sh
+++ b/DATA/testing/detectors/TRD/trd-noise.sh
@@ -8,16 +8,22 @@ source common/getCommonArgs.sh
 # Define input data required by DPL (in this case all RAWDATA from TRD)
 PROXY_INSPEC="A:TRD/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
 
-# Allow for setting external options (in this case setting the CCDB path via TRD_CCDB_PATH)
-if [ -z $TRD_CCDB_PATH ] ; then
+# Allow for setting external options
+if [ -z $TRD_CCDB_PATH ]; then
   TRD_CCDB_PATH="http://o2-ccdb.internal"
+fi
+if [ -z $TRD_REJECTION_FACTOR ]; then
+  TRD_REJECTION_FACTOR=4
+fi
+if [ -z $TRD_N_READERS ]; then
+  TRD_N_READERS=16
 fi
 
 # Start with an empty workflow
 WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --readout-proxy \"--channel-config \\\"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\\\"\"" "" 0
-add_W o2-trd-datareader "--disable-root-output"
-add_W o2-calibration-trd-workflow "--noise"
+add_W o2-trd-datareader "--disable-root-output --every-nth-tf $TRD_REJECTION_FACTOR --pipeline trd-datareader:$TRD_N_READERS"
+add_W o2-calibration-trd-workflow "--noise --calib-dds-collection-index 0"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path $TRD_CCDB_PATH"
 
 # Finally add the o2-dpl-run workflow manually, allow for either printing the workflow or creating a topology (default)


### PR DESCRIPTION
Tested today with Meike a new configuration for taking TRD noise runs. Now we can use an arbitrary number of EPNs and only a single node will upload a calibration object to the CCDB.

Still a very strange behavior was observed for the processing. Using 5 nodes in the beginning for 3 nodes the buffer was immediately full. Another EPN was OK for few minutes and then got a full buffer. The last EPN could happily process the data continuously. All EPNs should be seeing very similar input data, it is not clear to me how this can happen. In case the CCDB populator is by chance put on a node for which the buffer is filled immediately then we don't get a calibration object.

![Screenshot from 2023-07-20 11-48-00](https://github.com/AliceO2Group/O2DPG/assets/26281793/da144c62-185b-45db-ad75-e00b579e389b)
