### PR TITLE
[EMCAL-1037] Specifically request trigger records on subspec 0

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -73,7 +73,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-triggers:EMC/CELLSTRGR;ctp-digits:CTP/DIGITS"
+          "query": "emcal-triggers:EMC/CELLSTRGR/0;ctp-digits:CTP/DIGITS"
         },
         "taskParameters": {
         }


### PR DESCRIPTION
In the asynchronous stage uncalibrated and calibrated
cells and their corresponding trigger records are
available on different subspecs. Only calibrated
trigger records must be used.