### PR TITLE
Possibility to take external config for Pythia8

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -97,6 +97,8 @@ def create_geant_config(args, externalConfigString):
     # creates generic transport simulation config key values
     # based on arguments args (run number, energy, ...) originally passed
     # to o2dpg_sim_workflow.py
+    #
+    # returns a dictionary of mainkey -> dictionary of subkey : values
     config = {}
     def add(cfg, flatconfig):
        for entry in flatconfig:


### PR DESCRIPTION
In case of generator pythia8, we have so far always constructed a Pythia8 config file from the parameters given to o2dpg_sim_workflow.py

However, some expert users may want to use an external configuration for Pythia8.

This commit provides the possibility to do so via sensitivity to the `GeneratorPythia8.config` ConfigurableParam (so far ignored).

An example is:

```
${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 14000 -col pp -gen pythia8 -proc cdiff -tf 2      \
                                           -ns 20 -e ${SIMENGINE}                                 \
                                           -j ${NWORKERS} -interactionRate 500000                 \
                                           -run 302000 -seed 624                                  \
                                           -confKey "GeneratorPythia8.config=/SOMEPATH/pythia8_powheg.cfg"
```

The new feature allows expert studies with specially setup Pythia8 configs. The development was motivated from https://its.cern.ch/jira/browse/O2-4549

However, note that options `-proc` `-eCM` etc. might have no effect or are ignored in such cases.