### PR TITLE
Set the analysisQC axis range depending on the coll system

### DIFF
--- a/MC/analysis_testing/o2dpg_analysis_test_utils.py
+++ b/MC/analysis_testing/o2dpg_analysis_test_utils.py
@@ -30,6 +30,10 @@ ANALYSIS_MERGED_ANALYSIS_NAME = "MergedAnalyses"
 def adjust_configuration_line(line, data_or_mc, collision_system):
     line = line.replace('!ANALYSIS_QC_is_mc!', str(data_or_mc == ANALYSIS_VALID_MC).lower())
     line = line.replace('!ANALYSIS_QC_is_data!', str(data_or_mc == ANALYSIS_VALID_DATA).lower())
+    if collision_system == "pp":
+        line = line.replace('!OVERWRITEAXISRANGEFORPBPBVALUE!', "false")
+    else:
+        line = line.replace('!OVERWRITEAXISRANGEFORPBPBVALUE!', "true")
     return line
 
 

--- a/MC/config/analysis_testing/json/dpl/o2-analysis-qa-event-track.json
+++ b/MC/config/analysis_testing/json/dpl/o2-analysis-qa-event-track.json
@@ -1,7 +1,7 @@
 {
   "qa-event-track": {
     "checkOnlyPVContributor": "true",
-    "overwriteAxisRangeForPbPb": "true",
+    "overwriteAxisRangeForPbPb": "!OVERWRITEAXISRANGEFORPBPBVALUE!",
     "processData": "!ANALYSIS_QC_is_data!",
     "processDataIU": "false",
     "processDataIUFiltered": "false",


### PR DESCRIPTION
This should fix the issue seen in the analysis QC for the qa-event-track task for which the axis range is always the one of PbPb instead of changing in case of pp data. 
@mfaggin , @alcaliva 