### PR TITLE
TPC: Simplify and uinfy remapping, relax traking toleances

### DIFF
--- a/DATA/production/calib/tpc-laser-aggregator.sh
+++ b/DATA/production/calib/tpc-laser-aggregator.sh
@@ -4,6 +4,8 @@ source common/setenv.sh
 
 source common/getCommonArgs.sh
 
+FILEWORKDIR="/home/wiechula/processData/inputFilesTracking/triggeredLaser"
+
 PROXY_INSPEC="A:TPC/LASERTRACKS;B:TPC/CEDIGITS;D:TPC/CLUSREFS"
 
 CALIB_CONFIG="TPCCalibPulser.FirstTimeBin=450;TPCCalibPulser.LastTimeBin=550;TPCCalibPulser.NbinsQtot=250;TPCCalibPulser.XminQtot=2;TPCCalibPulser.XmaxQtot=502;TPCCalibPulser.MinimumQtot=8;TPCCalibPulser.MinimumQmax=6;TPCCalibPulser.XminT0=450;TPCCalibPulser.XmaxT0=550;TPCCalibPulser.NbinsT0=400;keyval.output_dir=/dev/null"
@@ -20,7 +22,7 @@ publish_after=440
 min_tracks=0
 num_lanes=36
 
-REMAP="--condition-remap \"file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPECS,GLO/Config/GRPMagField,TPC/Calib/LaserTracks\" "
+REMAP="--condition-remap \"file://${FILEWORKDIR}=GLO/Config/GRPECS,GLO/Config/GRPMagField,TPC/Calib/LaserTracks\" "
 if [[ ! -z ${TPC_CALIB_MAX_EVENTS:-} ]]; then
     max_events=${TPC_CALIB_MAX_EVENTS}
 fi

--- a/DATA/production/calib/tpc-laser-filter.sh
+++ b/DATA/production/calib/tpc-laser-filter.sh
@@ -51,7 +51,7 @@ QC_CONFIG="components/qc/ANY/any/tpc-laser-calib-qcmn"
 
 
 RAWDIGIT_CONFIG="TPCDigitDump.NoiseThreshold=3;TPCDigitDump.LastTimeBin=600;NameConf.mDirGRP=$FILEWORKDIR;NameConf.mDirGeom=$FILEWORKDIR2;NameConf.mDirCollContext=$FILEWORKDIR;NameConf.mDirMatLUT=$FILEWORKDIR"
-REMAP="--condition-remap \"file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPECS;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPMagField;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser=TPC/Calib/LaserTracks\" "
+REMAP="--condition-remap \"file://${FILEWORKDIR}=GLO/Config/GRPECS,GLO/Config/GRPMagField,TPC/Calib/LaserTracks\" "
 RECO_CONFIG="NameConf.mDirGRP=$FILEWORKDIR;"
 RECO_CONFIG+="NameConf.mDirGeom=$FILEWORKDIR2;"
 RECO_CONFIG+="NameConf.mDirCollContext=$FILEWORKDIR;"
@@ -65,7 +65,9 @@ RECO_CONFIG+="GPU_rec_tpc.clusterError2AdditionalY=0.1;"
 RECO_CONFIG+="GPU_rec_tpc.clusterError2AdditionalZ=0.15;"
 RECO_CONFIG+="GPU_rec_tpc.clustersShiftTimebinsClusterizer=35;"
 RECO_CONFIG+="GPU_proc.memoryScalingFactor=2;"
-RECO_CONFIG+="GPU_proc_param.tpcTriggerHandling=0"
+RECO_CONFIG+="GPU_proc_param.tpcTriggerHandling=0;"
+# relax tolerances on tracking and selection cut to deal with very low laser intensities
+RECO_CONFIG+="GPU_rec_tpc.trackFollowingMaxRowGap=15;GPU_rec_tpc.trackFollowingMaxRowGapSeed=15;GPU_rec_tpc.minTrackdEdxMax=8;GPU_rec_tpc.adddEdxSubThresholdClusters=0;"
 
 
 WORKFLOW=

--- a/DATA/production/calib/tpc-laser.sh
+++ b/DATA/production/calib/tpc-laser.sh
@@ -84,8 +84,10 @@ if [[ ${TPC_CALIB_TRACKS_PUBLISH_EOS:-} == 1 ]]; then
 fi
 
 RAWDIGIT_CONFIG="TPCDigitDump.NoiseThreshold=3;TPCDigitDump.LastTimeBin=600"
-REMAP="--condition-remap \"file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPECS;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser/=GLO/Config/GRPMagField;file:///home/wiechula/processData/inputFilesTracking/triggeredLaser=TPC/Calib/LaserTracks\" "
-RECO_CONFIG="align-geom.mDetectors=none;GPU_global.deviceType=$GPUTYPE;GPU_proc.tpcIncreasedMinClustersPerRow=500000;GPU_proc.ignoreNonFatalGPUErrors=1;$GPU_CONFIG_KEY;GPU_global.tpcTriggeredMode=1;GPU_rec_tpc.clusterError2AdditionalY=0.1;GPU_rec_tpc.clusterError2AdditionalZ=0.15;GPU_rec_tpc.clustersShiftTimebinsClusterizer=35"   
+REMAP="--condition-remap \"file://${FILEWORKDIR}=GLO/Config/GRPECS,GLO/Config/GRPMagField,TPC/Calib/LaserTracks\" "
+RECO_CONFIG="align-geom.mDetectors=none;GPU_global.deviceType=$GPUTYPE;GPU_proc.tpcIncreasedMinClustersPerRow=500000;GPU_proc.ignoreNonFatalGPUErrors=1;$GPU_CONFIG_KEY;GPU_global.tpcTriggeredMode=1;GPU_rec_tpc.clusterError2AdditionalY=0.1;GPU_rec_tpc.clusterError2AdditionalZ=0.15;GPU_rec_tpc.clustersShiftTimebinsClusterizer=35;"
+# relax tolerances on tracking and selection cut to deal with very low laser intensities
+RECO_CONFIG+="GPU_rec_tpc.trackFollowingMaxRowGap=15;GPU_rec_tpc.trackFollowingMaxRowGapSeed=15;GPU_rec_tpc.minTrackdEdxMax=8;GPU_rec_tpc.adddEdxSubThresholdClusters=0;"
 
 WORKFLOW=
 add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@tf-builder-pipe-0,transport=shmem,rateLogging=1\"" "" 0


### PR DESCRIPTION
In order to reconstruct more laser tracks, the trackig tolerances are relaxed. The laser intensity is very weak. This leads to very few clusters above threshold and very low dE/dx.
What was modified is
- lower the track dEdx max cut from minimum 20 to 8
- switch off the addition of sub-threshold clusters. This will tear down the dE/dx even more, if enabled
- increase the tracking tolerances in terms of gaps between clusters from 4/2 in tracking/seeding to 15/15