### PR TITLE
Better support to treat events from HepMC event files (multi-timefram…

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -108,6 +108,13 @@ def create_geant_config(args, externalConfigString):
            d[sk] = flatconfig[entry]
            cfg[mk] = d
 
+    # ----- special setting for hepmc generator -----
+    if args.gen == "hepmc":
+      eventSkipPresent = config.get("HepMC",{}).get("eventsToSkip")
+      if eventSkipPresent == None:
+          # add it
+          add(config, {"HepMC.eventsToSkip" : '${HEPMCEVENTSKIP:-0}'})
+
     # ----- add default settings -----
 
     add(config, {"MFTBase.buildAlignment" : "true"})

--- a/UTILS/ReadHepMCEventSkip.sh
+++ b/UTILS/ReadHepMCEventSkip.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Path to the JSON file
+JSON_FILE=$1
+tf=$2
+JQCOMMAND="jq '[.[] | select(.tf < ${tf}) | .HepMCEventCount] | add' ${JSON_FILE}"
+eval ${JQCOMMAND}

--- a/UTILS/UpdateHepMCEventSkip.sh
+++ b/UTILS/UpdateHepMCEventSkip.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Path to the JSON file
+JSON_FILE=${1:-HepMC_EventSkip_ALT.json}
+tf=$2
+
+# Value to set or add
+EVENTS=$(grep "DISTRIBUTING" ../tf${tf}/sgngen_*.log | tail -n 1 | awk '//{print $5}')
+
+[ -f $JSON_FILE ] || echo "[]" > ${JSON_FILE} # init json file if it doesn't exist
+# insert event count ... if a count for this tf does not already exist
+JQ_COMMAND="jq 'if any(.[]; .tf == ${tf}) then . else . + [{\"tf\": ${tf}, "HepMCEventCount": ${EVENTS}}] end' ${JSON_FILE} > tmp_123.json; mv tmp_123.json ${JSON_FILE}"
+eval ${JQ_COMMAND}


### PR DESCRIPTION
…e case)

Some users give existing .hepmc files to the event generator.

So far, this was problematic because separate timeframes will read from the same file and due to a lack of synchronization, each timeframe read the same events.

This is now fixed. Whenever an hepmc event file is given as input to O2DPG-MC, we make sure that timeframes read from the HepMC file incrementally. This is achieved through:

- sequentially producing events for timeframes
- communication of the number processed from one timeframe to the next (via HepMCEventSkip.json file).