### PR TITLE
Change from consul to apricot (tpc standalone + global sync)

### DIFF
--- a/DATA/production/calib/tpc-laser-aggregator.sh
+++ b/DATA/production/calib/tpc-laser-aggregator.sh
@@ -14,7 +14,7 @@ HOST=localhost
 
 QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-raw-qcmn"
 
-QC_CONFIG_CONSUL="/o2/components/qc/ANY/any/tpc-raw-qcmn"
+QC_CONFIG="components/qc/ANY/any/tpc-raw-qcmn"
 max_events=300
 publish_after=440
 min_tracks=0
@@ -50,7 +50,7 @@ add_W o2-dpl-raw-proxy " --proxy-name tpc-laser-input-proxy --dataspec \"$PROXY_
 add_W o2-tpc-calib-laser-tracks "${REMAP} --use-filtered-tracks ${EXTRA_CONFIG_TRACKS} --min-tfs=${min_tracks} "
 add_W o2-tpc-calib-pad-raw " ${EXTRA_CONFIG}" "${CALIB_CONFIG}"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path ${CCDB_PATH}" "" 0
-#add_QC_from_consul "${QC_CONFIG_CONSUL}" "--local --host lcoalhost"
+#add_QC_from_apricot "${QC_CONFIG_CONSUL}" "--local --host lcoalhost"
 
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 if [ $WORKFLOWMODE == "print" ]; then
@@ -62,16 +62,4 @@ else
   eval $WORKFLOW
 fi
 
-#o2-dpl-raw-proxy $ARGS_ALL \
-#  --proxy-name tpc-laser-input-proxy \
-#  --dataspec "${PROXY_INSPEC}" \
-#  --network-interface ib0 \
-#  --channel-config "name=tpc-laser-input-proxy,method=bind,type=pull,rateLogging=0,transport=zeromq" \
-# | o2-tpc-calib-laser-tracks  ${ARGS_ALL} --use-filtered-tracks ${EXTRA_CONFIG_TRACKS} --min-tfs=${min_tracks} \
-# --condition-remap "file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPECS;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPMagField;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser=TPC/Calib/LaserTracks" \
-# | o2-tpc-calib-pad-raw ${ARGS_ALL} \
-# --configKeyValues ${CALIB_CONFIG}  ${EXTRA_CONFIG} \
-# | o2-calibration-ccdb-populator-workflow  ${ARGS_ALL} \
-# --ccdb-path ${CCDB_PATH} \
-# | o2-dpl-run $ARGS_ALL --dds ${WORKFLOWMODE_FILE}
 

--- a/DATA/production/calib/tpc-laser-filter.sh
+++ b/DATA/production/calib/tpc-laser-filter.sh
@@ -47,7 +47,7 @@ PROXY_OUTSPEC="A:TPC/LASERTRACKS;B:TPC/CEDIGITS;D:TPC/CLUSREFS"
 HOST=localhost
 
 QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-laser-calib-qcmn"
-QC_CONFIG=components/qc/ANY/any/tpc-laser-calib-qcmn
+QC_CONFIG="components/qc/ANY/any/tpc-laser-calib-qcmn"
 
 
 RAWDIGIT_CONFIG="TPCDigitDump.NoiseThreshold=3;TPCDigitDump.LastTimeBin=600;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR2;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR"

--- a/DATA/production/calib/tpc-laser.sh
+++ b/DATA/production/calib/tpc-laser.sh
@@ -48,7 +48,7 @@ HOST=localhost
 
 
 QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-raw-qcmn"
-QC_CONFIG_CONSUL="/o2/components/qc/ANY/any/tpc-raw-qcmn"
+QC_CONFIG="components/qc/ANY/any/tpc-raw-qcmn"
 
 max_events=300
 publish_after=440
@@ -95,7 +95,7 @@ add_W o2-tpc-laser-track-filter "" "" 0
 add_W o2-tpc-calib-laser-tracks "--use-filtered-tracks ${EXTRA_CONFIG_TRACKS} --min-tfs=${min_tracks}"
 add_W o2-tpc-calib-pad-raw " ${EXTRA_CONFIG}" "${CALIB_CONFIG}"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path ${CCDB_PATH}" "" 0
-add_QC_from_consul "${QC_CONFIG_CONSUL}" "--local --host lcoalhost"
+add_QC_from_apricot "${QC_CONFIG_CONSUL}" "--local --host lcoalhost"
 
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 if [ $WORKFLOWMODE == "print" ]; then

--- a/DATA/production/calib/tpc-pedestal.sh
+++ b/DATA/production/calib/tpc-pedestal.sh
@@ -18,7 +18,7 @@ CCDB_PATH="http://o2-ccdb.internal"
 HOST=localhost
 
 #QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-pedestal-calib-qcmn"
-QC_CONFIG="/o2/components/qc/ANY/any/tpc-pedestal-calib-qcmn"
+QC_CONFIG="components/qc/ANY/any/tpc-pedestal-calib-qcmn"
 
 max_events=50
 publish_after=400
@@ -39,7 +39,7 @@ WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0
 add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\"  --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36" 
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path \"http://o2-ccdb.internal\" " "" 0
-add_QC_from_consul "${QC_CONFIG}" "--local --host localhost"
+add_QC_from_apricot "${QC_CONFIG}" "--local --host localhost"
 
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/calib/tpc-pulser-long.sh
+++ b/DATA/production/calib/tpc-pulser-long.sh
@@ -18,7 +18,7 @@ CCDB_PATH="http://o2-ccdb.internal"
 HOST=localhost
 
 #QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-raw-qcmn"
-QC_CONFIG="/o2/components/qc/ANY/any/tpc-pulser-calib-qcmn"
+QC_CONFIG="components/qc/ANY/any/tpc-pulser-calib-qcmn"
 max_events=1000000
 publish_after=200
 
@@ -38,7 +38,7 @@ WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0
 add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\" --calib-type pulser --reset-after-publish --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36 --check-calib-infos" 
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path \"http://o2-ccdb.internal\" " "" 0
-add_QC_from_consul "${QC_CONFIG}" "--local --host localhost"
+add_QC_from_apricot "${QC_CONFIG}" "--local --host localhost"
 
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/calib/tpc-pulser.sh
+++ b/DATA/production/calib/tpc-pulser.sh
@@ -19,7 +19,7 @@ CCDB_PATH="http://o2-ccdb.internal"
 
 HOST=localhost
 
-QC_CONFIG="/o2/components/qc/ANY/any/tpc-pulser-calib-qcmn"
+QC_CONFIG="components/qc/ANY/any/tpc-pulser-calib-qcmn"
 
 max_events=200
 publish_after=230
@@ -40,7 +40,7 @@ WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0
 add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\" --calib-type pulser --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36 --check-calib-infos" "${CALIB_CONFIG}" 
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path \"http://o2-ccdb.internal\" " "" 0
-add_QC_from_consul "${QC_CONFIG}" "--local --host localhost"
+add_QC_from_apricot "${QC_CONFIG}" "--local --host localhost"
 
 WORKFLOW+="o2-dpl-run ${ARGS_ALL} ${GLOBALDPLOPT}"
 

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -52,7 +52,7 @@ if [[ -z ${QC_JSON_FROM_OUTSIDE:-} && ! -z ${GEN_TOPO_QC_JSON_FILE:-} && -f $GEN
   QC_JSON_FROM_OUTSIDE=$GEN_TOPO_QC_JSON_FILE
 elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
   if [[ $EPNSYNCMODE == 1 || "${GEN_TOPO_LOAD_QC_JSON_FROM_CONSUL:-}" == "1" ]]; then # Sync processing running on the EPN
-    [[ -z "${QC_JSON_TPC:-}" ]] && QC_JSON_TPC=consul://o2/components/qc/ANY/any/tpc-full-qcmn
+    [[ -z "${QC_JSON_TPC:-}" ]] && QC_JSON_TPC=apricot://o2/components/qc/ANY/any/tpc-full-qcmn
     [[ -z "${QC_JSON_ITS:-}" ]] && QC_JSON_ITS=consul://o2/components/qc/ANY/any/its-qcmn-epn-full
     if [[ -z "${QC_JSON_MFT:-}" ]]; then
       if has_detector MFT && has_processing_step MFT_RECO; then


### PR DESCRIPTION
Change from consol to apricot usage for retrieving qc configuration.
Changes were tested in REPLAY runs in production with all detectors. 