### PR TITLE
adding missing flag for TOF in cpass0

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -497,6 +497,7 @@ export CONFIG_EXTRA_PROCESS_o2_tof_matcher_workflow+=";$ITSEXTRAERR;$TRACKTUNETP
 
 if [[ $ALIEN_JDL_LPMPASSNAME == "cpass0" ]]; then
    CONFIG_EXTRA_PROCESS_o2_tof_matcher_workflow+=";MatchTOF.nsigmaTimeCut=6;"
+   ARGS_EXTRA_PROCESS_o2_tof_matcher_workflow+=" --for-calib"
 fi
 
 # ad-hoc settings for TRD matching


### PR DESCRIPTION
Dear @chiarazampolli , @shahor02 ,
I realized that we are missing one flag needed for cpass0 to disable the check on problematic channels.

Today from QC (@ercolessi) we realized that two runs had problem with sync calibrations and the problem was propagated to cpass0 sine of this missing flags.

In such cases we cannot use cpass0 to calibrate.

We need this fix as soon as possible for cpass0 reco.
Cheers,
Francesco