### PR TITLE
Small fix to heavy-quark rapidity check for HF generator

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -88,12 +88,18 @@ protected:
         auto daughterList = event[iPart].daughterList();
         bool hasQ = false, hasQbar = false, atSelectedY = false;
         for (auto iDau : daughterList) {
-          if (event[iDau].id() == mQuarkPdg)
+          if (event[iDau].id() == mQuarkPdg) {
             hasQ = true;
-          if (event[iDau].id() == -mQuarkPdg)
+            if ((event[iDau].y() > mQuarkRapidityMin) && (event[iDau].y() < mQuarkRapidityMax)) {
+              atSelectedY = true;
+            }
+          }
+          if (event[iDau].id() == -mQuarkPdg) {
             hasQbar = true;
-          if ((event[iDau].y() > mQuarkRapidityMin) && (event[iDau].y() < mQuarkRapidityMax))
-            atSelectedY = true;
+            if ((event[iDau].y() > mQuarkRapidityMin) && (event[iDau].y() < mQuarkRapidityMax)) {
+              atSelectedY = true;
+            }
+          }  
         }
         if (hasQ && hasQbar && atSelectedY) {
           isGoodAtPartonLevel = true;


### PR DESCRIPTION
Previously the requirement of having a heavy quark with rapidity within the defined window could be satisfied by another parton not composing the heavy-quark pair.

I tested the change generating 20000 b-bbar events with the old and new behavior and requiring a rapidity window between -1 and 1 (the seed is also the same for the two productions).  

The rapidity vs pt distribution for the old rapidity check
![RapDistr_oldLogic](https://github.com/AliceO2Group/O2DPG/assets/11328262/1bed2de6-d472-487d-a123-287af02f4ba7)

The same for the new rapidity check
![RapDistr_newLogic](https://github.com/AliceO2Group/O2DPG/assets/11328262/ae196276-ffbb-4768-96e2-bbe6aad714c2)

Plotting the difference between the old and the new distributions (old-new), there is an improvement: events with b quarks at very low pT and large rapidity are removed, while new ones with larger pT and closer to the rapidity window are generated.
![image](https://github.com/AliceO2Group/O2DPG/assets/11328262/3bc2528f-2c8d-4fbe-a828-2d1204477b2d)

@fgrosa @fcolamar @cterrevo @ZFederica @zhangbiao-phy @mfaggin The difference w.r.t. the previous code is small, but I would merge this since there is an improvement of the generation process.
