### PR TITLE
MFT: new configuration check for async qc

### DIFF
--- a/DATA/production/qc-async/mft.json
+++ b/DATA/production/qc-async/mft.json
@@ -105,6 +105,22 @@
         "moduleName": "QcMFT",
         "detectorName": "MFT",
         "policy": "OnEachSeparately"
+      },
+      "MFTTracks": {
+        "active": "true",
+        "checkName": "Tracks",
+        "dataSource": [{
+          "type": "Task",
+          "name": "MFTTracks",
+          "MOs" : ["mClusterRatioVsBunchCrossing"]
+        }],
+        "checkParameters" : {
+            "onlineQC" : "0"
+        },
+        "className": "o2::quality_control_modules::mft::QcMFTTrackCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnEachSeparately"
       }
     }
   },


### PR DESCRIPTION
* New MFT configuration check. New code already merged to QC (https://github.com/AliceO2Group/QualityControl/pull/2357).

* This is a changed configuration for async qc for proper timestamp retrieval.