### PR TITLE
CTF Size QC task - Only for Global run

### DIFF
--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -272,7 +272,7 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
   # CTF QC
   if [[ ! -z "${QC_JSON_CTF_SIZE:-}" ]]; then
     add_QC_JSON GLO_CTF ${QC_JSON_CTF_SIZE}
-    add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.CTFSize.taskParameters.detectors=\"${WORKFLOW_DETECTORS}\"'
+#  add_pipe_separated QC_DETECTOR_CONFIG_OVERRIDE '.qc.tasks.CTFSize.taskParameters.detectors=\"${WORKFLOW_DETECTORS}\"'
   fi
 
   # arbitrary extra QC

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -124,7 +124,7 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
     elif has_detectors_reco MCH MID && has_matching_qc MCHMID; then
         [[ -z "${QC_JSON_GLO_MCHMID:-}" ]] && QC_JSON_GLO_MCHMID=consul://o2/components/qc/ANY/any/glo-mchmid-mtch-qcmn-epn
     fi
-    if has_processing_step ENTROPY_ENCODER && [[ ! -z "$WORKFLOW_DETECTORS_CTF" ]] && [[ $WORKFLOW_DETECTORS_CTF != "NONE" ]]; then
+    if has_processing_step ENTROPY_ENCODER && [[ ! -z "$WORKFLOW_DETECTORS_CTF" ]] && [[ $WORKFLOW_DETECTORS_CTF != "NONE" ]] && has_detector CTP; then
       [[ -z "${QC_JSON_CTF_SIZE:-}" ]] && QC_JSON_CTF_SIZE=consul://o2/components/qc/ANY/any/glo-qc-data-size
     fi
     if [[ "${GEN_TOPO_DEPLOYMENT_TYPE:-}" == "ALICE_STAGING" ]]; then


### PR DESCRIPTION
To avoid conflict between parallel runs, the QC task on the EPNs is only started if CTP readout is enabled. 

In this case the task is only executed for one partion in parallel. 