### PR TITLE
Add dedicated staging QC global config

### DIFF
--- a/DATA/production/qc-sync/qc-global-epn-staging.json
+++ b/DATA/production/qc-sync/qc-global-epn-staging.json
@@ -1,0 +1,36 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "alio2-cr1-hv-mvs00:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "http://127.0.0.1:8084"
+      },
+      "infologger": {
+        "filterDiscardDebug": "true",
+        "filterDiscardLevel": "1",
+        "filterDiscardFile": "../../qc-_ID_.log",
+        "filterRotateMaxBytes": "100000000",
+        "filterRotateMaxFiles": "1"
+      },
+      "bookkeeping": {
+        "url": ""
+      }
+    }
+  }
+}

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -110,7 +110,11 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
         QC_JSON_TOF_MATCH=consul://o2/components/qc/ANY/any/tof-qcmn-match-itstpctof
       fi
     fi
-    [[ -z "${QC_JSON_GLOBAL:-}" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-sync/qc-global-epn.json # this must be last
+    if [[ "${GEN_TOPO_DEPLOYMENT_TYPE:-}" == "ALICE_STAGING" ]]; then
+      [[ -z "${QC_JSON_GLOBAL:-}" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-sync/qc-global-epn-staging.json # this must be last
+    else
+      [[ -z "${QC_JSON_GLOBAL:-}" ]] && QC_JSON_GLOBAL=$O2DPG_ROOT/DATA/production/qc-sync/qc-global-epn.json # this must be last
+    fi
   elif [[ $SYNCMODE == 1 ]]; then # Sync processing running locally (CI, laptop)
     [[ -z "${QC_JSON_TPC:-}" ]] && QC_JSON_TPC=$O2DPG_ROOT/DATA/production/qc-sync/tpc.json
     [[ -z "${QC_JSON_ITS:-}" ]] && QC_JSON_ITS=$O2DPG_ROOT/DATA/production/qc-sync/its.json


### PR DESCRIPTION
as discussed in https://alice.its.cern.ch/jira/browse/O2-4069 so far staging could use the same configuration as production, since the database was not used by the worker nodes. Soon the qc task will interface with bookkeeping, so we need to distinguish between staging and prod. Since more than a single key will change I believe its cleaner to have a second json for staging if fine with @davidrohr 

Will merge only after https://github.com/AliceO2Group/O2DPG/pull/1195