### PR TITLE
Keep parton-event information

### DIFF
--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar.ini
@@ -5,3 +5,4 @@ funcName=GeneratorPythia8GapTriggeredBeauty(3, -1.5, 1.5)
 
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar.ini
@@ -5,3 +5,4 @@ funcName=GeneratorPythia8GapTriggeredCharm(3, -1.5, 1.5)
 
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar.ini
@@ -5,3 +5,4 @@ funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(2, -1.5, 1.5)
 
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+includePartonEvent=true


### PR DESCRIPTION
Needed since [this commit](https://github.com/AliceO2Group/AliceO2/commit/a3142359b3b535f0654077234eeeadc1c313b64e) changed the default behavior. This information is particularly useful in the debug phase of the MC production.