### PR TITLE
FIT: add MC aQC for FV0 and FDD

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -104,6 +104,8 @@ def include_all_QC_finalization(ntimeframes, standalone, run, productionTag, con
   else:
      add_QC_finalization('tofPIDQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/pidtofNoTRD.json')
   add_QC_finalization('RecPointsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/ft0-reconstruction-config.json')
+  add_QC_finalization('FV0DigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/fv0-digits.json')
+  add_QC_finalization('FDDRecPointsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/fdd-recpoints.json')
   add_QC_finalization('CPVDigitsQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/cpv-digits-task.json')
   add_QC_finalization('CPVClustersQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/cpv-clusters-task.json')
   add_QC_finalization('PHSCellsClustersQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/phs-cells-clusters-task.json')

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1342,9 +1342,21 @@ for tf in range(1, NTIMEFRAMES + 1):
                       configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/emc-bc-task.json')
      ### FT0
      addQCPerTF(taskName='RecPointsQC',
-                   needs=[FT0RECOtask['name']],
-                   readerCommand='o2-ft0-recpoints-reader-workflow  --infile o2reco_ft0.root',
-                   configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/ft0-reconstruction-config.json')
+                needs=[FT0RECOtask['name']],
+                readerCommand='o2-ft0-recpoints-reader-workflow --infile o2reco_ft0.root',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/ft0-reconstruction-config.json')
+
+      # ### FV0
+     addQCPerTF(taskName='FV0DigitsQC',
+                needs=[getDigiTaskName("FV0")],
+                readerCommand='o2-fv0-digit-reader-workflow --fv0-digit-infile fv0digits.root',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/fv0-digits.json')
+
+     ### FDD
+     addQCPerTF(taskName='FDDRecPointsQC',
+                needs=[FDDRECOtask['name']],
+                readerCommand='o2-fdd-recpoints-reader-workflow --fdd-recpoints-infile o2reco_fdd.root',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/fdd-recpoints.json')
 
      ### GLO + RECO
      addQCPerTF(taskName='vertexQC',

--- a/MC/config/QC/json/fdd-recpoints.json
+++ b/MC/config/QC/json/fdd-recpoints.json
@@ -1,0 +1,38 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "provenance": "qc_mc",
+        "passName": "passMC",
+        "periodName": "SimChallenge"
+      },
+      "monitoring": {
+        "url": "no-op://"
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
+      }
+    },
+    "tasks": {
+      "RecPoints": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fdd::RecPointsQcTask",
+        "moduleName": "QcFDD",
+        "detectorName": "FDD",
+        "cycleDurationSeconds": "600",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "recpoints:FDD/RECPOINTS/0;channels:FDD/RECCHDATA/0"
+        }
+      }
+    }
+  }
+}

--- a/MC/config/QC/json/fv0-digits.json
+++ b/MC/config/QC/json/fv0-digits.json
@@ -1,0 +1,51 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "provenance": "qc_mc",
+        "passName": "passMC",
+        "periodName": "SimChallenge"
+      },
+      "monitoring": {
+        "url": "no-op://"
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
+      }
+    },
+    "tasks": {
+      "Digits": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::DigitQcTask",
+        "moduleName": "QcFV0",
+        "detectorName": "FV0",
+        "cycleDurationSeconds": "600",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:FV0/DIGITSBC/0;channels:FV0/DIGITSCH/0"
+        },
+        "taskParameters": {
+          "#ChannelIDs": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48",
+          "#ChannelIDsAmpVsTime": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48",
+          "trgModeInnerOuterThresholdVar": "Ampl",
+          "trgThresholdNChannels": "2",
+          "trgThresholdCharge": "8",
+          "trgThresholdChargeInner": "4",
+          "trgThresholdChargeOuter": "4",
+          "trgChargeLevelLow": "6",
+          "trgChargeLevelHigh": "4095",
+          "minGateTimeForRatioHistogram": "-192",
+          "maxGateTimeForRatioHistogram": "192"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enable MC aQC for FV0 and FDD. **NOTE!!!** This needs [https://github.com/AliceO2Group/AliceO2/pull/13482](https://github.com/AliceO2Group/AliceO2/pull/13482) to work!