### PR TITLE
Change --require-tpc-lumi option to --lumi-type <type>

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -97,7 +97,7 @@ if [[ -z "${IS_TRIGGERED_DATA:-}" ]]; then export IS_TRIGGERED_DATA=0; fi       
 if [[ -z "${CTF_DIR:-}" ]];           then CTF_DIR=$FILEWORKDIR; fi             # Directory where to store CTFs
 if [[ -z "${CALIB_DIR:-}" ]];         then CALIB_DIR="/dev/null"; fi            # Directory where to store output from calibration workflows, /dev/null : skip their writing
 if [[ -z "${EPN2EOS_METAFILES_DIR:-}" ]]; then EPN2EOS_METAFILES_DIR="/dev/null"; fi # Directory where to store epn2eos files metada, /dev/null : skip their writing
-if [[ -z "${TPC_CORR_SCALING:-}" ]]; then export TPC_CORR_SCALING=""; fi      # TPC corr.map lumi scaling options, any combination of --require-ctp-lumi, --corrmap-lumi-mean <float>, --corrmap-lumi-inst <float>, --ctp-lumi-factor <float=1>, --ctp-lumi-source <int=0>
+if [[ -z "${TPC_CORR_SCALING:-}" ]]; then export TPC_CORR_SCALING=""; fi      # TPC corr.map lumi scaling options, any combination of --lumi-type 0 or 1 or 2, --corrmap-lumi-mean <float>, --corrmap-lumi-inst <float>, --ctp-lumi-factor <float=1>, --ctp-lumi-source <int=0>
 if [[ $EPNSYNCMODE == 0 ]]; then
   if [[ -z "${SHMSIZE:-}" ]];       then export SHMSIZE=$(( 8 << 30 )); fi    # Size of shared memory for messages
   if [[ -z "${NGPUS:-}" ]];         then export NGPUS=1; fi                   # Number of GPUs to use, data distributed round-robin

--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -320,7 +320,10 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
       return 1
     fi
     echo "Using CTP inst lumi stored in data"
-    export TPC_CORR_SCALING+=" --require-ctp-lumi "
+    export TPC_CORR_SCALING+=" --lumi-type 1 "
+  elif [[ $INST_IR_FOR_TPC == "IDCCCDB" ]]; then
+    echo "TPC correction with IDC from CCDB will ne used"
+    export TPC_CORR_SCALING+=" --lumi-type 2 "
   else
     echo "Unknown setting for INST_IR_FOR_TPC = $INST_IR_FOR_TPC (with ALIEN_JDL_INST_IR_FOR_TPC = $ALIEN_JDL_INST_IR_FOR_TPC)"
     return 1
@@ -332,11 +335,11 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
 
   if [[ $ALIEN_JDL_LPMANCHORYEAR == "2023" ]] && [[ $BEAMTYPE == "PbPb" ]]; then
     unset TPC_CORR_SCALING
-    export TPC_CORR_SCALING=" --ctp-lumi-factor 2.414 --require-ctp-lumi"
+    export TPC_CORR_SCALING=" --ctp-lumi-factor 2.414 --lumi-type 1"
     if [[ $SCALE_WITH_ZDC == 0 ]]; then
       # scaling with FT0
       if [[ $SCALE_WITH_FT0 == 1 ]]; then
-	export TPC_CORR_SCALING=" --ctp-lumi-source 1 --ctp-lumi-factor 135. --require-ctp-lumi "
+	export TPC_CORR_SCALING=" --ctp-lumi-source 1 --ctp-lumi-factor 135. --lumi-type 1 "
       else
 	echo "Neither ZDC nor FT0 are in the run, and this is from 2023 PbPb: we cannot scale TPC ditortion corrections, aborting..."
 	return 1

--- a/UTILS/parse-async-WorkflowConfig.py
+++ b/UTILS/parse-async-WorkflowConfig.py
@@ -193,8 +193,9 @@ def parse_important_DPL_args(cmds, flat_config):
          s2 = extract_args(tokens, '--corrmap-lumi-mean')
          if s2:
             corrstring += ' --corrmap-lumi-mean ' + s2
-         if '--require-ctp-lumi' in tokens:
-            corrstring += ' --require-ctp-lumi '
+         s3 = extract_args(tokens, '--lumi-type')
+         if s3:
+            corrstring += ' --lumi-type ' + s3
          # these are some options applied in multiple places (so save them flatly under tpc-corr-scaling)
          flat_config['tpc-corr-scaling'] = corrstring
 


### PR DESCRIPTION
Following PR#12205 and PR#12237 instead of boolean switch --require-tpc-lumi one should use --lumi-type <int_type>  option with the meaning:
0 : no dynamic scaling
1 : require CTP lumi for TPC correction scaling
2 : require TPC scalers from CCDB for TPC correction scaling

--lumi-type 1 corresponds to previous ALIEN_JDL_INSTIRFORTPC=CTP --lumi-type 2 corresponds to previous ALIEN_JDL_INSTIRFORTPC=IDCCCDB