### PR TITLE
Enable strangeness tracking by default

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -114,7 +114,7 @@ parser.add_argument('--no-combine-smaller-digi', action='store_true', help=argpa
 parser.add_argument('--no-combine-dpl-devices', action='store_true', help=argparse.SUPPRESS)
 parser.add_argument('--no-mc-labels', action='store_true', default=False, help=argparse.SUPPRESS)
 parser.add_argument('--no-tpc-digitchunking', action='store_true', help=argparse.SUPPRESS)
-parser.add_argument('--with-strangeness-tracking', action='store_true', default=False, help="Enable strangeness tracking")
+parser.add_argument('--no-strangeness-tracking', action='store_true', default=False, help="Disable strangeness tracking")
 parser.add_argument('--combine-tpc-clusterization', action='store_true', help=argparse.SUPPRESS) #<--- useful for small productions (pp, low interaction rate, small number of events)
 parser.add_argument('--first-orbit', default=0, type=int, help=argparse.SUPPRESS)  # to set the first orbit number of the run for HBFUtils (only used when anchoring)
                                                             # (consider doing this rather in O2 digitization code directly)
@@ -1347,7 +1347,7 @@ for tf in range(1, NTIMEFRAMES + 1):
    svfinder_sources = anchorConfig.get('o2-secondary-vertexing-workflow-options', {}). get('vertexing-sources', 'ITS-TPC,TPC-TRD,ITS-TPC-TRD,TPC-TOF,ITS-TPC-TOF,TPC-TRD-TOF,ITS-TPC-TRD-TOF,MFT-MCH,MCH-MID,ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV,ZDC,FDD,HMP,FV0,TRD,MCH,CTP')
    SVFINDERtask['cmd'] += ' --vertexing-sources ' + svfinder_sources + (' --combine-source-devices','')[args.no_combine_dpl_devices]
    # strangeness tracking is now called from the secondary vertexer
-   if not args.with_strangeness_tracking:
+   if args.no_strangeness_tracking:
       SVFINDERtask['cmd'] += ' --disable-strangeness-tracker'
    # if enabled, it may require MC labels
    else:
@@ -1385,7 +1385,7 @@ for tf in range(1, NTIMEFRAMES + 1):
    if environ.get('O2DPG_AOD_NOTRUNCATE') != None or environ.get('ALIEN_JDL_O2DPG_AOD_NOTRUNCATE') != None:
       AODtask['cmd'] += ' --enable-truncation 0'  # developer option to suppress precision truncation
 
-   if not args.with_strangeness_tracking:
+   if args.no_strangeness_tracking:
       AODtask['cmd'] += ' --disable-strangeness-tracker'
 
    # Enable CTP readout replay for triggered detectors (EMCAL, HMPID, PHOS/CPV, TRD)

--- a/MC/run/PWGLF/run_HyperNucleiInjectedGap.sh
+++ b/MC/run/PWGLF/run_HyperNucleiInjectedGap.sh
@@ -26,7 +26,7 @@ ENERGY=${ENERGY:-13600}
 
 # create workflow
 ${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM ${ENERGY} -col ${SYSTEM} -gen external -j ${NWORKERS} -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -interactionRate ${INTRATE} -confKey "Diamond.width[0]=0.1;Diamond.width[1]=0.1;Diamond.width[2]=6." -e ${SIMENGINE} ${SEED} -mod "--skipModules ZDC" \
-        -ini ${O2DPG_ROOT}/MC/config/PWGLF/ini/GeneratorLFHyperNuclei${SYSTEM}Gap.ini --with-strangeness-tracking
+        -ini ${O2DPG_ROOT}/MC/config/PWGLF/ini/GeneratorLFHyperNuclei${SYSTEM}Gap.ini
 
 # run workflow
 # allow increased timeframe parallelism with --cpu-limit 32

--- a/MC/run/PWGLF/run_StrangenessInjected.sh
+++ b/MC/run/PWGLF/run_StrangenessInjected.sh
@@ -35,7 +35,7 @@ O2_SIM_WORKFLOW=${O2_SIM_WORKFLOW:-"${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py"}
 $O2_SIM_WORKFLOW -eCM ${ENERGY} -col ${SYSTEM} -gen external \
         -j ${NWORKERS} \
         -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -interactionRate ${INTRATE} \
-        -confKey "Diamond.width[2]=6." --with-strangeness-tracking \
+        -confKey "Diamond.width[2]=6." \
         ${SEED} \
         -procBkg "inel" -colBkg $SYSTEM --embedding -nb ${NBKGEVENTS} -genBkg pythia8 \
         -e ${SIMENGINE} \

--- a/MC/run/PWGLF/run_StrangenessTriggered.sh
+++ b/MC/run/PWGLF/run_StrangenessTriggered.sh
@@ -34,7 +34,7 @@ O2_SIM_WORKFLOW=${O2_SIM_WORKFLOW:-"${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py"}
 $O2_SIM_WORKFLOW -eCM ${ENERGY} -col ${SYSTEM} -gen external \
         -j ${NWORKERS} \
         -ns ${NSIGEVENTS} -tf ${NTIMEFRAMES} -interactionRate ${INTRATE} \
-        -confKey "Diamond.width[2]=6." --with-strangeness-tracking \
+        -confKey "Diamond.width[2]=6." \
         ${SEED} \
         -e ${SIMENGINE} \
         -ini $CFGINIFILE


### PR DESCRIPTION
This ensures consistency between MC and data reconstruction conditions, where strangeness tracking is enabled by default both in pp and Pb--Pb