### PR TITLE
ITS: push to ccdb test for synthetic/staging calibration scans

### DIFF
--- a/DATA/production/calib/its-threshold-aggregator.sh
+++ b/DATA/production/calib/its-threshold-aggregator.sh
@@ -10,17 +10,22 @@ PROXY_INSPEC="tunestring:ITS/TSTR;runtype:ITS/RUNT;fittype:ITS/FITT;scantype:ITS
 
 CCDBPATH1=""
 CCDBPATH2=""
-if [ $RUNTYPE == "tuning" ] || [ $RUNTYPE == "digital" ] || [ $RUNTYPE == "tuningbb" ]; then
+if [ $RUNTYPE_ITS == "tuning" ] || [ $RUNTYPE_ITS == "digital" ] || [ $RUNTYPE_ITS == "tuningbb" ]; then
   CCDBPATH1="http://alio2-cr1-flp199.cern.ch:8083"
   CCDBPATH2="http://o2-ccdb.internal"
 else 
   CCDBPATH1="http://o2-ccdb.internal"
 fi
 
+if [[ $RUNTYPE == "SYNTHETIC" || "${GEN_TOPO_DEPLOYMENT_TYPE:-}" == "ALICE_STAGING" ]]; then
+  CCDBPATH1="http://ccdb-test.cern.ch:8080"
+  CCDBPATH2="http://ccdb-test.cern.ch:8080"
+fi
+
 WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --exit-transition-timeout 20 --proxy-name its-thr-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=its-thr-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq\" | "
 WORKFLOW+="o2-its-threshold-aggregator-workflow -b $ARGS_ALL | "
 WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH1\" --sspec-min 0 --sspec-max 0 --name-extention dcs | "
-if [ $RUNTYPE == "digital" ]; then
+if [ $RUNTYPE_ITS == "digital" ]; then
   WORKFLOW+="o2-calibration-ccdb-populator-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --ccdb-path=\"$CCDBPATH2\" --sspec-min 1 --sspec-max 1 | "
 fi
 

--- a/DATA/production/calib/its-threshold-processing.sh
+++ b/DATA/production/calib/its-threshold-processing.sh
@@ -14,23 +14,23 @@ PROXY_OUTSPEC="tunestring:ITS/TSTR;runtype:ITS/RUNT;fittype:ITS/FITT;scantype:IT
 
 CHIPMODBASE=5
 NDECODERS=6
-if [ $RUNTYPE == "digital" ]; then
+if [ $RUNTYPE_ITS == "digital" ]; then
   CHIPMODBASE=10
 fi
-if [ $RUNTYPE == "thrfull" ]; then
+if [ $RUNTYPE_ITS == "thrfull" ]; then
   CHIPMODBASE=20
   NDECODERS=10
 fi
 ADDITIONAL_OPTIONS_DEC=""
 ADDITIONAL_OPTIONS_CAL=""
-if [ $RUNTYPE == "tuningbb" ]; then
+if [ $RUNTYPE_ITS == "tuningbb" ]; then
   ADDITIONAL_OPTIONS_CAL="--min-vcasn 30 --max-vcasn 130"
 fi
-if [[ $RUNTYPE == "tot1row" || $RUNTYPE == "vresetd" ]]; then
+if [[ $RUNTYPE_ITS == "tot1row" || $RUNTYPE_ITS == "vresetd" ]]; then
   ADDITIONAL_OPTIONS_DEC="--allow-empty-rofs"
   ADDITIONAL_OPTIONS_CAL="--ninj 10"
 fi
-if [ $RUNTYPE == "totfullfast" ]; then
+if [ $RUNTYPE_ITS == "totfullfast" ]; then
   ADDITIONAL_OPTIONS_DEC="--allow-empty-rofs"
   ADDITIONAL_OPTIONS_CAL="--calculate-slope --charge-a 30 --charge-b 60 --ninj 10"
 fi

--- a/DATA/production/standalone-calibration.desc
+++ b/DATA/production/standalone-calibration.desc
@@ -4,23 +4,23 @@ ITS-noise-calibration: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELIN
 
 ITS-noise-calibration-clusters: "O2PDPSuite" reco,20,20,"NITSDECTHREADS=4 NITSDECTPIPELINES=6 USECLUSTERS=1 production/calib/its-noise-processing.sh" calib,20,"USECLUSTERS=1 NTHREADS=32 production/calib/its-noise-aggregator.sh"
 
-ITS-thr-tuning: "O2PDPSuite" reco,40,40,"RUNTYPE=tuning production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=tuning production/calib/its-threshold-aggregator.sh"
+ITS-thr-tuning: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=tuning production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=tuning production/calib/its-threshold-aggregator.sh"
 
-ITS-thr-tuning-bb: "O2PDPSuite" reco,40,40,"RUNTYPE=tuningbb production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=tuningbb production/calib/its-threshold-aggregator.sh"
+ITS-thr-tuning-bb: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=tuningbb production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=tuningbb production/calib/its-threshold-aggregator.sh"
 
-ITS-thr-short: "O2PDPSuite" reco,40,40,"RUNTYPE=thrshort production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=thrshort production/calib/its-threshold-aggregator.sh"
+ITS-thr-short: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=thrshort production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=thrshort production/calib/its-threshold-aggregator.sh"
 
-ITS-thr-full: "O2PDPSuite" reco,80,80,"RUNTYPE=thrfull production/calib/its-threshold-processing.sh" calib,80,"RUNTYPE=thrfull production/calib/its-threshold-aggregator.sh"
+ITS-thr-full: "O2PDPSuite" reco,80,80,"RUNTYPE_ITS=thrfull production/calib/its-threshold-processing.sh" calib,80,"RUNTYPE_ITS=thrfull production/calib/its-threshold-aggregator.sh"
 
-ITS-digital: "O2PDPSuite" reco,40,40,"RUNTYPE=digital production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=digital production/calib/its-threshold-aggregator.sh"
+ITS-digital: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=digital production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=digital production/calib/its-threshold-aggregator.sh"
 
-ITS-pulselength: "O2PDPSuite" reco,40,40,"RUNTYPE=pulselength production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=pulselength production/calib/its-threshold-aggregator.sh"
+ITS-pulselength: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=pulselength production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=pulselength production/calib/its-threshold-aggregator.sh"
 
-ITS-tot-1row: "O2PDPSuite" reco,40,40,"RUNTYPE=tot1row production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=tot1row production/calib/its-threshold-aggregator.sh"
+ITS-tot-1row: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=tot1row production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=tot1row production/calib/its-threshold-aggregator.sh"
 
-ITS-tot-fullfast: "O2PDPSuite" reco,40,40,"RUNTYPE=totfullfast production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE=totfullfast production/calib/its-threshold-aggregator.sh"
+ITS-tot-fullfast: "O2PDPSuite" reco,40,40,"RUNTYPE_ITS=totfullfast production/calib/its-threshold-processing.sh" calib,40,"RUNTYPE_ITS=totfullfast production/calib/its-threshold-aggregator.sh"
 
-ITS-vresetd: "O2PDPSuite" reco,5,5,"RUNTYPE=vresetd production/calib/its-threshold-processing.sh" calib,5,"RUNTYPE=vresetd production/calib/its-threshold-aggregator.sh"
+ITS-vresetd: "O2PDPSuite" reco,5,5,"RUNTYPE_ITS=vresetd production/calib/its-threshold-processing.sh" calib,5,"RUNTYPE_ITS=vresetd production/calib/its-threshold-aggregator.sh"
 
 TOF-diagnostic-calibration: "O2PDPSuite" reco,10,10,"SHMSIZE=120376524800 production/calib/tof-standalone-reco.sh" calib,4,"production/calib/tof-diagn-aggregator.sh"
 


### PR DESCRIPTION
Hi @davidrohr, this is to include the feature you suggested in your email few days ago. 
I renamed RUNTYPE to RUNTYPE_ITS to avoid having a variable with the same name of the one used for the real run type set in ECS. 