### PR TITLE
Enable TRD gain calib ROOT output

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -484,6 +484,7 @@ if [[ $ADD_CALIB == "1" ]]; then
     export SVERTEXING_SOURCES=none # disable secondary vertexing
   fi
   if [[ $ALIEN_JDL_DOTRDGAINCALIB == 1 ]]; then
+    export ARGS_EXTRA_PROCESS_o2_calibration_trd_workflow="$ARGS_EXTRA_PROCESS_o2_calibration_trd_workflow --enable-root-output"
     export CALIB_TRD_GAIN=1
   fi
   if [[ $ALIEN_JDL_DOUPLOADSLOCALLY == 1 ]]; then


### PR DESCRIPTION
Hi @chiarazampolli 
sorry, I did not think this through. If we run the gain calibration offline we need to enable the ROOT output, so that we can prepare the manual upload of calibration objects afterwards.
The additional file we'll need to keep is `trd_calibgain.root`.
Cheers,
Ole