### PR TITLE
FIT: add digitizer settings for MC anchored to 2023 PbPb

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -85,6 +85,11 @@ def create_sim_config(args):
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):
         add(config, {"ITSVertexerParam.lowMultBeamDistCut": "0."})
 
+    # FIT digitizer settings for 2023 PbPb
+    if 543437 <= int(args.run) and int(args.run) <= 545367:
+        add(config, {"FT0DigParam.mMip_in_V": "7", "FT0DigParam.mMV_2_Nchannels": "2", "FT0DigParam.mMV_2_NchannelsInverse": "0.5"})
+        add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+
     return config
 
 


### PR DESCRIPTION
Provide FT0 and FV0 gain settings for MC anchored to 2023 PbPb. This is temporary and will be removed when these settings are pulled from CCDB.