### PR TITLE
TPC reco needs CTP digits

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -948,7 +948,7 @@ for tf in range(1, NTIMEFRAMES + 1):
    # -----------
    # reco
    # -----------
-   tpcreconeeds=[]
+   tpcreconeeds=[FT0FV0EMCCTPDIGItask['name']]
    if not args.combine_tpc_clusterization:
      # We treat TPC clusterization in multiple (sector) steps in order to
      # stay within the memory limit or to parallelize over sector from outside (not yet supported within cluster algo)


### PR DESCRIPTION
spotted when running with non-parallel execution in the pipeline runner