### PR TITLE
remove ft0 usage from TOF calib

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -405,7 +405,7 @@ export CONFIG_EXTRA_PROCESS_o2_tpcits_match_workflow+=";$ITSEXTRAERR;$ITSTPCMATC
 has_detector FT0 && export ARGS_EXTRA_PROCESS_o2_tpcits_match_workflow="$ARGS_EXTRA_PROCESS_o2_tpcits_match_workflow --use-ft0"
 
 # ad-hoc settings for TOF matching
-export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="$ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow --output-type matching-info,calib-info --enable-dia --use-fit"
+export ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow="$ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow --output-type matching-info,calib-info --enable-dia"
 export CONFIG_EXTRA_PROCESS_o2_tof_matcher_workflow+=";$ITSEXTRAERR;$TRACKTUNETPC;$VDRIFTPARAMOPTION;"
 
 # ad-hoc settings for TRD matching


### PR DESCRIPTION
I found that TOF calib infos when using FT0 (recently introduced) are not as expected and cannot be used for calibration.
For the moment we cannot use it. Restore to previous behavior.
