### PR TITLE
[EMCAL-756] Add pileup cut for total energy histograms

### DIFF
--- a/DATA/production/qc-async/emc_PbPb.json
+++ b/DATA/production/qc-async/emc_PbPb.json
@@ -42,7 +42,8 @@
           "MultiplicityRangeSMThreshold": "200",
           "TotalEnergyRangeDetector": "700",
           "TotalEnergyRangeSM": "200",
-          "TotalEnergyRange": "2000" 
+          "TotalEnergyRange": "2000",
+          "TotalEnergyMaxCellTime": "25"
         }
       },
       "ClusterTaskEMCAL": {


### PR DESCRIPTION
Total energy has pileup tail, 25 ns cut sufficient for a 50 ns filling scheme.