### PR TITLE
avoid hang in grid submit

### DIFF
--- a/GRID/utils/grid_submit.sh
+++ b/GRID/utils/grid_submit.sh
@@ -569,9 +569,9 @@ export PATH=$PATH:$PWD
 chmod +x ./alien_jobscript.sh
 ./alien_jobscript.sh
 
-# just to be sure that we get the logs
-cp alien_log_${ALIEN_PROC_ID:-0}.txt logtmp_${ALIEN_PROC_ID:-0}.txt
-[ "${ALIEN_JOB_OUTPUTDIR}" ] && upload_to_Alien logtmp_${ALIEN_PROC_ID:-0}.txt ${ALIEN_JOB_OUTPUTDIR}/
+# just to be sure that we get the logs (temporarily disabled since the copy seems to hang sometimes)
+#cp alien_log_${ALIEN_PROC_ID:-0}.txt logtmp_${ALIEN_PROC_ID:-0}.txt
+#[ "${ALIEN_JOB_OUTPUTDIR}" ] && upload_to_Alien logtmp_${ALIEN_PROC_ID:-0}.txt ${ALIEN_JOB_OUTPUTDIR}/
 
 echo "Job done"
 


### PR DESCRIPTION
`alien.py cp ...` is not returning (after the copy).... probably related to a software-platform inconsistency (to be confirmed).

Avoid this hang meanwhile, until issue is fully understood.

Related to https://its.cern.ch/jira/browse/O2-4804