### PR TITLE
Enable TRD QC tracking task by default

### DIFF
--- a/DATA/production/qc-async/trd.json
+++ b/DATA/production/qc-async/trd.json
@@ -60,7 +60,7 @@
         }
       },
       "Tracking": {
-        "active": "false",
+        "active": "true",
         "className": "o2::quality_control_modules::trd::TrackingTask",
         "moduleName": "QcTRD",
         "detectorName": "TRD",

--- a/DATA/production/qc-sync/trd.json
+++ b/DATA/production/qc-sync/trd.json
@@ -129,7 +129,7 @@
         ]
       },
       "Tracking": {
-        "active": "false",
+        "active": "true",
         "className": "o2::quality_control_modules::trd::TrackingTask",
         "moduleName": "QcTRD",
         "detectorName": "TRD",

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -244,6 +244,10 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
         add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.Tracking.active=false'
         add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.PHTrackMatch.active=false'
       fi
+      if has_matching_qc TPCTRD && has_detectors_reco TPC TRD; then # should be only enabled in async
+        add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.Tracking.dataSource.query=\"trackITSTPCTRD:TRD/MATCH_ITSTPC\;trigITSTPCTRD:TRD/TRGREC_ITSTPC\;trackTPCTRD:TRD/MATCH_TPC\;trigTPCTRD:TRD/TRGREC_TPC\"'
+        add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.Tracking.taskParameters.trackSources=\"ITS-TPC-TRD,TPC-TRD\"'
+      fi
     fi
   fi
 


### PR DESCRIPTION
@chiarazampolli this should be what is needed to have at least some tracking QC for async. But I still need to test on staging if this does not break something when there is no TPC-TRD matching enabled