### PR TITLE
Remove option ctp-readout-create

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1433,9 +1433,6 @@ for tf in range(1, NTIMEFRAMES + 1):
    if args.no_strangeness_tracking:
       AODtask['cmd'] += ' --disable-strangeness-tracker'
 
-   # Enable CTP readout replay for triggered detectors (EMCAL, HMPID, PHOS/CPV, TRD)
-   # Needed untill triggers are supported in CTP simulation
-   AODtask['cmd'] += ' --ctpreadout-create 1'
    workflow['stages'].append(AODtask)
 
    # TPC - time-series objects


### PR DESCRIPTION
- ctp readout create does not properly work in
  2023 as only 1 trigger class per trigger is
  expeected
- By design it is impossible to recover the trigger
  classes from the trigger records as they are not
  encoded in the trigger record, so the min. bias trigger
  is assumed. This does not work for triggers that
  provide triggers themselves.