### PR TITLE
Fix warnings about invalid escape sequences

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -1601,12 +1601,13 @@ Use the `--produce-script myscript.sh` option for this.
                   os.environ['ROOT_LDSYSPATH'] = libpath.decode()
 
                # b) the PATH for compiler includes needed by Cling
-               cmd='LC_ALL=C c++ -xc++ -E -v /dev/null 2>&1 | sed -n \'/^.include/,${/^ \/.*++/{p}}\'' # | sed \'s/ //\''
+               cmd = "LC_ALL=C c++ -xc++ -E -v /dev/null 2>&1 | sed -n '/^#include/,${/^ \\/.*++/{p}}'"
                proc = subprocess.Popen([cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
                incpath, err = proc.communicate()
                incpaths = [ line.lstrip() for line in incpath.decode().splitlines() ]
                joined = ':'.join(incpaths)
                if not (args.no_rootinit_speedup == True):
+                  actionlogger.info("Determined ROOT_CPPSYSINCL=" + joined)
                   os.environ['ROOT_CPPSYSINCL'] = joined
 
         speedup_ROOT_Init()

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -249,7 +249,7 @@ def retrieve_sor(run_number):
     SOR=0
     # extract SOR by pattern matching
     for t in tokens:
-      match_object=re.match("\s*(SOR\s*=\s*)([0-9]*)\s*", t)
+      match_object=re.match(r"\s*(SOR\s*=\s*)([0-9]*)\s*", t)
       if match_object != None:
          SOR=match_object[2]
          break


### PR DESCRIPTION
observed with Python on EL9