### PR TITLE
Fix converter logic for o2-analysis-v0converter in test workflow

### DIFF
--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -190,7 +190,7 @@ def get_additional_workflows(input_aod):
         o2_analysis_converters = {"O2collision_001": "o2-analysis-collision-converter --doNotSwap",
                                   "O2zdc_001": "o2-analysis-zdc-converter",
                                   "O2bc_001": "o2-analysis-bc-converter",
-                                  "O2v0_001": "o2-analysis-v0converter",
+                                  "O2v0_002": "o2-analysis-v0converter",
                                   "O2trackextra_001": "o2-analysis-tracks-extra-converter"}
         for i in froot.GetListOfKeys():
             if "DF_" not in i.GetName():

--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -191,7 +191,8 @@ def get_additional_workflows(input_aod):
                                   "O2zdc_001": "o2-analysis-zdc-converter",
                                   "O2bc_001": "o2-analysis-bc-converter",
                                   "O2v0_002": "o2-analysis-v0converter",
-                                  "O2trackextra_001": "o2-analysis-tracks-extra-converter"}
+                                  "O2trackextra_001": "o2-analysis-tracks-extra-converter",
+                                  "O2ft0corrected": "o2-ft0-corrected-table"}
         for i in froot.GetListOfKeys():
             if "DF_" not in i.GetName():
                 continue

--- a/MC/analysis_testing/o2dpg_analysis_test_workflow.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_workflow.py
@@ -192,7 +192,7 @@ def get_additional_workflows(input_aod):
                                   "O2bc_001": "o2-analysis-bc-converter",
                                   "O2v0_002": "o2-analysis-v0converter",
                                   "O2trackextra_001": "o2-analysis-tracks-extra-converter",
-                                  "O2ft0corrected": "o2-ft0-corrected-table"}
+                                  "O2ft0corrected": "o2-analysis-ft0-corrected-table"}
         for i in froot.GetListOfKeys():
             if "DF_" not in i.GetName():
                 continue


### PR DESCRIPTION
Since o2-analysis-v0converter produces the v0_002 table, it should be checking for that and not O2v0_001 to decide whether to run the converter