### PR TITLE
TPC - Add min ADC value in pedestal workflow

### DIFF
--- a/DATA/production/calib/tpc-pedestal.sh
+++ b/DATA/production/calib/tpc-pedestal.sh
@@ -39,7 +39,7 @@ fi
 
 WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0
-add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\"  --configKeyValues \"${CALIB_CONFIG}\" --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36" 
+add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\" --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36" "${CALIB_CONFIG}"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path \"http://o2-ccdb.internal\" " "" 0
 add_QC_from_apricot "${QC_CONFIG}" "--local --host localhost"
 

--- a/DATA/production/calib/tpc-pedestal.sh
+++ b/DATA/production/calib/tpc-pedestal.sh
@@ -19,6 +19,8 @@ HOST=localhost
 
 #QC_CONFIG="consul-json://alio2-cr1-hv-con01.cern.ch:8500/o2/components/qc/ANY/any/tpc-pedestal-calib-qcmn"
 QC_CONFIG="components/qc/ANY/any/tpc-pedestal-calib-qcmn"
+CALIB_CONFIG="TPCCalibPedestal.ADCMin=20"
+ 
 
 max_events=50
 publish_after=400
@@ -37,7 +39,7 @@ fi
 
 WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0
-add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\"  --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36" 
+add_W o2-tpc-calib-pad-raw "--input-spec \"$CALIB_INSPEC\"  --configKeyValues \"${CALIB_CONFIG}\" --publish-after-tfs ${publish_after} --max-events ${max_events} --lanes 36" 
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path \"http://o2-ccdb.internal\" " "" 0
 add_QC_from_apricot "${QC_CONFIG}" "--local --host localhost"
 


### PR DESCRIPTION
If syncfilter is not active the first sync signal can spoil the result of the pedestal fit. 
Values are suppressed by minADC cut. 