### PR TITLE
PWGLF: Update the number of injected particle for PbPb

### DIFF
--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
+funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json", true, 4)
 
 # [GeneratorPythia8]
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
+funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json", true, 4)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg

--- a/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json
+++ b/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json
@@ -1,0 +1,56 @@
+{
+    "Lambda(1520)0" : {
+        "pdg": 102134,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Lambda(1520)0" : {
+        "pdg": -102134,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Xi(1820)0" : {
+        "pdg": 123314,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Anti-Xi(1820)0" : {
+        "pdg": -123314,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Xi(1820)-" : {
+        "pdg": 123324,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Xi(1820)+" : {
+        "pdg": -123324,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    }
+}

--- a/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json
+++ b/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json
@@ -1,0 +1,164 @@
+{
+    "K(892)+" : {
+        "pdg": 323,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "K(892)-" : {
+        "pdg": -323,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "f_0(980)" : {
+        "pdg": 9010221,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "rho(770)0" : {
+        "pdg": 113,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "rho(770)+" : {
+        "pdg": 213,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "rho(770)-" : {
+        "pdg": -213,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Sigma(1385)-" : {
+        "pdg": 3114,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Sigma(1385)+" : {
+        "pdg": -3114,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Sigma(1385)+" : {
+        "pdg": 3224,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Sigma(1385)-" : {
+        "pdg": -3224,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Xi(1530)0" : {
+        "pdg": 3324,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Xi(1530)0" : {
+        "pdg": -3324,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "K1(1270)+": {
+        "pdg": 10323,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "K1(1270)-": {
+        "pdg": -10323,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Delta++" : {
+        "pdg": 2224,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Delta++" : {
+        "pdg": -2224,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "Delta0" : {
+        "pdg": 2114,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    },
+    "anti-Delta0" : {
+        "pdg": -2114,
+        "n": 10,
+        "ptMin": 0.0,
+        "ptMax": 20,
+        "etaMin": -1.2,
+        "etaMax": 1.2,
+        "genDecayed": true
+    }
+}


### PR DESCRIPTION
So far, we intend to inject only one particle per event.

But in PbPb collision, we could increase this to save the computing resources.

We updated the number of injected particles in the PbPb injector case.