### PR TITLE
Default for RECO_NUM_NODES_WORKFLOW_CMP

### DIFF
--- a/DATA/production/workflow-multiplicities.sh
+++ b/DATA/production/workflow-multiplicities.sh
@@ -29,6 +29,7 @@ fi
 if [[ $SYNCMODE == 1 ]]; then NTRDTRKTHREADS=1; else NTRDTRKTHREADS=; fi
 
 : ${NGPURECOTHREADS:=-1} # -1 = auto-detect
+: ${RECO_NUM_NODES_WORKFLOW_CMP:=0}  # 0
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Process multiplicities


### PR DESCRIPTION
@benedikt-voelkel , for https://its.cern.ch/jira/browse/O2-4706
@davidrohr , @martenole : 0 should be invalid as default, but I prefer that it crashes, than to put a meaningless value. Let me know.