### PR TITLE
Clean and adapt config files for EventaTrack AnalysisQC

### DIFF
--- a/MC/config/analysis_testing/json/EventSelectionQA/pbpb/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/EventSelectionQA/pbpb/analysis-testing-data.json
@@ -270,67 +270,14 @@
     }
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
+    "overwriteAxisRangeForPbPb": "true",
     "processData": "true",
-    "processDataIU": "false",
+    "processDataIU": "true",
     "processDataIUFiltered": "false",
     "processMC": "false",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "qa-k0s-tracking-efficiency": {

--- a/MC/config/analysis_testing/json/EventTrackQA/pbpb/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/EventTrackQA/pbpb/analysis-testing-data.json
@@ -11,67 +11,14 @@
     "syst": "pp"
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
+    "overwriteAxisRangeForPbPb": "true",
     "processData": "true",
     "processDataIU": "true",
-    "processDataIUFiltered": "true",
+    "processDataIUFiltered": "false",
     "processMC": "false",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "track-propagation": {

--- a/MC/config/analysis_testing/json/EventTrackQA/pp/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/EventTrackQA/pp/analysis-testing-data.json
@@ -11,67 +11,13 @@
     "syst": "pp"
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
     "processData": "true",
     "processDataIU": "true",
-    "processDataIUFiltered": "true",
+    "processDataIUFiltered": "false",
     "processMC": "false",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "track-propagation": {

--- a/MC/config/analysis_testing/json/default/pbpb/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/default/pbpb/analysis-testing-data.json
@@ -269,67 +269,14 @@
     }
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
+    "overwriteAxisRangeForPbPb": "true",
     "processData": "true",
-    "processDataIU": "false",
+    "processDataIU": "true",
     "processDataIUFiltered": "false",
     "processMC": "false",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "qa-k0s-tracking-efficiency": {

--- a/MC/config/analysis_testing/json/default/pbpb/analysis-testing-mc.json
+++ b/MC/config/analysis_testing/json/default/pbpb/analysis-testing-mc.json
@@ -1029,67 +1029,14 @@
     }
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
-    "processData": "true",
+    "checkOnlyPVContributor": "true",
+    "overwriteAxisRangeForPbPb": "true",
+    "processData": "false",
     "processDataIU": "false",
     "processDataIUFiltered": "false",
     "processMC": "true",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "table-maker-m-c": {

--- a/MC/config/analysis_testing/json/default/pp/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/default/pp/analysis-testing-data.json
@@ -269,67 +269,13 @@
     }
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
     "processData": "true",
-    "processDataIU": "false",
+    "processDataIU": "true",
     "processDataIUFiltered": "false",
     "processMC": "false",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "qa-k0s-tracking-efficiency": {

--- a/MC/config/analysis_testing/json/default/pp/analysis-testing-mc.json
+++ b/MC/config/analysis_testing/json/default/pp/analysis-testing-mc.json
@@ -1029,67 +1029,13 @@
     }
   },
   "qa-event-track": {
-    "binsPt": {
-      "values": [
-        "0",
-        "0",
-        "0.10000000000000001",
-        "0.20000000000000001",
-        "0.29999999999999999",
-        "0.40000000000000002",
-        "0.5",
-        "0.59999999999999998",
-        "0.69999999999999996",
-        "0.80000000000000004",
-        "0.90000000000000002",
-        "1",
-        "1.1000000000000001",
-        "1.2",
-        "1.3",
-        "1.3999999999999999",
-        "1.5",
-        "2",
-        "5",
-        "10",
-        "20",
-        "50"
-      ]
-    },
-    "binsVertexPosXY": {
-      "values": [
-        "500",
-        "-1",
-        "1"
-      ]
-    },
-    "binsVertexPosZ": {
-      "values": [
-        "100",
-        "-20",
-        "20"
-      ]
-    },
-    "fractionOfSampledEvents": "1",
-    "isRun3": "true",
-    "maxEta": "2",
-    "maxPhi": "10",
-    "maxPt": "1e+10",
-    "minEta": "-2",
-    "minPhi": "-1",
-    "minPt": "-10",
+    "checkOnlyPVContributor": "true",
     "processData": "true",
-    "processDataIU": "false",
+    "processDataIU": "true",
     "processDataIUFiltered": "false",
     "processMC": "true",
     "processTableData": "false",
     "processTableMC": "false",
-    "selectCharge": "0",
-    "selectGoodEvents": "true",
-    "selectMaxVtxZ": "100",
-    "selectPID": "0",
-    "selectPrim": "false",
-    "selectSec": "false",
-    "targetNumberOfEvents": "10000000",
     "trackSelection": "1"
   },
   "table-maker-m-c": {


### PR DESCRIPTION
 - clean all obsolete Configurables
 - remove most of Configurables set to default values
 - switch-on the overwriteAxisRangeForPbPb flag, to rearrange multiplicity axes for Pb-Pb
    !!! O2Physics PR https://github.com/AliceO2Group/O2Physics/pull/3883#pullrequestreview-1735107548 mandatory!!!
 - enable the processing only for PV contributor tracks