### PR TITLE
Update mult config analysis-testing-data.json

### DIFF
--- a/MC/config/analysis_testing/json/default/pbpb/analysis-testing-data.json
+++ b/MC/config/analysis_testing/json/default/pbpb/analysis-testing-data.json
@@ -185,10 +185,14 @@
         "TPCMults",
         "PVMults",
         "MultsExtra",
+        "MultSelections",
         "MultZeqs",
         "MultsExtraMC"
       ],
       "values": [
+        [
+          "-1"
+        ],
         [
           "-1"
         ],


### PR DESCRIPTION
This update to the multiplicity-table configuration in the PbPb testing workflow is required for compatibility with PR [O2Physics#5003](https://github.com/AliceO2Group/O2Physics/pull/5003) (tags daily-20240307 and newer); current version crashes during initialisation of the multiplicity task on newer O2Physics versions.