### PR TITLE
[PbPb-async-MC-RelVal][O2-4445]: Remove obsolete cuts for ITS iterations

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -83,8 +83,6 @@ def create_sim_config(args):
 
     # deal with larger combinatorics
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):
-        add(config, {"ITSCATrackerParam.trackletsPerClusterLimit": 20,
-                     "ITSCATrackerParam.cellsPerClusterLimit": 20,
-                     "ITSVertexerParam.lowMultBeamDistCut": "0."})
+        add(config, {"ITSVertexerParam.lowMultBeamDistCut": "0."})
 
     return config


### PR DESCRIPTION
These selections are obsoleted, and the behaviour has been changed in https://github.com/AliceO2Group/AliceO2/pull/12256
See https://github.com/AliceO2Group/O2DPG/pull/1336 proposing the same change for data.

@mpuccio 