### PR TITLE
Fix syntax checks for shell scripts

### DIFF
--- a/DATA/common/gen_topo_helper_functions.sh
+++ b/DATA/common/gen_topo_helper_functions.sh
@@ -104,37 +104,37 @@ _check_multiple()
 
 has_detectors()
 {
-  _check_multiple has_detector $@
+  _check_multiple has_detector "$@"
 }
 
 has_detectors_qc()
 {
-  _check_multiple has_detector_qc $@
+  _check_multiple has_detector_qc "$@"
 }
 
 has_detectors_calib()
 {
-  _check_multiple has_detector_calib $@
+  _check_multiple has_detector_calib "$@"
 }
 
 has_detectors_reco()
 {
-  _check_multiple has_detector_reco $@
+  _check_multiple has_detector_reco "$@"
 }
 
 has_detectors_ctf()
 {
-  _check_multiple has_detector_ctf $@
+  _check_multiple has_detector_ctf "$@"
 }
 
 has_detectors_flp_processing()
 {
-  _check_multiple has_detector_flp_processing $@
+  _check_multiple has_detector_flp_processing "$@"
 }
 
 workflow_has_parameters()
 {
-  _check_multiple workflow_has_parameter $@
+  _check_multiple workflow_has_parameter "$@"
 }
 
 add_comma_separated()

--- a/DATA/common/setenv_calib.sh
+++ b/DATA/common/setenv_calib.sh
@@ -14,7 +14,7 @@ SOURCE_GUARD_SETENV_CALIB=1
 # define the conditions for each calibration
 if has_detector_calib ITS && has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]]; then CAN_DO_CALIB_PRIMVTX_MEANVTX=1; else CAN_DO_CALIB_PRIMVTX_MEANVTX=0; fi
 if has_detector_calib TOF && has_detector_reco TOF; then CAN_DO_CALIB_TOF_DIAGNOSTICS=1; CAN_DO_CALIB_TOF_INTEGRATEDCURR=1; else CAN_DO_CALIB_TOF_DIAGNOSTICS=0; CAN_DO_CALIB_TOF_INTEGRATEDCURR=0; fi
-if has_detector_calib TOF && has_detector_reco TOF && (( has_detectors_reco ITS TPC && has_detector_matching ITSTPCTOF ) || ( has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRDTOF )); then CAN_DO_CALIB_TOF_LHCPHASE=1; CAN_DO_CALIB_TOF_CHANNELOFFSETS=1; else CAN_DO_CALIB_TOF_LHCPHASE=0; CAN_DO_CALIB_TOF_CHANNELOFFSETS=0; fi
+if has_detector_calib TOF && has_detector_reco TOF && ( ( has_detectors_reco ITS TPC && has_detector_matching ITSTPCTOF ) || ( has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRDTOF ) ); then CAN_DO_CALIB_TOF_LHCPHASE=1; CAN_DO_CALIB_TOF_CHANNELOFFSETS=1; else CAN_DO_CALIB_TOF_LHCPHASE=0; CAN_DO_CALIB_TOF_CHANNELOFFSETS=0; fi
 if has_detector_calib TPC && has_detectors ITS TPC TOF TRD && has_detector_matching ITSTPCTRDTOF; then CAN_DO_CALIB_TPC_SCDCALIB=1; else CAN_DO_CALIB_TPC_SCDCALIB=0; fi
 if has_detector_calib TPC && has_processing_step TPC_DEDX; then CAN_DO_CALIB_TPC_TIMEGAIN=1; CAN_DO_CALIB_TPC_RESPADGAIN=1; else CAN_DO_CALIB_TPC_TIMEGAIN=0; CAN_DO_CALIB_TPC_RESPADGAIN=0; fi
 if has_detector_calib TPC && has_detectors ITS TPC && has_detector_matching ITSTPC; then CAN_DO_CALIB_TPC_VDRIFTTGL=1; else CAN_DO_CALIB_TPC_VDRIFTTGL=0; fi

--- a/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
+++ b/DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh
@@ -72,6 +72,7 @@ fi
 CTP_BC_SHIFT=0
 if [[ $ALIEN_JDL_LPMANCHORYEAR == "2022" ]]; then
   CTP_BC_SHIFT=-294
+fi
 if [[ $RUNNUMBER -ge 538923 ]] && [[ $RUNNUMBER -le 539700 ]]; then
   # 3 BC offset (future direction) in CTP data observed for LHC23zd - LHC23zs
   CTP_BC_SHIFT=-3

--- a/DATA/production/configurations/asyncReco/async_pass.sh
+++ b/DATA/production/configurations/asyncReco/async_pass.sh
@@ -576,7 +576,7 @@ else
           echo "nCTFsFilesInspected_step1 = $nCTFsFilesInspected_step1, nCTFsFilesInspected_step2 = $nCTFsFilesInspected_step2" > validation_error.message
           echo "nCTFsFilesOK_step1 = $nCTFsFilesOK_step1, nCTFsFilesOK_step2 = $nCTFsFilesOK_step2" > validation_error.message
           echo "nCTFsProcessed_step1 = $nCTFsProcessed_step1, nCTFsProcessed_step2 = $nCTFsProcessed_step2" > validation_error.message
-          exit 1000
+          exit 255
         fi
       fi
     fi
@@ -745,7 +745,7 @@ if [[ $ALIEN_JDL_AODOFF != 1 ]]; then
       CURRENT_POOL_SIZE=`jobs -r | wc -l`
     done < $JOB_LIST
     # collecting return codes of the merging processes
-    for i in ${!arr[@]}; do
+    for i in "${!arr[@]}"; do
       wait ${arr[$i]}
       exitcode=$?
       if [[ $exitcode -ne 0 ]]; then


### PR DESCRIPTION
To make the new check added in https://github.com/AliceO2Group/O2DPG/pull/1469/files happy.

The functionality remains the same, only the `DATA/production/configurations/2022/LHC22f/apass1/setenv_extra.sh` script had a bug but I believe this is not used anymore in any case.