### PR TITLE
fixing missing inputs in TRD digit

### DIFF
--- a/MC/config/QC/json/trd-digits-task.json
+++ b/MC/config/QC/json/trd-digits-task.json
@@ -39,7 +39,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD"
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD;noiseMap:TRD/NOISEMAP/0?lifetime=condition&ccdb-path=TRD/Calib/NoiseMapMCM;chamberStatus:TRD/CHSTATUS/0?lifetime=condition&ccdb-path=TRD/Calib/HalfChamberStatusQC"
         },
         "taskParameters": {
           "peakregionstart": "7.0",


### PR DESCRIPTION
@chiarazampolli @catalinristea 
This is needed to resume Pb-Pb MC