### PR TITLE
[SimWF] Protect the -e argument

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -85,7 +85,7 @@ parser.add_argument('-iniBkg',help='embedding background generator init paramete
 parser.add_argument('-confKeyBkg',help='embedding background configuration key values, for example: "GeneratorPythia8.config=pythia8bkg.cfg"', default='')
 parser.add_argument('-colBkg',help='embedding background collision system', default='PbPb')
 
-parser.add_argument('-e',help='simengine', default='TGeant4')
+parser.add_argument('-e',help='simengine', default='TGeant4', choices=['TGeant4', 'TGeant3', 'TFluka'])
 parser.add_argument('-tf',help='number of timeframes', default=2)
 parser.add_argument('--production-offset',help='Offset determining bunch-crossing '
                      + ' range within a (GRID) production. This number sets first orbit to '


### PR DESCRIPTION
Without this, passing -embedding would work and produce a workflow.json. However, the resulting WF has nothing to with embedding, since the real flag for that has 2 dashed: --embedding
What really happened was that the engine would now be "mbedding"

So far there are no clashes for -j or -o which are also valid arguments.