### PR TITLE
Adjust matching chi2 cut to 80 for pbpb

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -293,7 +293,7 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
   ERROB="100e-8"
   [[ -z $TPCITSTIMEERR ]] && TPCITSTIMEERR="0.2"
   [[ -z $ITS_CONFIG || "$ITS_CONFIG" != *"--tracking-mode"* ]] && export ITS_CONFIG+=" --tracking-mode async"
-  CUT_MATCH_CHI2=100
+  [[ $ALIEN_JDL_LPMANCHORYEAR == "2023" ]] && [[ $BEAMTYPE == "PbPb" ]] && CUT_MATCH_CHI2=80 || CUT_MATCH_CHI2=100
   export ITSTPCMATCH="tpcitsMatch.safeMarginTimeCorrErr=2.;tpcitsMatch.XMatchingRef=60.;tpcitsMatch.cutMatchingChi2=$CUT_MATCH_CHI2;;tpcitsMatch.crudeAbsDiffCut[0]=6;tpcitsMatch.crudeAbsDiffCut[1]=6;tpcitsMatch.crudeAbsDiffCut[2]=0.3;tpcitsMatch.crudeAbsDiffCut[3]=0.3;tpcitsMatch.crudeAbsDiffCut[4]=2.5;tpcitsMatch.crudeNSigma2Cut[0]=64;tpcitsMatch.crudeNSigma2Cut[1]=64;tpcitsMatch.crudeNSigma2Cut[2]=64;tpcitsMatch.crudeNSigma2Cut[3]=64;tpcitsMatch.crudeNSigma2Cut[4]=64;"
 
   #-------------------------------------- TPC corrections -----------------------------------------------


### PR DESCRIPTION
The matching chi2 cut for pbpb is set to 80. It is still an overkill but will add a ~2% of fakes only (should be much more below the main chi2 peak)

![chi2pbpb](https://github.com/AliceO2Group/O2DPG/assets/7382029/b93845ca-7995-48dd-8e55-3219e79dda24)

Already the tracks with Chi2>40 seem not to have any contribution to the K0's.
![k0vschi2match](https://github.com/AliceO2Group/O2DPG/assets/7382029/aa3311ec-5112-4020-a3e3-5ebe894cfb03)

