### PR TITLE
LF: fix bug in N:1 gap-triggering

### DIFF
--- a/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
@@ -165,7 +165,7 @@ class GeneratorPythia8LF : public o2::eventgen::GeneratorPythia8
         if (mGapBetweenInjection > 0) {
           if (mGapBetweenInjection == 1 && mEventCounter % 2 == 0) {
             doSignal = false;
-          } else if (mEventCounter % mGapBetweenInjection != 0) {
+          } else if (mEventCounter % mGapBetweenInjection + 1 != 0) {
             doSignal = false;
           }
         }


### PR DESCRIPTION
@njacazio this fixes the "number of events between trigger" to be correct. At the moment, for N > 1, the gap-to-triggered ratio is (N-1):1 and not N:1 as the name of the variable suggests. Note this may offset our conclusions regarding [O2-3702](https://its.cern.ch/jira/browse/O2-3702) - though AFAIK this is the only use case so far. 