### PR TITLE
ITS: Added V0 reconstruction in async workflow

### DIFF
--- a/DATA/production/qc-async/its.json
+++ b/DATA/production/qc-async/its.json
@@ -79,7 +79,8 @@
           "doTTree": "0",
 	  "nBCbins" : "103",
 	  "dicttimestamp" : 0,
-	  "doNorm": "1"
+	  "doNorm": "1",
+          "InvMasses" : "1"
         }
       }
     },


### PR DESCRIPTION
This commit switches ON the flag for V0 inv. mass reconstruction in ITS a-QC, which is OFF by default 