### PR TITLE
ITS tracker: release tracklets/cells selection for Pb-Pb tests

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -369,7 +369,7 @@ export ITSEXTRAERR="ITSCATrackerParam.sysErrY2[0]=$ERRIB;ITSCATrackerParam.sysEr
 # ad-hoc options for ITS reco workflow
 EXTRA_ITSRECO_CONFIG=
 if [[ $BEAMTYPE == "PbPb" ]]; then
-  EXTRA_ITSRECO_CONFIG="ITSCATrackerParam.trackletsPerClusterLimit=5.;ITSCATrackerParam.cellsPerClusterLimit=5.;ITSVertexerParam.clusterContributorsCut=16;ITSVertexerParam.lowMultBeamDistCut=0;"
+  EXTRA_ITSRECO_CONFIG="ITSCATrackerParam.trackletsPerClusterLimit=15.;ITSCATrackerParam.cellsPerClusterLimit=35.;ITSVertexerParam.clusterContributorsCut=16;ITSVertexerParam.lowMultBeamDistCut=0;"
 elif [[ $BEAMTYPE == "pp" ]]; then
   EXTRA_ITSRECO_CONFIG="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;"
 fi


### PR DESCRIPTION
@chiarazampolli : in run: `544116  @38342 Hz`, these thresholds are beyond the measured distribution.
For instance, the attached image is the dist for `cellsPerClusters`-only, since `trackletPerClusters` never exceeds its threshold.
It is however the case for higher IR, therefore I set the two cuts such as I know they should work.

This should be ready for the tests. I left non-fatal behaviour to allow the processing of the logs to double-check, as I understood this is not yet in production.

CC-ing: @mpuccio @shahor02 

<img width="1455" alt="Screenshot 2023-11-13 at 17 49 43" src="https://github.com/AliceO2Group/O2DPG/assets/4990252/e2b170d7-d0d3-45d6-a8cf-fef975c70a10">
