### PR TITLE
set ft0-eff with energy/coll_system

### DIFF
--- a/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
+++ b/MC/run/ANCHOR/2021/OCT/pass4/anchorMC.sh
@@ -99,10 +99,10 @@ NSIGEVENTS=${NSIGEVENTS:-22}
 # THIS NEEDS TO COME FROM OUTSIDE
 # echo "$" | awk -F' -- ' '{print $1, $3}'
 
-baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER}"
+baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER} -eCM 900 -col pp"
 
 # THIS NEEDS TO COME FROM OUTSIDE
-remainingargs="-eCM 900 -col pp -gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                \
+remainingargs="-gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                                 \
                -interactionRate ${INTERACTIONRATE}                                                                                                                        \
                -confKey \"Diamond.width[2]=6.0;Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.position[0]=0.0;Diamond.position[1]=-0.035;Diamond.position[2]=0.41\"  \
               --include-local-qc --include-analysis --mft-reco-full"

--- a/MC/run/ANCHOR/2022/JUN/pass1/anchorMC.sh
+++ b/MC/run/ANCHOR/2022/JUN/pass1/anchorMC.sh
@@ -89,10 +89,10 @@ NSIGEVENTS=${NSIGEVENTS:-22}
 # THIS NEEDS TO COME FROM OUTSIDE
 # echo "$" | awk -F' -- ' '{print $1, $3}'
 
-baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER}"
+baseargs="-tf ${NTIMEFRAMES} --split-id ${ALIEN_JDL_SPLITID:-0} --prod-split ${ALIEN_JDL_PRODSPLIT:-100} --run-number ${RUNNUMBER} -eCM 900 -col pp"
 
 # THIS NEEDS TO COME FROM OUTSIDE
-remainingargs="-eCM 900 -col pp -gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                \
+remainingargs="-gen pythia8 -proc cdiff -ns ${NSIGEVENTS}                                                                                                                 \
                -interactionRate ${INTERACTIONRATE}                                                                                                                        \
                -confKey \"Diamond.width[2]=6.0;Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.position[0]=0.0;Diamond.position[1]=-0.035;Diamond.position[2]=0.41\"  \
               --include-local-qc --include-analysis --mft-reco-full"


### PR DESCRIPTION
I changed the anchoring script to parse eCM and col to set ft0-eff.
Then the parameters are forwarded to the sim script

Note that in our scripts these two parameters have to be moved from
remainingargs -> baseargs
once this change is in, as shown also in this PR (and --ft0-eff flag should be no longer used)

Please check also syntax since I couldn't test the change

