### PR TITLE
Use proper hadronic process for the different nuclear species

### DIFF
--- a/MC/config/PWGLF/xsection/g4config_had_x2.in
+++ b/MC/config/PWGLF/xsection/g4config_had_x2.in
@@ -64,10 +64,10 @@
 
 
 # Scale hadronic cross section
-/mcPhysics/setCrossSectionFactor deuteron hadInElastic 2.
-/mcPhysics/setCrossSectionFactor anti_deuteron hadInElastic 2.
-/mcPhysics/setCrossSectionFactor triton hadInElastic 2.
-/mcPhysics/setCrossSectionFactor anti_triton hadInElastic 2.
-/mcPhysics/setCrossSectionFactor he3 hadInElastic 2.
-/mcPhysics/setCrossSectionFactor anti_he3 hadInElastic 2.
+/mcPhysics/setCrossSectionFactor deuteron dInelastic 2.
+/mcPhysics/setCrossSectionFactor anti_deuteron anti_deuteronInelastic 2.
+/mcPhysics/setCrossSectionFactor triton tInelastic 2.
+/mcPhysics/setCrossSectionFactor anti_triton anti_tritonInelastic 2.
+/mcPhysics/setCrossSectionFactor He3 He3Inelastic 2.
+/mcPhysics/setCrossSectionFactor anti_He3 anti_He3Inelastic 2.
 


### PR DESCRIPTION
For bookkeeping: hadronic processes for the different nuclei are defined starting from L. 150 of the 
`G4IonPhysics::ConstructProcess()` function: [link](https://apc.u-paris.fr/~franco/g4doxy/html/classG4IonPhysics.html#e1df0b79959a6330ab6d53d9ec02d911)

@njacazio , now the proper scaling is applied to the different XSs

