### PR TITLE
fix ft0 ctp input for pp case

### DIFF
--- a/MC/bin/o2dpg_sim_workflow_anchored.py
+++ b/MC/bin/o2dpg_sim_workflow_anchored.py
@@ -232,7 +232,7 @@ def retrieve_MinBias_CTPScaler_Rate(ctpscaler, finaltime, trig_eff, NBunches, Co
     """
     # this is the default for pp
     ctpclass = 0 # <---- we take the scaler for FT0
-    ctptype = 0
+    ctptype = 1
     # this is the default for PbPb
     if ColSystem == "PbPb":
       ctpclass = 25  # <--- we take scalers for ZDC


### PR DESCRIPTION
Dear @benedikt-voelkel , @chiarazampolli , @sawenzel , @shahor02 , @gconesab,
this is to recover the right behaviour in pp anchored MC (temporary solution) since ctpinput=0 is invalid.
Final solution has to be discussed with Roman