### PR TITLE
TPC QC allow proper init of propagator to avoid error message in FST

### DIFF
--- a/DATA/production/qc-sync/tpc.json
+++ b/DATA/production/qc-sync/tpc.json
@@ -110,6 +110,16 @@
           "cutMinNCluster": "60",
           "cutMindEdxTot": "20."
         },
+        "grpGeomRequest" : {
+          "geomRequest": "Aligned",
+          "askGRPECS": "false",
+          "askGRPLHCIF": "false",
+          "askGRPMagField": "true",
+          "askMatLUT": "true",
+          "askTime": "false",
+          "askOnceAllButField": "true",
+          "needPropagatorD":  "false"
+	      },
         "location": "local",
         "localMachines": [
           "localhost",


### PR DESCRIPTION
To avoid triggering the error here in the FST CI:
```
Detectors/TPC/qc/src/Tracks.cxx:185:          LOGP(error, "o2::base::Propagator not properly initialized, MatLUT ({}) and / or Field ({}) missing, will not fill DCA histograms", (void*)propagator->getMatLUT(), propagator->hasMagFieldSet());
```