### PR TITLE
Update its-noise-aggregator.sh: keep flp199 ccdb for tests

### DIFF
--- a/DATA/production/calib/its-noise-aggregator.sh
+++ b/DATA/production/calib/its-noise-aggregator.sh
@@ -20,7 +20,7 @@ CCDBPATH1="http://o2-ccdb.internal"
 CCDBPATH2="$DCSCCDBSERVER_PERS"
 if [[ $RUNTYPE == "SYNTHETIC" || "${GEN_TOPO_DEPLOYMENT_TYPE:-}" == "ALICE_STAGING" || ! -z $ISTEST ]]; then
   CCDBPATH1="http://ccdb-test.cern.ch:8080"
-  CCDBPATH2="http://ccdb-test.cern.ch:8080"
+  CCDBPATH2="$DCSCCDBSERVER_PERS"
 fi
 
 WORKFLOW=


### PR DESCRIPTION
Minor change which simplify the tests of noise calibration. If the list of noisy pixels is sent to flp199 ccdb is easier to retrieve the object than ccdb-test with dcs scripts.