### PR TITLE
Add empty external generator and adjust ini files to adhere to hyperloop workflow

### DIFF
--- a/MC/config/ALICE3/ini/pythia8_ArAr.ini
+++ b/MC/config/ALICE3/ini/pythia8_ArAr.ini
@@ -1,5 +1,9 @@
 [Diamond]
 width[2]=6.0
 
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg

--- a/MC/config/ALICE3/ini/pythia8_KrKr.ini
+++ b/MC/config/ALICE3/ini/pythia8_KrKr.ini
@@ -1,5 +1,9 @@
 [Diamond]
 width[2]=6.0
 
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg

--- a/MC/config/ALICE3/ini/pythia8_OO.ini
+++ b/MC/config/ALICE3/ini/pythia8_OO.ini
@@ -1,5 +1,9 @@
 [Diamond]
 width[2]=6.0
 
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg

--- a/MC/config/ALICE3/ini/pythia8_PbPb.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb.ini
@@ -1,5 +1,9 @@
 [Diamond]
 width[2]=6.0
 
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg

--- a/MC/config/ALICE3/ini/pythia8_XeXe.ini
+++ b/MC/config/ALICE3/ini/pythia8_XeXe.ini
@@ -1,5 +1,9 @@
 [Diamond]
 width[2]=6.0
 
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
 [GeneratorPythia8]
 config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg

--- a/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+++ b/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
@@ -1,0 +1,31 @@
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "Pythia8/Pythia.h"
+#include "FairGenerator.h"
+#include "FairPrimaryGenerator.h"
+#include "Generators/GeneratorPythia8.h"
+#include "TRandom3.h"
+#include "TParticlePDG.h"
+#include "TDatabasePDG.h"
+#include "TMath.h"
+#include <cmath>
+using namespace Pythia8;
+#endif
+
+// Default pythia8 minimum bias generator
+// Please do not change
+
+class GeneratorPythia8ALICE3 : public o2::eventgen::GeneratorPythia8
+{
+public:
+  /// Constructor
+  GeneratorPythia8ALICE3() {}
+
+  ///  Destructor
+  ~GeneratorPythia8ALICE3() = default;
+};
+
+ FairGenerator *generator_pythia8_ALICE3() 
+ {
+   return new GeneratorPythia8ALICE3();
+ }


### PR DESCRIPTION
This purpose of this pull request is to allow the use of the default pythia8 generator without changing the command specifying which generator to use from "external" to desired generator on hyperloop. 
