### PR TITLE
Add track-extra-converter dependency.

### DIFF
--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -189,6 +189,7 @@ def get_additional_workflows(input_aod):
         found_O2collision_001 = False
         found_O2zdc_001 = False
         found_O2bc_001 = False
+        found_O2trackextra_001 = False
         for i in froot.GetListOfKeys():
             if "DF_" not in i.GetName():
                 continue
@@ -202,12 +203,16 @@ def get_additional_workflows(input_aod):
                     found_O2zdc_001 = True
                 if "O2bc_001" in j.GetName():
                     found_O2bc_001 = True
+                if "O2trackextra" in j.GetName():
+                    found_O2trackextra_001 = True 
             if not found_O2collision_001:
                 additional_workflows.append("o2-analysis-collision-converter --doNotSwap")
             if not found_O2zdc_001:
                 additional_workflows.append("o2-analysis-zdc-converter")
             if not found_O2bc_001:
                 additional_workflows.append("o2-analysis-bc-converter")
+            if found_O2trackextra_001:
+                additional_workflows.append("o2-analysis-tracks-extra-converter")
             break
     return additional_workflows
 

--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -211,7 +211,7 @@ def get_additional_workflows(input_aod):
                 additional_workflows.append("o2-analysis-zdc-converter")
             if not found_O2bc_001:
                 additional_workflows.append("o2-analysis-bc-converter")
-            if found_O2trackextra_001:
+            if not found_O2trackextra_001:
                 additional_workflows.append("o2-analysis-tracks-extra-converter")
             break
     return additional_workflows

--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -203,7 +203,7 @@ def get_additional_workflows(input_aod):
                     found_O2zdc_001 = True
                 if "O2bc_001" in j.GetName():
                     found_O2bc_001 = True
-                if "O2trackextra" in j.GetName():
+                if "O2trackextra_001" in j.GetName():
                     found_O2trackextra_001 = True 
             if not found_O2collision_001:
                 additional_workflows.append("o2-analysis-collision-converter --doNotSwap")


### PR DESCRIPTION
Extra dependency needed for AO2Ds produced with O2 tags not including this PR: [12087](https://github.com/AliceO2Group/AliceO2/pull/12087).

See also comment from David Chinellato in the O2 Analysis Announcements Mattermost channel on 27th October 2023: [link](https://mattermost.web.cern.ch/alice/pl/4esghoynzjyxtqnsgmgsb91dqe)