### PR TITLE
PWGHF: add possibility to use different config for MB events in gap trigger

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -64,8 +64,8 @@ public:
     addSubGenerator(4, "Charm injected");
     addSubGenerator(5, "Beauty injected");
     bool initAltOk{true};
-    bool initMainOk = o2::eventgen::GeneratorPythia8::Init();
     // we also initialise alternative PYTHIA generator, if needed
+    bool initMainOk = o2::eventgen::GeneratorPythia8::Init();
     if (mUseAltGenForBkg)
     {
       initAltOk = mBkgGen.init();
@@ -99,7 +99,6 @@ protected:
   //__________________________________________________________________
   bool generateEvent() override
   {
-    
 
     // Simple straightforward check to alternate generators
     if (mGeneratedEvents % mInverseTriggerRatio == 0)
@@ -144,6 +143,7 @@ protected:
       }
       else
       {
+        mPythia.event.reset();
         mBkgGen.event.reset();
         while (!genOk) {
           genOk = mBkgGen.next();
@@ -309,7 +309,7 @@ FairGenerator *GeneratorPythia8GapHF(int inputTriggerRatio, float yQuarkMin = -1
 }
 
 // Charm and beauty enriched (with same ratio)
-FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {})
+FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {}, std::string bkgConfig = "")
 {
   auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{4, 5}, hadronPdgList);
   auto seed = (gRandom->TRandom::GetSeed() % 900000000);
@@ -320,6 +320,6 @@ FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(int in
   {
     myGen->setHadronRapidity(yHadronMin, yHadronMax);
   }
-  myGen->setAlternativeConfigForBkgEvents("$O2DPG_ROOT/MC/config/PWGHF/pythia8/generator/pythia8_inel_forbkg.cfg", seed);
+  myGen->setAlternativeConfigForBkgEvents(bkgConfig, seed);
   return myGen;
 }

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(3, -1.5, 1.5)
+
+[GeneratorPythia8]
+config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
-funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(3, -1.5, 1.5)
+funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(3, -1.5, 1.5, -1.5, 1.5, {}, "$O2DPG_ROOT/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg")
 
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
-funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(5, -1.5, 1.5)
+funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(5, -1.5, 1.5, -1.5, 1.5, {}, "$O2DPG_ROOT/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg")
 
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredCharmAndBeautyWithAltBkgEvents(5, -1.5, 1.5)
+
+[GeneratorPythia8]
+config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.C
@@ -129,7 +129,7 @@ int External() {
         return 1;
     }
 
-    if (averagePt < 8.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD)
+    if (averagePt < 5.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD), but it can be a bit lower in case of contaminations from MB events
         std::cerr << "Average pT of charmed hadrons " << averagePt << " lower than expected\n";
         return 1;
     }

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_ptHardBins.C
@@ -1,0 +1,138 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuarkOne{4};
+    int checkPdgQuarkTwo{5};
+    float ratioTrigger = 1./3; // each event triggered
+    float averagePt = 0.;
+
+    std::vector<int> checkPdgHadron{411, 421, 431, 4122, 4132, 4232, 4332};
+    std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
+        {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
+        {421, {{-321, 211}, {-321, 111, 211}}}, // D0
+        {431, {{211, 333}, {-313, 321}}}, // Ds+
+        {4122, {{-313, 2212}, {-321, 2224}, {211, 3124}, {-321, 211, 2212}, {311, 2212}}}, // Lc+
+        {4132, {{211, 3312}}}, // Xic0
+        {4232, {{-313, 2212}, {-321, 3324}, {211, 211, 3312}, {-321, 211, 2212}}}, // Xic+
+        {4332, {{211, 3334}}} // Omegac+
+    };
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsMB{}, nEventsInjOne{}, nEventsInjTwo{};
+    int nQuarksOne{}, nQuarksTwo{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == 0) {
+                nEventsMB++;
+            } else if (subGeneratorId == checkPdgQuarkOne) {
+                nEventsInjOne++;
+            } else if (subGeneratorId == checkPdgQuarkTwo) {
+                nEventsInjTwo++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::abs(pdg) == checkPdgQuarkOne) {
+                nQuarksOne++;
+                continue;
+            }
+            if (std::abs(pdg) == checkPdgQuarkTwo) {
+                nQuarksTwo++;
+                continue;
+            }
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+                nSignals++; // count signal PDG
+                averagePt += track.GetPt();
+
+                std::vector<int> pdgsDecay{};
+                std::vector<int> pdgsDecayAntiPart{};
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    pdgsDecay.push_back(pdgDau);
+                    if (pdgDau != 333) { // phi is antiparticle of itself
+                        pdgsDecayAntiPart.push_back(-pdgDau);
+                    } else {
+                        pdgsDecayAntiPart.push_back(pdgDau);
+                    }
+                }
+
+                std::sort(pdgsDecay.begin(), pdgsDecay.end());
+                std::sort(pdgsDecayAntiPart.begin(), pdgsDecayAntiPart.end());
+
+                for (auto &decay : checkHadronDecays[std::abs(pdg)]) {
+                    if (pdgsDecay == decay || pdgsDecayAntiPart == decay) {
+                        nSignalGoodDecay++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    averagePt /= nSignals; 
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << "# MB events: " << nEventsMB << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkOne) << nEventsInjOne << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkTwo) << nEventsInjTwo << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkOne) << nQuarksOne << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkTwo) << nQuarksTwo << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+    std::cout <<"average pT of signal hadrons: " << averagePt << "\n";
+
+    if (nEventsMB < nEvents * (1 - ratioTrigger) * 0.95 || nEventsMB > nEvents * (1 - ratioTrigger) * 1.05) { // we put some tolerance since the number of generated events is small
+        std::cerr << "Number of generated MB events different than expected\n";
+        return 1;
+    }
+    if (nEventsInjOne < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjOne > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkOne << " different than expected\n";
+        return 1;
+    }
+    if (nEventsInjTwo < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjTwo > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkTwo << " different than expected\n";
+        return 1;
+    }
+
+    if (nQuarksOne < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkOne << " lower than expected\n";
+        return 1;
+    }
+    if (nQuarksTwo < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkTwo << " lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (e.g. due to oscillations which might change the final state)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    if (averagePt < 8.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD)
+        std::cerr << "Average pT of charmed hadrons " << averagePt << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.C
@@ -129,7 +129,7 @@ int External() {
         return 1;
     }
 
-    if (averagePt < 8.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD)
+    if (averagePt < 5.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD), but it can be a bit lower in case of contaminations from MB events
         std::cerr << "Average pT of charmed hadrons " << averagePt << " lower than expected\n";
         return 1;
     }

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_ptHardBins.C
@@ -1,0 +1,138 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuarkOne{4};
+    int checkPdgQuarkTwo{5};
+    float ratioTrigger = 1./5; // each event triggered
+    float averagePt = 0.;
+
+    std::vector<int> checkPdgHadron{411, 421, 431, 4122, 4132, 4232, 4332};
+    std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
+        {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
+        {421, {{-321, 211}, {-321, 111, 211}}}, // D0
+        {431, {{211, 333}, {-313, 321}}}, // Ds+
+        {4122, {{-313, 2212}, {-321, 2224}, {211, 3124}, {-321, 211, 2212}, {311, 2212}}}, // Lc+
+        {4132, {{211, 3312}}}, // Xic0
+        {4232, {{-313, 2212}, {-321, 3324}, {211, 211, 3312}, {-321, 211, 2212}}}, // Xic+
+        {4332, {{211, 3334}}} // Omegac+
+    };
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsMB{}, nEventsInjOne{}, nEventsInjTwo{};
+    int nQuarksOne{}, nQuarksTwo{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == 0) {
+                nEventsMB++;
+            } else if (subGeneratorId == checkPdgQuarkOne) {
+                nEventsInjOne++;
+            } else if (subGeneratorId == checkPdgQuarkTwo) {
+                nEventsInjTwo++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::abs(pdg) == checkPdgQuarkOne) {
+                nQuarksOne++;
+                continue;
+            }
+            if (std::abs(pdg) == checkPdgQuarkTwo) {
+                nQuarksTwo++;
+                continue;
+            }
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+                nSignals++; // count signal PDG
+                averagePt += track.GetPt();
+
+                std::vector<int> pdgsDecay{};
+                std::vector<int> pdgsDecayAntiPart{};
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    pdgsDecay.push_back(pdgDau);
+                    if (pdgDau != 333) { // phi is antiparticle of itself
+                        pdgsDecayAntiPart.push_back(-pdgDau);
+                    } else {
+                        pdgsDecayAntiPart.push_back(pdgDau);
+                    }
+                }
+
+                std::sort(pdgsDecay.begin(), pdgsDecay.end());
+                std::sort(pdgsDecayAntiPart.begin(), pdgsDecayAntiPart.end());
+
+                for (auto &decay : checkHadronDecays[std::abs(pdg)]) {
+                    if (pdgsDecay == decay || pdgsDecayAntiPart == decay) {
+                        nSignalGoodDecay++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    averagePt /= nSignals; 
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << "# MB events: " << nEventsMB << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkOne) << nEventsInjOne << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkTwo) << nEventsInjTwo << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkOne) << nQuarksOne << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkTwo) << nQuarksTwo << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+    std::cout <<"average pT of signal hadrons: " << averagePt << "\n";
+
+    if (nEventsMB < nEvents * (1 - ratioTrigger) * 0.95 || nEventsMB > nEvents * (1 - ratioTrigger) * 1.05) { // we put some tolerance since the number of generated events is small
+        std::cerr << "Number of generated MB events different than expected\n";
+        return 1;
+    }
+    if (nEventsInjOne < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjOne > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkOne << " different than expected\n";
+        return 1;
+    }
+    if (nEventsInjTwo < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjTwo > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkTwo << " different than expected\n";
+        return 1;
+    }
+
+    if (nQuarksOne < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkOne << " lower than expected\n";
+        return 1;
+    }
+    if (nQuarksTwo < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkTwo << " lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (e.g. due to oscillations which might change the final state)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    if (averagePt < 8.) { // by testing locally it should be around 8.5 GeV/c with pthard bin 20-200 (contrary to 2-2.5 GeV/c of SoftQCD)
+        std::cerr << "Average pT of charmed hadrons " << averagePt << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/pythia8/generator/pythia8_inel_forbkg.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_inel_forbkg.cfg
@@ -1,0 +1,24 @@
+### authors: Fabrizio Grosa (fabrizio.grosa@cern.ch)
+###          Cristina Terrevoli (cristina.terrevoli@cern.ch)
+###          Fabio Catalano (fabio.catalano@cern.ch)
+### last update:  April 2024
+
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13600. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+# Correct decay lengths (wrong in PYTHIA8 decay table)
+# Lb
+5122:tau0 = 0.4390
+# Xic0
+4132:tau0 = 0.0455
+# OmegaC
+4332:tau0 = 0.0803


### PR DESCRIPTION
This PR adds the possibility to use a different config for MB events in the gap trigger HF generator. This is useful as alternative to the embedding with replacement when for example using `HardQCD` for the signal events. The implementation is similar to the DQ gap trigger generator (see [generator_pythia8_NonPromptSignals_gaptriggered_dq.C](https://github.com/AliceO2Group/O2DPG/blob/23d985d220f4020bc055499e3c2eb01dd0f502b3/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C))
I tested it (currently for unanchored MCs) but @fcatalan92 could you also please cross check that it is fine? Thanks!

One note: I noticed that passing the second config for the PYTHIA instance for MB events was resetting the decay table also of the main PYTHIA instance (the one for signal events). It might be that the decay table is global and shared among PYTHIA instances, hence I set the same decay table for signal and background events (as done in the usual HF gap trigger configs).