### PR TITLE
Bugfix: only add extra options if detector is included in the run

### DIFF
--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -239,9 +239,11 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
   # for strings remember to escape e.g. " and ;
   # e.g. .qc.tasks.Tracking.taskParameters.dataSource.query=\"tracks:TPC/TRACKS\;clusters:TPC/CLUSTERS\"
   if [[ -z "${DISABLE_QC_DETECTOR_CONFIG_OVERRIDE:-}" ]]; then
-    if ! has_matching_qc ITSTPCTRD || ! has_detectors_reco ITS TPC TRD; then
-      add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.Tracking.active=false'
-      add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.PHTrackMatch.active=false'
+    if has_detector_qc TRD && [[ ! -z ${QC_JSON_TRD:-} ]]; then # extra settings for TRD QC
+      if ! has_matching_qc ITSTPCTRD || ! has_detectors_reco ITS TPC TRD; then
+        add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.Tracking.active=false'
+        add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.PHTrackMatch.active=false'
+      fi
     fi
   fi
 


### PR DESCRIPTION
If keys for QC tasks are added to the json file without the tasks being properly defined somewhere o2-qc complains about it
```
2023-08-31 09:34:59.721077 fat  odc-grpc-server     3023 2hPLNpkKH2P:0        [ERROR] error while setting up workflow in o2-qc: /jenkins/workspace/DailyBuilds/WeeklyO2Release/daily-tags.8SiFdovCvV/slc8_x86-64/boost/v1.75.0-103/include/boost/property_tree/detail/ptree_implementation.hpp(576): Throw in function boost::property_tree::basic_ptree<K, D, C>& boost::property_tree::basic_ptree<Key, Data, KeyCompare>::get_child(const path_type&) [with Key = std::__cxx11::basic_string<char>; Data = std::__cxx11::basic_string<char>; KeyCompare = std::less<std::__cxx11::basic_string<char> >; path_type = boost::property_tree::string_path<std::__cxx11::basic_string<char>, boost::property_tree::id_translator<std::__cxx11::basic_string<char> > >]
2023-08-31 09:34:59.721088 fat  odc-grpc-server     3023 2hPLNpkKH2P:0        [ERROR] Dynamic exception type: boost::wrapexcept<boost::property_tree::ptree_bad_path>
2023-08-31 09:34:59.721097 fat  odc-grpc-server     3023 2hPLNpkKH2P:0        [ERROR] std::exception::what: No such node (className)
2023-08-31 09:34:59.721106 fat  odc-grpc-server     3023 2hPLNpkKH2P:0        [ERROR]
```
So manipulations can only be done if the tasks which are supposed to be modified actually exist