### PR TITLE
PWGHF: add ini for B-forced MCs for pp collisions

### DIFF
--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredBeauty(5, -1.5, 1.5)
+
+[GeneratorPythia8]
+config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.C
@@ -1,0 +1,115 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuark{5};
+    float ratioTrigger = 1./5; // one event triggered out of 5
+
+    std::vector<int> checkPdgHadron{411, 421, 431, 4122, 4132, 4232, 4332};
+    std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
+        {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
+        {421, {{-321, 211}, {-321, 111, 211}}}, // D0
+        {431, {{211, 333}, {-313, 321}}}, // Ds+
+        {4122, {{-313, 2212}, {-321, 2224}, {211, 102134}, {-321, 211, 2212}, {311, 2212}}}, // Lc+
+        {4132, {{211, 3312}}}, // Xic0
+        {4232, {{-313, 2212}, {-321, 3324}, {211, 211, 3312}, {-321, 211, 2212}}}, // Xic+
+        {4332, {{211, 3334}}}, // Omegac+
+        {511, {{-411, 211}, {-413, 211}, {-411, 213}, {431, -211}}}, // B0
+        {521, {{-421, 211}, {-423, 211}, {-421, 213}}}, // B+
+        {531, {{-431, 211}, {-433, 211}, {-431, 213}}}, // Bs0
+        {5122, {{4122, -211}, {4122, -213}, {4122, 211, -211, -211}, {4212, -211}}} // Lb0
+    };
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsMB{}, nEventsInj{};
+    int nQuarks{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == 0) {
+                nEventsMB++;
+            } else if (subGeneratorId == checkPdgQuark) {
+                nEventsInj++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::abs(pdg) == checkPdgQuark) {
+                nQuarks++;
+                continue;
+            }
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+                nSignals++; // count signal PDG
+
+                std::vector<int> pdgsDecay{};
+                std::vector<int> pdgsDecayAntiPart{};
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    pdgsDecay.push_back(pdgDau);
+                    if (pdgDau != 333) { // phi is antiparticle of itself
+                        pdgsDecayAntiPart.push_back(-pdgDau);
+                    } else {
+                        pdgsDecayAntiPart.push_back(pdgDau);
+                    }
+                }
+
+                std::sort(pdgsDecay.begin(), pdgsDecay.end());
+                std::sort(pdgsDecayAntiPart.begin(), pdgsDecayAntiPart.end());
+
+                for (auto &decay : checkHadronDecays[std::abs(pdg)]) {
+                    if (pdgsDecay == decay || pdgsDecayAntiPart == decay) {
+                        nSignalGoodDecay++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << "# MB events: " << nEventsMB << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuark) << nEventsInj << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuark) << nQuarks << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+
+    if (nEventsMB < nEvents * (1 - ratioTrigger) * 0.95 || nEventsMB > nEvents * (1 - ratioTrigger) * 1.05) { // we put some tolerance since the number of generated events is small
+        std::cerr << "Number of generated MB events different than expected\n";
+        return 1;
+    }
+    if (nEventsInj < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInj > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuark << " different than expected\n";
+        return 1;
+    }
+
+    if (nQuarks < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuark << " lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (e.g. due to oscillations which might change the final state)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
@@ -1,0 +1,174 @@
+### authors: Fabrizio Grosa (fabrizio.grosa@cern.ch)
+###          Cristina Terrevoli (cristina.terrevoli@cern.ch)
+###          Fabio Catalano (fabio.catalano@cern.ch)
+### last update:  November 2023
+
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13600. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+### switching on Pythia Mode2
+ColourReconnection:mode 1
+ColourReconnection:allowDoubleJunRem off
+ColourReconnection:m0 0.3
+ColourReconnection:allowJunctions on
+ColourReconnection:junctionCorrection 1.20
+ColourReconnection:timeDilationMode 2
+ColourReconnection:timeDilationPar 0.18
+StringPT:sigma 0.335
+StringZ:aLund 0.36
+StringZ:bLund 0.56
+StringFlav:probQQtoQ 0.078
+StringFlav:ProbStoUD 0.2
+StringFlav:probQQ1toQQ0join 0.0275,0.0275,0.0275,0.0275
+MultiPartonInteractions:pT0Ref 2.15
+BeamRemnants:remnantMode 1
+BeamRemnants:saturation 5
+
+# Correct decay lengths (wrong in PYTHIA8 decay table)
+# Lb
+5122:tau0 = 0.4390
+# Xic0
+4132:tau0 = 0.0455
+# OmegaC
+4332:tau0 = 0.0803
+
+### Force golden charm hadrons decay modes for D2H studies
+### add D+ decays absent in PYTHIA8 decay table and set BRs from PDG for other
+411:oneChannel = 1 0.0752 0 -321 211 211
+411:addChannel = 1 0.0104 0 -313 211
+411:addChannel = 1 0.0156 0 311 211
+411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
+## add Lc decays absent in PYTHIA8 decay table and set BRs from PDG for other
+4122:oneChannel = 1 0.0196 100 2212 -313
+4122:addChannel = 1 0.0108 100 2224 -321
+4122:addChannel = 1 0.022 100 102134 211
+4122:addChannel = 1 0.035 0 2212 -321 211
+4122:addChannel = 1 0.0159 0 2212 311
+### add Xic+ decays absent in PYTHIA8 decay table
+4232:addChannel = 1 0.2 0 2212 -313
+4232:addChannel = 1 0.2 0 2212 -321 211
+4232:addChannel = 1 0.2 0 3324 211
+4232:addChannel = 1 0.2 0 3312 211 211
+### add Xic0 decays absent in PYTHIA8 decay table
+4132:addChannel = 1 0.0143 0 3312 211
+### add OmegaC decays absent in PYTHIA8 decay table
+4332:addChannel = 1 0.5 0 3334 211
+4332:addChannel = 1 0.5 0 3312 211
+
+### K* -> K pi
+313:onMode = off
+313:onIfAll = 321 211
+### for Ds -> Phi pi+
+333:onMode = off
+333:onIfAll = 321 321
+### for D0 -> rho0 pi+ k-
+113:onMode = off
+113:onIfAll = 211 211
+### for Lambda_c -> Delta++ K-
+2224:onMode = off
+2224:onIfAll = 2212 211
+### for Lambda_c -> Lambda(1520) K-
+102134:onMode = off
+102134:onIfAll = 2212 321
+### for Xic0 -> pi Xi -> pi pi Lambda -> pi pi pi p 
+### and Omega_c -> pi Xi -> pi pi Lambda -> pi pi pi p
+3312:onMode = off
+3312:onIfAll = 3122 -211
+3122:onMode = off
+3122:onIfAll = 2212 -211
+### for Omega_c -> pi Omega -> pi K Lambda -> pi K pi p
+3334:onMode = off
+3334:onIfAll = 3122 -321
+
+### switch off all decay channels
+411:onMode = off
+421:onMode = off
+431:onMode = off
+4112:onMode = off
+4122:onMode = off
+4232:onMode = off
+4132:onMode = off
+443:onMode = off
+4332:onMode = off
+511:onMode = off
+521:onMode = off
+531:onMode = off
+5122:onMode = off
+
+### D0 -> K pi
+421:onIfMatch = 321 211
+
+### D+/- -> K pi pi 
+411:onIfMatch = 321 211 211
+### D+/- -> K* pi
+411:onIfMatch = 313 211
+### D+/- -> phi pi
+411:onIfMatch = 333 211
+
+### D_s -> K K*
+431:onIfMatch = 321 313
+### D_s -> Phi pi
+431:onIfMatch = 333 211
+
+### Lambda_c -> p K*
+4122:onIfMatch = 2212 313
+### Lambda_c -> Delta K
+4122:onIfMatch = 2224 321
+### Lambda_c -> Lambda(1520) pi
+4122:onIfMatch = 102134 211
+### Lambda_c -> p K pi
+4122:onIfMatch = 2212 321 211
+### Lambda_c -> pK0s
+4122:onIfMatch = 2212 311 
+
+### Xic+ -> pK*0
+4232:onIfMatch = 2212 313
+### Xic+ -> p K- pi+
+4232:onIfMatch = 2212 321 211
+### Xic+ -> Xi*0 pi+, Xi*->Xi- pi+
+4232:onIfMatch = 3324 211
+### Xic+ -> Xi- pi+ pi+
+4232:onIfMatch = 3312 211 211
+    
+### Xic0 -> Xi- pi+
+4132:onIfMatch = 3312 211
+
+### Omega_c -> Omega pi
+4332:onIfMatch = 3334 211
+### Omega_c -> Xi pi
+4332:onIfMatch = 3312 211
+
+### Force also golden beauty hadrons decay modes for D2H studies
+### add B0 decays
+511:oneChannel = 1 0.4 0 -411 211
+511:addChannel = 1 0.3 0 -413 211
+511:addChannel = 1 0.2 0 431 -211
+### add B+ decays
+521:oneChannel = 1 0.8 0 -421 211
+### add Bs0 decays
+531:oneChannel = 1 0.8 0 -431 211
+### add Lb decays
+5122:oneChannel = 1 0.8 0 4122 -211
+
+### we also add channels useful for study of partly reconstructed decays / correlated backgrounds
+### add B0 decays
+511:oneChannel = 1 0.1 0 -411 213
+### add B+ decays
+521:oneChannel = 1 0.1 0 -421 213
+521:oneChannel = 1 0.1 0 -423 211
+### add Bs0 decays
+531:oneChannel = 1 0.1 0 -431 213
+531:oneChannel = 1 0.1 0 -433 211
+### add Lb decays
+5122:oneChannel = 1 0.1 0 4122 -213
+5122:oneChannel = 1 0.05 0 4122 211 -211 -211
+5122:oneChannel = 1 0.05 0 4212 -211


### PR DESCRIPTION
This PR adds the configuration for pp MC simulations with B-hadron decays forced, in view of anchored productions.

Besides the golden decay channels, I added the dominant decays for the studies of partly reconstructed decays and correlated backgrounds (suppressed compared to the main decays, typically with -an arbitrary- 20% contribution).
@fcatalan92 @mfaggin @fcolamar please have a look if it sounds reasonable to you (also @AlexBigO, since you did quite extensive studies for the B0, if you have time to check it would be great).