### PR TITLE
ALICE3: Allow external generator to accept seed during initialization

### DIFF
--- a/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
@@ -18,4 +18,4 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-Random:seed = 0
+# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
@@ -18,4 +18,3 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
@@ -18,4 +18,3 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
 
 Random:setSeed = on
-# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
@@ -18,4 +18,4 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
 
 Random:setSeed = on
-Random:seed = 0
+# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
@@ -15,4 +15,4 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-Random:seed = 0
+# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
@@ -15,4 +15,3 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
@@ -15,4 +15,4 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
 
 Random:setSeed = on
-Random:seed = 0
+#Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
@@ -15,4 +15,3 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
 
 Random:setSeed = on
-#Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
@@ -15,4 +15,4 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-Random:seed = 0
+# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
@@ -15,4 +15,3 @@ HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
 HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
     
 Random:setSeed = on
-# Random:seed = 0

--- a/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+++ b/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
@@ -1,28 +1,40 @@
-
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "Pythia8/Pythia.h"
 #include "FairGenerator.h"
 #include "FairPrimaryGenerator.h"
 #include "Generators/GeneratorPythia8.h"
-#include "TRandom3.h"
-#include "TParticlePDG.h"
-#include "TDatabasePDG.h"
-#include "TMath.h"
-#include <cmath>
+#include <stdlib.h>
+
 using namespace Pythia8;
 #endif
 
 // Default pythia8 minimum bias generator
-// Please do not change
 
 class GeneratorPythia8ALICE3 : public o2::eventgen::GeneratorPythia8
 {
 public:
+
   /// Constructor
-  GeneratorPythia8ALICE3() {}
+  GeneratorPythia8ALICE3() {
+
+    char* job_id = getenv("JOB_ID");
+    int seed;
+
+    if (job_id != NULL) {
+      LOG(info) << "Seed set to JOB_ID: " << seed;
+      seed = atoi(job_id);
+    } else {
+      LOG(info) << "Unable to retrieve JOB_ID";
+      LOG(info) << "Setting seed to 0 (random)";
+      seed = 0;
+    }
+
+    mPythia.readString("Random:seed = "+std::to_string(seed));
+  }
 
   ///  Destructor
   ~GeneratorPythia8ALICE3() = default;
+
 };
 
  FairGenerator *generator_pythia8_ALICE3() 

--- a/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+++ b/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
@@ -20,9 +20,9 @@ public:
     char* alien_proc_id = getenv("ALIEN_PROC_ID");
     int seed;
 
-    if (job_id != NULL) {
+    if (alien_proc_id != NULL) {
       LOG(info) << "Seed set to ALIEN_PROC_ID: " << seed;
-      seed = atoi(job_id);
+      seed = atoi(alien_proc_id);
     } else {
       LOG(info) << "Unable to retrieve ALIEN_PROC_ID";
       LOG(info) << "Setting seed to 0 (random)";

--- a/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+++ b/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
@@ -17,14 +17,14 @@ public:
   /// Constructor
   GeneratorPythia8ALICE3() {
 
-    char* job_id = getenv("JOB_ID");
+    char* alien_proc_id = getenv("ALIEN_PROC_ID");
     int seed;
 
     if (job_id != NULL) {
-      LOG(info) << "Seed set to JOB_ID: " << seed;
+      LOG(info) << "Seed set to ALIEN_PROC_ID: " << seed;
       seed = atoi(job_id);
     } else {
-      LOG(info) << "Unable to retrieve JOB_ID";
+      LOG(info) << "Unable to retrieve ALIEN_PROC_ID";
       LOG(info) << "Setting seed to 0 (random)";
       seed = 0;
     }


### PR DESCRIPTION
Since we specify the use of an external generator on hyperloop the o2-sim-dpl-eventgen task does not accept a seed given using the "--seed" command line option and we instead have to give the seed manually when we initialize the generator.