### PR TITLE
TRD fix for labelling error in async qc

### DIFF
--- a/DATA/production/qc-async/trd.json
+++ b/DATA/production/qc-async/trd.json
@@ -53,7 +53,10 @@
         "dataSource": {
           "type": "direct",
           "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD"
-        }
+        },
+        "taskParameters": {
+          "ignorelayerlabels": "1"
+        },
       }
     }
   },

--- a/DATA/production/qc-async/trditstpc.json
+++ b/DATA/production/qc-async/trditstpc.json
@@ -53,7 +53,10 @@
         "dataSource": {
           "type": "direct",
           "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD"
-        }
+        },
+        "taskParameters": {
+          "ignorelayerlabels": "1"
+        },
       },
       "TRDPulseHeightTrackMatch": {
         "active": "true",


### PR DESCRIPTION
Add a parameter to the async qc to stop a pile of messages about labels.
This fixes older versions of qc, and newer ones are fixed via : qc pr  #1951