### PR TITLE
[EMCAL-1118] Make QC workflow mode settable

### DIFF
--- a/DATA/production/calib/emc-pedestal-aggregator.sh
+++ b/DATA/production/calib/emc-pedestal-aggregator.sh
@@ -7,7 +7,8 @@ source common/setenv.sh
 source common/getCommonArgs.sh
 
 INPTYPE=""
-  PROXY_INSPEC="A:EMC/PEDDATA/0;eos:***/INFORMATION"
+#PROXY_INSPEC="A:EMC/PEDDATA/0;eos:***/INFORMATION"
+PROXY_INSPEC="A:EMC/PEDDATA/0"
 
 CCDBPATH1="http://o2-ccdb.internal"
 CCDBPATH2="$DCSCCDBSERVER"
@@ -16,14 +17,26 @@ if [[ $RUNTYPE == "SYNTHETIC" || "${GEN_TOPO_DEPLOYMENT_TYPE:-}" == "ALICE_STAGI
   CCDBPATH2="http://ccdb-test.cern.ch:8080"
 fi
 
+QC_STANDALONE=0
+if [[ ! -z ${EMC_PEDQC_STANDALONE:-} ]]; then
+        QC_STANDALONE=${EMC_PEDQC_STANDALONE}
+fi
+
 QC_CONFIG="/o2/components/qc/ANY/any/emc-pedestal-qc"
+QC_OPT=
+if [ $QC_STANDALONE -gt 0 ]; then
+        QC_CONFIG="/o2/components/qc/ANY/any/emc-pedestal-qc-standalone"
+else
+        QC_CONFIG="/o2/components/qc/ANY/any/emc-pedestal-qc"
+        QC_OPT="--local --host localhost"
+fi
 
 WORKFLOW=
 add_W o2-dpl-raw-proxy "--proxy-name emc-pedestal-input-proxy --dataspec \"$PROXY_INSPEC\" --network-interface ib0 --channel-config \"name=emc-pedestal-input-proxy,method=bind,type=pull,rateLogging=1,transport=zeromq\"" "" 0
 add_W o2-calibration-emcal-pedestal-calib-workflow
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path=\"$CCDBPATH1\" --sspec-min 0 --sspec-max 0"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path=\"$CCDBPATH2\" --sspec-min 1 --sspec-max 1 --name-extention dcs"
-add_QC_from_consul "${QC_CONFIG}" "--local --host localhost"
+add_QC_from_consul "${QC_CONFIG}" "${QC_OPT}"
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 
 if [ $WORKFLOWMODE == "print" ]; then

--- a/DATA/production/calib/emc-pedestal-processing.sh
+++ b/DATA/production/calib/emc-pedestal-processing.sh
@@ -6,7 +6,7 @@ source common/setenv.sh
 # Set general arguments
 source common/getCommonArgs.sh
 
-PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0;eos:***/INFORMATION"
+PROXY_INSPEC="A:EMC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0"
 
 PROXY_OUTSPEC="downstream:EMC/PEDDATA/0"
 


### PR DESCRIPTION
Allow adjustable QC workflow as stand-alone or
multi-node workflow with separate configurations.
In addition minor fixes in the input proxy configuration.