### PR TITLE
[async ITS]: Remove deltaRof=1 in pp

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -446,7 +446,7 @@ EXTRA_ITSRECO_CONFIG=
 if [[ $BEAMTYPE == "PbPb" ]]; then
   EXTRA_ITSRECO_CONFIG="ITSCATrackerParam.deltaRof=1;ITSVertexerParam.clusterContributorsCut=16;ITSVertexerParam.lowMultBeamDistCut=0;ITSCATrackerParam.nROFsPerIterations=12;ITSCATrackerParam.perPrimaryVertexProcessing=true"
 elif [[ $BEAMTYPE == "pp" ]]; then
-  EXTRA_ITSRECO_CONFIG="ITSCATrackerParam.deltaRof=1;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;"
+  EXTRA_ITSRECO_CONFIG="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;"
 fi
 export CONFIG_EXTRA_PROCESS_o2_its_reco_workflow+=";$MAXBCDIFFTOMASKBIAS_ITS;$MAXBCDIFFTOSQUASHBIAS_ITS;$EXTRA_ITSRECO_CONFIG;"
 


### PR DESCRIPTION
As this would not recover enough efficiency, analysers would still be cutting tracks at the beginning of ROFs. The plan is to re-enable this together with multi-rof vertexer if this improves the efficiency