### PR TITLE
Add TPC as default source for the svertexer

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1320,7 +1320,7 @@ for tf in range(1, NTIMEFRAMES + 1):
    # Take None as default, we only add more if nothing from anchorConfig
    svfinder_sources = anchorConfig.get("o2-secondary-vertexing-workflow-options",{}).get("vertexing-sources", None)
    if not svfinder_sources:
-      svfinder_sources = "ITS,ITS-TPC,TPC-TRD,TPC-TOF,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF"
+      svfinder_sources = "ITS,TPC,ITS-TPC,TPC-TRD,TPC-TOF,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF"
       if isActive("MID"):
         svfinder_sources += ",MID"
    SVFINDERtask['cmd'] += ' --vertexing-sources ' + svfinder_sources + (' --combine-source-devices','')[args.no_combine_dpl_devices]


### PR DESCRIPTION
The work presented in https://indico.cern.ch/event/1351889/contributions/5696031/attachments/2762206/4810535/291123.pdf has been merged, and TPC only tracks have been added by default to the reconstruction. This PR updates the reconstruction in the simulation as well. @ddobrigk @shahor02 @f3sch