### PR TITLE
Prescale ITS in pbpb with multiplicity only, no random cut

### DIFF
--- a/DATA/production/workflow-multiplicities.sh
+++ b/DATA/production/workflow-multiplicities.sh
@@ -209,6 +209,11 @@ fi
 
 if [[ "$HIGH_RATE_PP" == "1" ]]; then
   : ${CUT_RANDOM_FRACTION_ITS:=0.97}
+elif [[ $BEAMTYPE == "PbPb" ]]; then
+  : ${CUT_RANDOM_FRACTION_ITS:=-1}
+  : ${CUT_MULT_MIN_ITS:=100}
+  : ${CUT_MULT_MAX_ITS:=200}
+  : ${CUT_MULT_VTX_ITS:=20}
 else
   : ${CUT_RANDOM_FRACTION_ITS:=0.95}
 fi


### PR DESCRIPTION
At the moment in the online PbPb the ITS reconstructs by defuilt 30-2000 tracks multiplicity range, corresponding to 53% of collisions and 28% of tracks of LHC22s spectrum. Additionally, we randomly downscale multiplicity-selected ROFs 5%, going to 2.6% collisions and naively 1.4% of all tracks but in reality more since we prioritize ROFs with triggers.

O2 https://github.com/AliceO2Group/AliceO2/pull/11853 makes more precise the mult estimated (tuned on LHC22s) and this PR sets the selected ITS multiplicity to 100:200 tracks range, which corresponds to ~7% of LHC22s ITS mult.spectrum and 1% of tracks. The random selection is turned off by default. The same settings are in the defaults of dpl-workflow.sh.

If needed, the prescaling can be modified via CUT_MULT_MIN_ITS and CUT_MULT_MAX_ITS env.vars.