### PR TITLE
Revert "calib-workflow: WORKAROUND: Currently cannot send CTP data to…

### DIFF
--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -271,7 +271,7 @@ if [[ -z ${CALIBDATASPEC_CALO_TF:-} ]]; then
   if [[ $CALIB_EMC_BADCHANNELCALIB == 1 ]] || [[ $CALIB_EMC_TIMECALIB == 1 ]]; then
     add_semicolon_separated CALIBDATASPEC_CALO_TF "cellsEMC:EMC/CELLS/0"
     add_semicolon_separated CALIBDATASPEC_CALO_TF "cellsTrgREMC:EMC/CELLSTRGR/0"
-    if false && has_detector CTP; then # FIXME: Currently we cannot send CTP/DIGITS to both CALO and BARREL workflow.
+    if has_detector CTP; then
       add_semicolon_separated CALIBDATASPEC_CALO_TF "ctpdigi:CTP/DIGITS/0"
     fi
   fi


### PR DESCRIPTION
… 2 output proxies"

This reverts commit 3b1f236981f6edcc914bff424e897161402644ce.