### PR TITLE
Topology parser: Override stdin file descriptor of the scripts that are called with an empty one

### DIFF
--- a/DATA/tools/epn/gen_topo_o2dpg.sh
+++ b/DATA/tools/epn/gen_topo_o2dpg.sh
@@ -89,6 +89,8 @@ while true; do
       git fetch --tags origin 1>&2 || { echo Repository update failed 1>&2; exit 1; }
       git checkout $GEN_TOPO_SOURCE &> /dev/null || { echo commit does not exist 1>&2; exit 1; }
     fi
+    git reset --hard $GEN_TOPO_SOURCE &> /dev/null  || { echo git reset error 1>&2; exit 1; }
+    rm -f DATA/core_dump_*
     # At a tag, or a detached non-dirty commit, but not on a branch
     if ! git describe --exact-match --tags HEAD &> /dev/null && ( git symbolic-ref -q HEAD &> /dev/null || ! git diff-index --quiet HEAD &> /dev/null ); then
       unset GEN_TOPO_CACHEABLE

--- a/DATA/tools/parse
+++ b/DATA/tools/parse
@@ -152,7 +152,7 @@ for line in f:
                     command += ' > ' + filename
                 print('Running DPL command', command)
                 starttime = time.time()
-                retVal = subprocess.run(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+                retVal = subprocess.run(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE, input="")
                 print('Execution time: ', time.time() - starttime)
                 tmpchk = retVal.stderr.decode() + retVal.stdout.decode()
                 haserror = 0


### PR DESCRIPTION
This fixes the topology generation failures which we started to see today.
No idea why it never happened before, and why now many environments are affected.

What happens is that stdin is passed from the script called by ODC to the topology parser and then to the DPL executables, and apparently in some cased we get an stdin file descriptor which reports to be not empty, but reading from it fails with `bad file descriptor`. This fix just overrides the stdin for all the scripts called by the parser with an empty one.