### PR TITLE
MUON: fixed normalization of tracks histograms

### DIFF
--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -41,7 +41,7 @@
                 },
                 "grpGeomRequest": {
                     "geomRequest": "Aligned",
-                    "askGRPECS": "false",
+                    "askGRPECS": "true",
                     "askGRPLHCIF": "false",
                     "askGRPMagField": "false",
                     "askMatLUT": "false",


### PR DESCRIPTION
The loading of the GRPECS object needs to be enabled in order to retrieve the correct value of orbits/TF, otherwise the default value of 128 is used. The orbits/TF is used for the absolute normalization of the histograms.