### PR TITLE
Enable by default strangeness tracking following data reconstruction)

### DIFF
--- a/MC/config/PWGLF/xsection/g4config_had_x2.in
+++ b/MC/config/PWGLF/xsection/g4config_had_x2.in
@@ -64,10 +64,10 @@
 
 
 # Scale hadronic cross section
-/mcPhysics/setCrossSectionFactor deuteron hadElastic 2.
-/mcPhysics/setCrossSectionFactor anti_deuteron hadElastic 2.
-/mcPhysics/setCrossSectionFactor triton hadElastic 2.
-/mcPhysics/setCrossSectionFactor anti_triton hadElastic 2.
-/mcPhysics/setCrossSectionFactor he3 hadElastic 2.
-/mcPhysics/setCrossSectionFactor anti_he3 hadElastic 2.
+/mcPhysics/setCrossSectionFactor deuteron hadInElastic 2.
+/mcPhysics/setCrossSectionFactor anti_deuteron hadInElastic 2.
+/mcPhysics/setCrossSectionFactor triton hadInElastic 2.
+/mcPhysics/setCrossSectionFactor anti_triton hadInElastic 2.
+/mcPhysics/setCrossSectionFactor he3 hadInElastic 2.
+/mcPhysics/setCrossSectionFactor anti_he3 hadInElastic 2.
 


### PR DESCRIPTION
This ensures consistency between MC and data reconstruction conditions, where strangeness tracking is enabled by default both in pp and Pb--Pb.
In the last GP (see [link](https://alimonitor.cern.ch/job_events.jsp?timesel=0&owner=aliprod&filter_run=544013:544510&filter_jobtype=Pb-Pb%2C+5.36+TeV+-+General+Purpose+anchored+to+Pb-Pb+data+periods+in+LHC23%2C+anchored+to+apass2+%28TRD+fix%29%2C+LHC23k6_TRDFix2%2C+O2-4613)), for example strangeness tracking is excluded while in the corresponding data reconstruction it is not

@mpuccio 