### PR TITLE
[EMCAL-756] Moving windows for EMCAL async QC

### DIFF
--- a/DATA/production/qc-async/emc.json
+++ b/DATA/production/qc-async/emc.json
@@ -21,11 +21,18 @@
         "className": "o2::quality_control_modules::emcal::CellTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",
-        "cycleDurationSeconds": "60",
+        "cycleDurationSeconds": "300",
         "dataSource": {
           "type": "direct",
           "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0"
-        }
+        },
+        "movingWindows": [
+          "averageCellTime_PHYS",
+          "cellAmplitudeSupermodule_PHYS",
+          "averageCellEnergy_PHYS",
+          "averageCellTime_PHYS",
+          "cellOccupancyEMCwThr_PHYS"
+        ]
       },
       "ClusterTaskEMCAL": {
         "active": "true",

--- a/DATA/production/qc-async/emc_PbPb.json
+++ b/DATA/production/qc-async/emc_PbPb.json
@@ -21,7 +21,7 @@
         "className": "o2::quality_control_modules::emcal::CellTask",
         "moduleName": "QcEMCAL",
         "detectorName": "EMC",
-        "cycleDurationSeconds": "60",
+        "cycleDurationSeconds": "300",
         "dataSource": {
           "type": "direct",
           "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0"
@@ -35,7 +35,14 @@
           "TotalEnergyRangeSM": "200",
           "TotalEnergyRange": "2000",
           "TotalEnergyMaxCellTime": "25"
-        }
+        },
+        "movingWindows": [
+          "averageCellTime_PHYS",
+          "cellAmplitudeSupermodule_PHYS",
+          "averageCellEnergy_PHYS",
+          "averageCellTime_PHYS",
+          "cellOccupancyEMCwThr_PHYS"
+        ]
       },
       "ClusterTaskEMCAL": {
         "active": "true",


### PR DESCRIPTION
Histograms from cell task:
- Amp vs. SM
- Time vs. SM
- Occupancy > 500 MeV
- Av. energy
- Av. time

For calibration checks. Cycle duration: 5 minutes.