### PR TITLE
Added possibility to define a general HEPMCOFFSET.

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -724,9 +724,17 @@ for tf in range(1, NTIMEFRAMES + 1):
                          cpu=1, mem=1000)
 
    SGNGENtask['cmd']=''
-   if GENERATOR=="hepmc" and tf > 1:
-     # determine the skip number
-     cmd = 'export HEPMCEVENTSKIP=$(${O2DPG_ROOT}/UTILS/ReadHepMCEventSkip.sh ../HepMCEventSkip.json ' + str(tf) + ');'
+   if GENERATOR=="hepmc":
+     if tf == 1:
+      # determine the offset number
+       eventOffset = environ.get('HEPMCOFFSET')
+       print("HEPMCOFFSET: ", eventOffset)
+       if eventOffset == None:
+        eventOffset = 0
+       cmd = 'export HEPMCEVENTSKIP=$(${O2DPG_ROOT}/UTILS/InitHepMCEventSkip.sh ../HepMCEventSkip.json ' + str(eventOffset) + ');'
+     elif tf > 1:
+       # determine the skip number
+       cmd = 'export HEPMCEVENTSKIP=$(${O2DPG_ROOT}/UTILS/ReadHepMCEventSkip.sh ../HepMCEventSkip.json ' + str(tf) + ');'
      SGNGENtask['cmd'] = cmd
    SGNGENtask['cmd'] +='${O2_ROOT}/bin/o2-sim --noGeant -j 1 --field ccdb --vertexMode kCCDB'         \
                      + ' --run ' + str(args.run) + ' ' + str(CONFKEY) + str(TRIGGER)                  \

--- a/UTILS/InitHepMCEventSkip.sh
+++ b/UTILS/InitHepMCEventSkip.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Path to the JSON file
+JSON_FILE=${1:-HepMC_EventSkip_ALT.json}
+EVENTS=$2
+
+# insert event count offset
+echo "[]" > ${JSON_FILE} # init json file
+JQ_COMMAND="jq '. + [{"HepMCEventOffset": ${EVENTS}}]' ${JSON_FILE} > tmp_123.json; mv tmp_123.json ${JSON_FILE}"
+eval ${JQ_COMMAND}
+
+echo ${EVENTS}

--- a/UTILS/ReadHepMCEventSkip.sh
+++ b/UTILS/ReadHepMCEventSkip.sh
@@ -3,5 +3,22 @@
 # Path to the JSON file
 JSON_FILE=$1
 tf=$2
+
+# get event offset
+JQCOMMAND="jq '.[] | select(.HepMCEventOffset) | .HepMCEventOffset' ${JSON_FILE}"
+offset=`eval ${JQCOMMAND}`
+if [ ! $offset ]
+then
+  offset=0
+fi
+
+# count generated events
 JQCOMMAND="jq '[.[] | select(.tf < ${tf}) | .HepMCEventCount] | add' ${JSON_FILE}"
-eval ${JQCOMMAND}
+events=`eval ${JQCOMMAND}`
+if [ ! $events ]
+then
+  events=0
+fi
+
+# total number of events to skip
+echo $((offset + events))


### PR DESCRIPTION
This is useful when simulating different SPLITIDs/CYCLEs of a run in separate jobs.

For given parameters:
PRODSPLIT
NTIMEFRAMES
NSIGEVENTS
SPLITID
CYCLE

the offset can e.g. be calculated with:
HEPMCOFFSET`echo "(${CYCLE}+${PRODSPLIT}*(${SPLITID}-1))*${NTIMEFRAMES}*${NSIGEVENTS}" | bc`