### PR TITLE
[EMCAL-1037]  Add CTP config input spec

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -73,7 +73,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-triggers:EMC/CELLSTRGR/0;ctp-digits:CTP/DIGITS"
+          "query": "emcal-triggers:EMC/CELLSTRGR/0;ctp-digits:CTP/DIGITS;ctp-config:CTP/CONFIG/0?lifetime=condition&ccdb-path=CTP/Config/Config&ccdb-run-dependent=true"
         },
         "taskParameters": {
         }

--- a/DATA/production/qc-async/emc_PbPb.json
+++ b/DATA/production/qc-async/emc_PbPb.json
@@ -87,7 +87,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "emcal-triggers:EMC/CELLSTRGR/0;ctp-digits:CTP/DIGITS"
+          "query": "emcal-triggers:EMC/CELLSTRGR/0;ctp-digits:CTP/DIGITS;ctp-config:CTP/CONFIG/0?lifetime=condition&ccdb-path=CTP/Config/Config&ccdb-run-dependent=true"
         },
         "taskParameters": {
           "AliasMB" : "CMTVXTSC"


### PR DESCRIPTION
Input Spec for DPL CCDB backend for CTP
configuration added, as the DPL CCDB backend
replaced the QC CCDB backend in the task.