### PR TITLE
Cleanup of predefined ECS configurations

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -110,7 +110,6 @@ if [[ -z "${IS_TRIGGERED_DATA:-}" ]]; then export IS_TRIGGERED_DATA=0; fi       
 if [[ -z "${CTF_DIR:-}" ]];           then CTF_DIR=$FILEWORKDIR; fi             # Directory where to store CTFs
 if [[ -z "${CALIB_DIR:-}" ]];         then CALIB_DIR="/dev/null"; fi            # Directory where to store output from calibration workflows, /dev/null : skip their writing
 if [[ -z "${EPN2EOS_METAFILES_DIR:-}" ]]; then EPN2EOS_METAFILES_DIR="/dev/null"; fi # Directory where to store epn2eos files metada, /dev/null : skip their writing
-if [[ -z "${TPC_CORR_SCALING:-}" ]]; then export TPC_CORR_SCALING=""; fi      # TPC corr.map lumi scaling options, any combination of --lumi-type <0,1,2> --corrmap-lumi-mode <0,1>  and TPCCorrMap... configurable param
 if [[ $EPNSYNCMODE == 0 ]]; then
   if [[ -z "${SHMSIZE:-}" ]];       then export SHMSIZE=$(( 8 << 30 )); fi    # Size of shared memory for messages
   if [[ -z "${NGPUS:-}" ]];         then export NGPUS=1; fi                   # Number of GPUs to use, data distributed round-robin
@@ -164,6 +163,13 @@ DISABLE_ROOT_INPUT="--disable-root-input"
 : ${DISABLE_DIGIT_CLUSTER_INPUT="--clusters-from-upstream"}
 
 # Special detector related settings
+if [[ -z "${TPC_CORR_SCALING:-}" ]]; then # TPC corr.map lumi scaling options, any combination of --lumi-type <0,1,2> --corrmap-lumi-mode <0,1>  and TPCCorrMap... configurable param
+ TPC_CORR_SCALING=
+ if [[ $BEAMTYPE == "pp" ]] || [[ $BEAMTYPE == "PbPb" ]]; then TPC_CORR_SCALING+="--lumi-type 1 TPCCorrMap.lumiInstFactor=2.414"; fi
+ if [[ $BEAMTYPE == "cosmic" ]]; then TPC_CORR_SCALING=" TPCCorrMap.lumiMean=-1;"; fi # for COSMICS we disable all corrections
+ export TPC_CORR_SCALING=$TPC_CORR_SCALING
+fi
+
 MID_FEEID_MAP="$FILEWORKDIR/mid-feeId_mapper.txt"
 
 ITSMFT_STROBES=""

--- a/DATA/production/workflow-multiplicities.sh
+++ b/DATA/production/workflow-multiplicities.sh
@@ -222,7 +222,7 @@ if [[ -z ${EVE_NTH_EVENT:-} ]]; then
     EVE_NTH_EVENT=2
   elif [[ "$HIGH_RATE_PP" == "1" ]]; then
     EVE_NTH_EVENT=10
-  elif [[ $BEAMTYPE == "pp" && "${ED_VERTEX_MODE:-}" == "1" ]]; then
+  elif [[ $BEAMTYPE == "pp" ]]; then
     EVE_NTH_EVENT=$((4 * 250 / $RECO_NUM_NODES_WORKFLOW_CMP))
   else # COSMICS / TECHNICALS / ...
     EVE_NTH_EVENT=1


### PR DESCRIPTION
Hi @shahor02 I have set `TPC_CORR_SCALING` as discussed in https://its.cern.ch/jira/browse/O2-4666. Shall we for synthetic runs disable the correction as we do for cosmics? The current central synthetic configurations don't have `TPC_CORR_SCALING` set, so they are using the default settings at the moment. If the behaviour should remain the same I will update this PR.