### PR TITLE
MUON: enabled magnetic field in tracks QC

### DIFF
--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -43,7 +43,7 @@
                     "geomRequest": "Aligned",
                     "askGRPECS": "false",
                     "askGRPLHCIF": "false",
-                    "askGRPMagField": "false",
+                    "askGRPMagField": "true",
                     "askMatLUT": "false",
                     "askTime": "false",
                     "askOnceAllButField": "true",

--- a/DATA/production/qc-async/mchmid-tracks.json
+++ b/DATA/production/qc-async/mchmid-tracks.json
@@ -21,7 +21,7 @@
           "geomRequest": "Aligned",
           "askGRPECS": "true",
           "askGRPLHCIF": "false",
-          "askGRPMagField": "false",
+          "askGRPMagField": "true",
           "askMatLUT": "false",
           "askTime": "false",
           "askOnceAllButField": "false",

--- a/DATA/production/qc-async/mftmch-tracks.json
+++ b/DATA/production/qc-async/mftmch-tracks.json
@@ -21,7 +21,7 @@
           "geomRequest": "Aligned",
           "askGRPECS": "true",
           "askGRPLHCIF": "false",
-          "askGRPMagField": "false",
+          "askGRPMagField": "true",
           "askMatLUT": "false",
           "askTime": "false",
           "askOnceAllButField": "false",

--- a/DATA/production/qc-async/mftmchmid-tracks.json
+++ b/DATA/production/qc-async/mftmchmid-tracks.json
@@ -21,7 +21,7 @@
           "geomRequest": "Aligned",
           "askGRPECS": "true",
           "askGRPLHCIF": "false",
-          "askGRPMagField": "false",
+          "askGRPMagField": "true",
           "askMatLUT": "false",
           "askTime": "false",
           "askOnceAllButField": "false",


### PR DESCRIPTION
The loading of the magnetic field is needed to correctly extrapolate the tracks to the interaction point.