### PR TITLE
Introduced new environment config variable

### DIFF
--- a/.github/workflows/syntax-checks.yml
+++ b/.github/workflows/syntax-checks.yml
@@ -71,6 +71,27 @@ jobs:
           jq -r '.comments[] | "Error found in \(.file) line \(.line):\n::error file=\(.file),line=\(.line),endLine=\(.endLine),col=\(.column),endColumn=\(.endColumn)::\(.message)"' errors.json
           exit "$error"
 
+  config-check:
+    name: Config-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run configurations checker
+        run: |
+          error=0
+          readarray -d '' files < \
+            <(find . -path ./.git -prune -false -or -type f -name '*.ini' -print0)
+          for cfg in "${files[@]}"; do
+            if grep -q "O2DPG_ROOT" "$cfg"; then
+              error=1
+              echo "Deprecated O2DPG_ROOT detected in $cfg, replace with O2DPG_MC_CONFIG_ROOT" >&2
+            fi
+          done
+          exit "$error"
+
   pylint:
     name: Pylint
     runs-on: ubuntu-latest

--- a/.github/workflows/syntax-checks.yml
+++ b/.github/workflows/syntax-checks.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run .ini configurations check
+      - name: Run .ini configs check
         run: |
           error=0
           readarray -d '' files < \

--- a/.github/workflows/syntax-checks.yml
+++ b/.github/workflows/syntax-checks.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run configurations checker
+      - name: Run .ini configurations check
         run: |
           error=0
           readarray -d '' files < \

--- a/MC/config/ALICE3/ini/pythia8_ArAr.ini
+++ b/MC/config/ALICE3/ini/pythia8_ArAr.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg

--- a/MC/config/ALICE3/ini/pythia8_ArAr.ini
+++ b/MC/config/ALICE3/ini/pythia8_ArAr.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_ArAr.cfg

--- a/MC/config/ALICE3/ini/pythia8_KrKr.ini
+++ b/MC/config/ALICE3/ini/pythia8_KrKr.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg

--- a/MC/config/ALICE3/ini/pythia8_KrKr.ini
+++ b/MC/config/ALICE3/ini/pythia8_KrKr.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_KrKr.cfg

--- a/MC/config/ALICE3/ini/pythia8_OO.ini
+++ b/MC/config/ALICE3/ini/pythia8_OO.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg

--- a/MC/config/ALICE3/ini/pythia8_OO.ini
+++ b/MC/config/ALICE3/ini/pythia8_OO.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_OO.cfg

--- a/MC/config/ALICE3/ini/pythia8_PbPb.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg

--- a/MC/config/ALICE3/ini/pythia8_PbPb.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb.cfg

--- a/MC/config/ALICE3/ini/pythia8_PbPb_536tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb_536tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_536tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_536tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_PbPb_536tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb_536tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_536tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_536tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_XeXe.ini
+++ b/MC/config/ALICE3/ini/pythia8_XeXe.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg

--- a/MC/config/ALICE3/ini/pythia8_XeXe.ini
+++ b/MC/config/ALICE3/ini/pythia8_XeXe.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_XeXe.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_13tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_13tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_13tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_13tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_hardQCD_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_hardQCD_136tev.ini
@@ -2,9 +2,9 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hardQCD_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hardQCD_136tev.cfg
 includePartonEvent=true

--- a/MC/config/ALICE3/ini/pythia8_pp_hardQCD_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_hardQCD_136tev.ini
@@ -2,9 +2,9 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hardQCD_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hardQCD_136tev.cfg
 includePartonEvent=true

--- a/MC/config/ALICE3/ini/pythia8_pp_hf_hardQCD_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_hf_hardQCD_136tev.ini
@@ -2,9 +2,9 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hf_hardQCD_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hf_hardQCD_136tev.cfg
 includePartonEvent=true

--- a/MC/config/ALICE3/ini/pythia8_pp_hf_hardQCD_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_hf_hardQCD_136tev.ini
@@ -2,9 +2,9 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hf_hardQCD_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_hf_hardQCD_136tev.cfg
 includePartonEvent=true

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_13tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_13tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_ropes_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_ropes_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_13tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_ropes_13tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving_136tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_136tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_13tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_13tev.cfg

--- a/MC/config/ALICE3/ini/pythia8_pp_shoving_13tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_shoving_13tev.ini
@@ -2,8 +2,8 @@
 width[2]=6.0
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
 funcName=generator_pythia8_ALICE3()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_13tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_shoving_13tev.cfg

--- a/MC/config/ALICE3/ini/xicc_PbPb.ini
+++ b/MC/config/ALICE3/ini/xicc_PbPb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_PbPb.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_PbPb.C
 funcName=generateNativeXiCC()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg

--- a/MC/config/ALICE3/ini/xicc_PbPb.ini
+++ b/MC/config/ALICE3/ini/xicc_PbPb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_PbPb.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_PbPb.C
 funcName=generateNativeXiCC()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg

--- a/MC/config/ALICE3/ini/xicc_pp.ini
+++ b/MC/config/ALICE3/ini/xicc_pp.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_pp.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_pp.C
 funcName=generateNativeXiCC()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg

--- a/MC/config/ALICE3/ini/xicc_pp.ini
+++ b/MC/config/ALICE3/ini/xicc_pp.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_pp.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_gun_pp.C
 funcName=generateNativeXiCC()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/config_custom_xicc.cfg

--- a/MC/config/PWGDQ/ini/GeneratorHF_JPsiToMuons_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_JPsiToMuons_fwdy.ini
@@ -2,5 +2,5 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
 funcName = GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV()

--- a/MC/config/PWGDQ/ini/GeneratorHF_JPsiToMuons_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_JPsiToMuons_fwdy.ini
@@ -2,5 +2,5 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV.C
 funcName = GeneratorParamPromptJpsiToMuonEvtGen_pp13TeV()

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
 funcName = GeneratorBplusToJpsiKaon_EvtGen()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectHFwithinAcc(521,kFALSE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBplusToJpsiKaon_EvtGen.C
 funcName = GeneratorBplusToJpsiKaon_EvtGen()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectHFwithinAcc(521,kFALSE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy_triggerGap.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBplusToJpsiKaon_EvtGen()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToBplus_midy_triggerGap.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBplusToJpsiKaon_EvtGen()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToDDbarToMuons_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToDDbarToMuons_fwdy.ini
@@ -3,15 +3,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
 funcName = GeneratorBeautyToMu_EvtGenFwdY(-4.3,-2.3,true,false)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -19,5 +19,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToDDbarToMuons_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToDDbarToMuons_fwdy.ini
@@ -3,15 +3,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
 funcName = GeneratorBeautyToMu_EvtGenFwdY(-4.3,-2.3,true,false)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -19,5 +19,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToMuonsSemileptonic_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToMuonsSemileptonic_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
 funcName = GeneratorBeautyToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbarToMuonsSemileptonic_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbarToMuonsSemileptonic_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToMu_EvtGen.C
 funcName = GeneratorBeautyToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
 funcName = GeneratorBeautyToPsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
 funcName = GeneratorBeautyToPsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
 funcName = GeneratorBeautyToPsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_Psi2S_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsi_EvtGen.C
 funcName = GeneratorBeautyToPsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(100443,kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selecMultipletHFwithinAcc("443;100443",kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selecMultipletHFwithinAcc("443;100443",kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy_triggerGap.ini
@@ -2,14 +2,14 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_fwdy_triggerGap.ini
@@ -2,14 +2,14 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selecMultipletHFwithinAcc("443;100443",kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToPsiAndJpsi_EvtGen.C
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selecMultipletHFwithinAcc("443;100443",kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy_triggerGap.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy_triggerGap.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_PsiAndJpsi_midy_triggerGap.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_gaptriggered_dq.C 
 funcName = GeneratorBeautyToPsiAndJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
 funcName = GeneratorBeautyToJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(443,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
 funcName = GeneratorBeautyToJpsi_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(443,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
 funcName = GeneratorBeautyToJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(443,kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_bbbar_midy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_bbbar_midy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorBeautyToJpsi_EvtGen.C
 funcName = GeneratorBeautyToJpsi_EvtGenMidY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,7 +18,7 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(443,kTRUE,-1.5,1.5)
 
 ### The setup inhibits transport of primary particles which are produce at forward rapidity.

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hf.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel_cr2.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel_cr2.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel_cr2.ini
+++ b/MC/config/PWGDQ/ini/GeneratorHF_ccbarToMuonsSemileptonic_fwdy_inel_cr2.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/GeneratorCharmToMu_EvtGen.C
 funcName = GeneratorCharmToMu_EvtGenFwdY()
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-4.3,-2.3)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(13,kTRUE,-4.3,-2.3)

--- a/MC/config/PWGDQ/ini/GeneratorJPsiHFCorr_ccbar.ini
+++ b/MC/config/PWGDQ/ini/GeneratorJPsiHFCorr_ccbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -6, 6, -4.5, -2., {443})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/decayer/jpsi_hf_corr.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/decayer/jpsi_hf_corr.cfg

--- a/MC/config/PWGDQ/ini/GeneratorJPsiHFCorr_ccbar.ini
+++ b/MC/config/PWGDQ/ini/GeneratorJPsiHFCorr_ccbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -6, 6, -4.5, -2., {443})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/decayer/jpsi_hf_corr.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/decayer/jpsi_hf_corr.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedChiCToElectronMidy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedChiCToElectronMidy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,6)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedChiCToElectronMidy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedChiCToElectronMidy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,6)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,3)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,3)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap_PbPb5TeV.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap_PbPb5TeV.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,7)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap_5TeV.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap_5TeV.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap_PbPb5TeV.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaFwdy_TriggerGap_PbPb5TeV.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,7)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap_5TeV.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap_5TeV.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaMidy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaMidy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,0)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaMidy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptCharmoniaMidy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,0)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptJpsiFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptJpsiFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,4)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptJpsiFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptJpsiFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,4)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptPsi2SFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptPsi2SFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGDQ/ini/Generator_InjectedPromptPsi2SFwdy_TriggerGap.ini
+++ b/MC/config/PWGDQ/ini/Generator_InjectedPromptPsi2SFwdy_TriggerGap.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedPromptSignals_gaptriggered_dq.C
 funcName=GeneratorPythia8InjectedPromptCharmoniaGapTriggered(5,5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/pythia8/generator/pythia8_inel_triggerGap.cfg

--- a/MC/config/PWGEM/ini/GeneratorEMCocktail.ini
+++ b/MC/config/PWGEM/ini/GeneratorEMCocktail.ini
@@ -2,5 +2,5 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
-funcName=GenerateEMCocktail(400,0,3,63,"${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/parametrizations/PbPb5TeV_central.json","5TeV_0005_wRatio_etatest",350,0.0,30.0,10000,1,1,0,0,"",0,1.1,"${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/decaytables/decaytable_LMee.dat",1)
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
+funcName=GenerateEMCocktail(400,0,3,63,"${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/parametrizations/PbPb5TeV_central.json","5TeV_0005_wRatio_etatest",350,0.0,30.0,10000,1,1,0,0,"",0,1.1,"${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/decaytables/decaytable_LMee.dat",1)

--- a/MC/config/PWGEM/ini/GeneratorEMCocktail.ini
+++ b/MC/config/PWGEM/ini/GeneratorEMCocktail.ini
@@ -2,5 +2,5 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
-funcName=GenerateEMCocktail(400,0,3,63,"${O2DPG_ROOT}/MC/config/PWGEM/parametrizations/PbPb5TeV_central.json","5TeV_0005_wRatio_etatest",350,0.0,30.0,10000,1,1,0,0,"",0,1.1,"${O2DPG_ROOT}/MC/config/PWGEM/decaytables/decaytable_LMee.dat",1)
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
+funcName=GenerateEMCocktail(400,0,3,63,"${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/parametrizations/PbPb5TeV_central.json","5TeV_0005_wRatio_etatest",350,0.0,30.0,10000,1,1,0,0,"",0,1.1,"${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/decaytables/decaytable_LMee.dat",1)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDDbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDDbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(false,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDDbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDDbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(false,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(true,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_bbbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(true,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_ccbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_ccbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(true,false)
 
 ### The external generator derives from GeneratorPythia8
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHFFull_ccbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFFull_ccbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorHFToEleFull_EvtGen.C
 funcName = GeneratorHFToEleFull_EvtGen(true,false)
 
 ### The external generator derives from GeneratorPythia8
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(3,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(3,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(4,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(4,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(5,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(5,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(6,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(6,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(7,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyForcedDecay_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyForcedDecays(7,2)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(3,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(3,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(4,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(4,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(5,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(5,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(6,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(6,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(7,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_BeautyNoForcedDecay_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredBeautyNoForcedDecays(7,3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(3,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap3.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap3.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(3,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(4,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap4.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap4.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(4,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(5,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap5.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap5.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(5,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(6,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap6.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap6.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(6,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(7,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap7.ini
+++ b/MC/config/PWGEM/ini/GeneratorHFGapTriggered_Charm_Gap7.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_HFLepton.C
 funcName = GeneratorPythia8GapTriggeredCharmLepton(7,1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/GeneratorHF_bbbarToDDbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_bbbarToDDbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
 funcName = GeneratorBeautyToEle_EvtGen(-1.5,1.5,true,false)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHF_bbbarToDDbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_bbbarToDDbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
 funcName = GeneratorBeautyToEle_EvtGen(-1.5,1.5,true,false)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kTRUE,-1.,1.,2)

--- a/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
 funcName = GeneratorBeautyToEle_EvtGen(-1.5,1.5,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_bbbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorBeautyToEle_EvtGen.C
 funcName = GeneratorBeautyToEle_EvtGen(-1.5,1.5,true)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_bbbar.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_bbbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
 funcName = GeneratorCharmToEle_EvtGen(-1.5,1.5)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
+++ b/MC/config/PWGEM/ini/GeneratorHF_ccbarToDielectrons.ini
@@ -2,15 +2,15 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCharmToEle_EvtGen.C
 funcName = GeneratorCharmToEle_EvtGen(-1.5,1.5)
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the bits of the interface: configuration and user hooks
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_pp_cr2.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 
 ### The setup uses an external even generator trigger which is
@@ -18,5 +18,5 @@ hooksFuncName = pythia8_userhooks_ccbar(-1.5,1.5)
 ### according to the specified function call
 
 [TriggerExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGDQ/trigger/selectDaughterFromHFwithinAcc.C
 funcName = selectDaughterFromHFwithinAcc(11,kFALSE,-1.,1.)

--- a/MC/config/PWGEM/ini/GeneratorLFCocktailPbPb.ini
+++ b/MC/config/PWGEM/ini/GeneratorLFCocktailPbPb.ini
@@ -2,6 +2,6 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
 funcName = GeneratorCocktailLF(1,false)
 

--- a/MC/config/PWGEM/ini/GeneratorLFCocktailPbPb.ini
+++ b/MC/config/PWGEM/ini/GeneratorLFCocktailPbPb.ini
@@ -2,6 +2,6 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
 funcName = GeneratorCocktailLF(1,false)
 

--- a/MC/config/PWGEM/ini/GeneratorLFCocktailpp.ini
+++ b/MC/config/PWGEM/ini/GeneratorLFCocktailpp.ini
@@ -2,6 +2,6 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
 funcName = GeneratorCocktailLF(1,true)
 

--- a/MC/config/PWGEM/ini/GeneratorLFCocktailpp.ini
+++ b/MC/config/PWGEM/ini/GeneratorLFCocktailpp.ini
@@ -2,6 +2,6 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/GeneratorCocktailLF.C
 funcName = GeneratorCocktailLF(1,true)
 

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(5+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(5+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap10.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap10.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(10+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap10.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap10.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(10+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap3.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap3.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(3+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap3.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap3.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(3+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(5+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(5+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap8.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap8.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(8+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap8.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_all_np1_gap8.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(8+1, -1.2, +1.2, 1, -1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap2.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap2.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(2+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap2.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap2.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(2+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap4.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap4.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(4+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap4.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap4.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(4+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap6.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap6.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(6+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap6.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np1_gap6.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(6+1, -1.2, +1.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np3_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np3_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 3, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np3_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np3_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 3, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np5_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np5_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 5, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np5_gap0.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFee_random_np5_gap0.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFee.C
 funcName = GeneratorPythia8GapTriggeredLFee_ForEM(0+1, -1.2, +1.2, 5, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma.ini
@@ -2,9 +2,9 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
-funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM("${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg", 5, -1.2, +1.2, 1)
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg", 5, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
-#config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+#config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma.ini
@@ -2,9 +2,9 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
-funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM("${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg", 5, -1.2, +1.2, 1)
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM("${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg", 5, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
-#config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+#config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/configPythiaEmpty.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap2.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap2.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(2+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap2.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap2.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(2+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap4.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap4.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(4+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap4.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap4.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(4+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap6.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap6.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(6+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap6.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np1_gap6.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(6+1, -1.2, +1.2, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np3_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np3_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(5+1, -1.2, +1.2, 3)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np3_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np3_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(5+1, -1.2, +1.2, 3)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np5_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np5_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(5+1, -1.2, +1.2, 5)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np5_gap5.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFgamma_np5_gap5.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFgamma.C
 funcName = GeneratorPythia8GapTriggeredLFgamma_ForEM(5+1, -1.2, +1.2, 5)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFmumu.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFmumu.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFmumu.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFmumu.C
 funcName = GeneratorPythia8GapTriggeredLFmumu_ForEM(5+1, -4.3, -2.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Generator_GapTriggered_LFmumu.ini
+++ b/MC/config/PWGEM/ini/Generator_GapTriggered_LFmumu.ini
@@ -2,8 +2,8 @@
 ### This part sets the path of the file and the function call to retrieve it
 
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFmumu.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_GapTriggered_LFmumu.C
 funcName = GeneratorPythia8GapTriggeredLFmumu_ForEM(5+1, -4.3, -2.2, 1, 1)
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_MB_gapevent.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
 funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;")
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-9999.,9999.)
 includePartonEvent=true
 
 [DecayerPythia8]
-config[0] = ${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg
+config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
 funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;")
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_bbbar(-9999.,9999.)
 includePartonEvent=true
 
 [DecayerPythia8]
-config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg
+config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Charm_Cocktail.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Charm_Cocktail.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
 funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
-hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
+hooksFileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-9999.,9999.)
 includePartonEvent=true
 
 [DecayerPythia8]
-config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg
+config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Charm_Cocktail.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Charm_Cocktail.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
 funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
-hooksFileName = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
+hooksFileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/hooks/pythia8_userhooks_qqbar.C
 hooksFuncName = pythia8_userhooks_ccbar(-9999.,9999.)
 includePartonEvent=true
 
 [DecayerPythia8]
-config[0] = ${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg
+config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGGAJE/ini/GeneratorHFJETrigger_ccbar.ini
+++ b/MC/config/PWGGAJE/ini/GeneratorHFJETrigger_ccbar.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet_charmtriggers_with_decays.cfg
 

--- a/MC/config/PWGGAJE/ini/GeneratorHFJETrigger_ccbar.ini
+++ b/MC/config/PWGGAJE/ini/GeneratorHFJETrigger_ccbar.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet_charmtriggers_with_decays.cfg
 

--- a/MC/config/PWGGAJE/ini/hook_jets.ini
+++ b/MC/config/PWGGAJE/ini/hook_jets.ini
@@ -1,6 +1,6 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_ROOT}/MC/config/PWGGAJE/hooks/jets_hook.C
+hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/jets_hook.C
 hooksFuncName=pythia8_userhooks_jets()
 includePartonEvent=true
 

--- a/MC/config/PWGGAJE/ini/hook_jets.ini
+++ b/MC/config/PWGGAJE/ini/hook_jets.ini
@@ -1,6 +1,6 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/jets_hook.C
+hooksFileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/hooks/jets_hook.C
 hooksFuncName=pythia8_userhooks_jets()
 includePartonEvent=true
 

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma.ini
@@ -1,5 +1,5 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma()
 

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma.ini
@@ -1,5 +1,5 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma()
 

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma_allcalo.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma_allcalo.ini
@@ -1,5 +1,5 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma(1)
 

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma_allcalo.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma_allcalo.ini
@@ -1,5 +1,5 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma(1)
 

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma_focal.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma_focal.ini
@@ -1,4 +1,4 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma(7)

--- a/MC/config/PWGGAJE/ini/hook_prompt_gamma_focal.ini
+++ b/MC/config/PWGGAJE/ini/hook_prompt_gamma_focal.ini
@@ -1,4 +1,4 @@
 [GeneratorPythia8]
 config=pythia8.cfg
-hooksFileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
+hooksFileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/hooks/prompt_gamma_hook.C
 hooksFuncName=pythia8_userhooks_promptgamma(7)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets()

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets()

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt3_5.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt3_5.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(0,3.5)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt3_5.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt3_5.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(0,3.5)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt7.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt7.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(0,7)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt7.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_TrigPt7.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(0,7)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt3_5.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt3_5.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(1,3.5)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt3_5.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt3_5.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(1,3.5)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt7.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt7.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(1,7)

--- a/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt7.ini
+++ b/MC/config/PWGGAJE/ini/trigger_decay_gamma_allcalo_TrigPt7.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/decay_gamma_jets.C
 funcName=decay_gamma_jets(1,7)

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma()

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma()

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma_allcalo.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma_allcalo.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma(1)

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma_allcalo.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma_allcalo.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma(1)

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma_focal.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma_focal.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma(7)

--- a/MC/config/PWGGAJE/ini/trigger_prompt_gamma_focal.ini
+++ b/MC/config/PWGGAJE/ini/trigger_prompt_gamma_focal.ini
@@ -2,5 +2,5 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGGAJE/trigger/prompt_gamma.C
 funcName=prompt_gamma(7)

--- a/MC/config/PWGHF/ini/GeneratorHFOmegaCEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFOmegaCEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4332, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFOmegaCEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFOmegaCEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4332, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFOmegaCToXiPiEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFOmegaCToXiPiEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4332, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c_toxipi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c_toxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFOmegaCToXiPiEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFOmegaCToXiPiEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4332, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c_toxipi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/omega_c_toxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_Bforced_decay.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_Bforced_decay.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_Bforced_decay.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_Bforced_decay.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_OmegaCToXiPi.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_OmegaCToXiPi.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5,-1.5,1.5,-1.5,1.5,{4332})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_omegactoxipi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_omegactoxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_OmegaCToXiPi.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_OmegaCToXiPi.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5,-1.5,1.5,-1.5,1.5,{4332})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_omegactoxipi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_omegactoxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_XiCToXiPi.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_XiCToXiPi.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5,-1.5,1.5,-1.5,1.5,{4132})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xictoxipi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xictoxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_XiCToXiPi.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_XiCToXiPi.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5,-1.5,1.5,-1.5,1.5,{4132})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xictoxipi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xictoxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_Xi_Omega_C.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_Xi_Omega_C.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapHF(5,-1.5,1.5,-1.5,1.5,{4,5}, {4132, 4332})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xicomegac.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xicomegac.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_Xi_Omega_C.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_Xi_Omega_C.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapHF(5,-1.5,1.5,-1.5,1.5,{4,5}, {4132, 4332})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xicomegac.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_xicomegac.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_bbbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_bbbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_bbbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_bbbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_ccbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_ccbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_ccbar.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_ccbar.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(3, -5, 5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_decays.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFXiCToXiPiEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFXiCToXiPiEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4132, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/xi_c_toxipi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/xi_c_toxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHFXiCToXiPiEmb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFXiCToXiPiEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(4132, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/xi_c_toxipi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/xi_c_toxipi.cfg

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Bforced_gap5_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_beautyhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_Mode2_ptHardBins.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(1, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_Mode2_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_Mode2_ptHardBins.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(1, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_ptHardBins.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
 funcName=GeneratorPythia8EmbedHFCharmAndBeauty()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
 funcName=GeneratorPythia8EmbedHFCharmAndBeauty()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb_ptHardBins.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
 funcName=GeneratorPythia8EmbedHFCharmAndBeauty(true)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb_ptHardBins.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_PbPb_ptHardBins.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
 funcName=GeneratorPythia8EmbedHFCharmAndBeauty(true)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap3_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(3, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DReso.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DReso.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DReso.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DReso.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DReso.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DReso.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DReso.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DReso.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132, 4332, 4232})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132, 4332, 4232})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC_OmegaC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC_OmegaC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132, 4332})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC_OmegaC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_XiC_OmegaC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {4132, 4332})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(8, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(8, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(8, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8_Mode2_XiC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap8_Mode2_XiC.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(8, -1.5, 1.5, -1.5, 1.5, {4132})
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_gap5.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_gap5.ini
@@ -1,8 +1,8 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredCharm(5, -1.5, 1.5)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays.cfg
 includePartonEvent=true

--- a/MC/config/PWGHF/ini/trigger_hf.ini
+++ b/MC/config/PWGHF/ini/trigger_hf.ini
@@ -2,12 +2,12 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/trigger/trigger_ccbar.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/trigger/trigger_ccbar.C
 funcName=trigger_ccbar(-1.5,1.5)
 
 [DecayerPythia8]
-config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D.cfg
-config[2] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D_use4bodies.cfg
+config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D.cfg
+config[2] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D_use4bodies.cfg
 
 #/alice/O2DPG/MC/config/PWGHF/external/trigger

--- a/MC/config/PWGHF/ini/trigger_hf.ini
+++ b/MC/config/PWGHF/ini/trigger_hf.ini
@@ -2,12 +2,12 @@
 config=pythia8.cfg
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/trigger/trigger_ccbar.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/trigger/trigger_ccbar.C
 funcName=trigger_ccbar(-1.5,1.5)
 
 [DecayerPythia8]
-config[0] = ${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D.cfg
-config[2] = ${O2DPG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D_use4bodies.cfg
+config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D.cfg
+config[2] = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8/decayer/force_hadronic_D_use4bodies.cfg
 
 #/alice/O2DPG/MC/config/PWGHF/external/trigger

--- a/MC/config/PWGHF/pythia8_gun/configOmegaAnd20Pions_randomCharge.ini
+++ b/MC/config/PWGHF/pythia8_gun/configOmegaAnd20Pions_randomCharge.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8_gun/generator_pythia8_gun.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8_gun/generator_pythia8_gun.C
 funcName=generateOmegaAndPions_RandomCharge(20)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8_gun/config_custom_OmegaC.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8_gun/config_custom_OmegaC.cfg

--- a/MC/config/PWGHF/pythia8_gun/configOmegaAnd20Pions_randomCharge.ini
+++ b/MC/config/PWGHF/pythia8_gun/configOmegaAnd20Pions_randomCharge.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGHF/pythia8_gun/generator_pythia8_gun.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8_gun/generator_pythia8_gun.C
 funcName=generateOmegaAndPions_RandomCharge(20)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGHF/pythia8_gun/config_custom_OmegaC.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGHF/pythia8_gun/config_custom_OmegaC.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFDeTrHe.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFDeTrHe.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.gun")
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.gun")
 ; funcName=generateLF({{1000010020, 10, 0.2, 10}, {-1000010020, 10, 0.2, 10}, {1000010030, 10, 0.2, 10}, {-1000010030, 10, 0.2, 10}, {1000020030, 10, 0.2, 10}, {-1000020030, 10, 0.2, 10}})
 #                                    Deuteron                   Anti-Deuteron               Triton                     Anti-Triton                 Helium3                    Anti-Helium3
 
 [GeneratorPythia8]
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
+; config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFDeTrHe.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFDeTrHe.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.gun")
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.gun")
 ; funcName=generateLF({{1000010020, 10, 0.2, 10}, {-1000010020, 10, 0.2, 10}, {1000010030, 10, 0.2, 10}, {-1000010030, 10, 0.2, 10}, {1000020030, 10, 0.2, 10}, {-1000020030, 10, 0.2, 10}})
 #                                    Deuteron                   Anti-Deuteron               Triton                     Anti-Triton                 Helium3                    Anti-Helium3
 
 [GeneratorPythia8]
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
+; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei_pbpb.gun", 1)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei_pbpb.gun", 1)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei_pbpb.gun", 1)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei_pbpb.gun", 1)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGapXSection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGapXSection.ini
@@ -1,9 +1,9 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
 
 [G4]
-configMacroFile=${O2DPG_ROOT}/MC/config/PWGLF/xsection/g4config_had_x2.in
+configMacroFile=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/xsection/g4config_had_x2.in

--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGapXSection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleippGapXSection.ini
@@ -1,9 +1,9 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
 
 [G4]
-configMacroFile=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/xsection/g4config_had_x2.in
+configMacroFile=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/xsection/g4config_had_x2.in

--- a/MC/config/PWGLF/ini/GeneratorLFHyperppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperppGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/hyper.gun", 5)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hyper.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHyperppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperppGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/hyper.gun", 5)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/hyper.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFHypertritonPbPbGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHypertritonPbPbGap.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
 funcName=generateLongLivedGapTriggered({1010010030}, 5, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFHypertritonPbPbGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHypertritonPbPbGap.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
 funcName=generateLongLivedGapTriggered({1010010030}, 5, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFHypertritonppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHypertritonppGap.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
 funcName=generateLongLivedGapTriggered({1010010030}, 5, 1)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFHypertritonppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHypertritonppGap.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
 funcName=generateLongLivedGapTriggered({1010010030}, 5, 1)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFLambdapp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFLambdapp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3122, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFLambdapp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFLambdapp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3122, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFNucleiFwdppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFNucleiFwdppGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei_fwd.gun", 5)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei_fwd.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFNucleiFwdppGap.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFNucleiFwdppGap.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
-funcName=generateLongLivedGapTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei_fwd.gun", 5)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/nuclei_fwd.gun", 5)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFOmegaEmb.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFOmegaEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(3334, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/omega.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/omega.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFOmegaEmb.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFOmegaEmb.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_box.C
 funcName=generatePythia8Box(3334, 3)
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/omega.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/omega.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFSigmapp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFSigmapp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3112, 5, 1, 9, 3222)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFSigmapp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFSigmapp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3112, 5, 1, 9, 3222)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFStrangeness.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangeness.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 0)
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 0)
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 4)
 
 ; [GeneratorPythia8] # If injected the generator must be left empty
 ; config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
 ; config=/home/njacazio/alice/O2DPG/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
 
 [DecayerPythia8] # The only configuration must be given to the decayer to handle particles that are not handled in the transport code
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
 verbose=true

--- a/MC/config/PWGLF/ini/GeneratorLFStrangeness.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangeness.ini
@@ -1,13 +1,13 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 0)
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 0)
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", true, 4)
 
 ; [GeneratorPythia8] # If injected the generator must be left empty
 ; config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
 ; config=/home/njacazio/alice/O2DPG/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
 
 [DecayerPythia8] # The only configuration must be given to the decayer to handle particles that are not handled in the transport code
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/decayer/strangeness.cfg
 verbose=true

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_900gev.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_900gev.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_900gev.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_900gev.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap2.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap2.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 2)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 2)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap2.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap2.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 2)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 2)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap3.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap3.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 3)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 3)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap3.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap3.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 3)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 3)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap5.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap5.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 5)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 5)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap5.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFStrangenessTriggered_gap5.ini
@@ -1,12 +1,12 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-# funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
-funcName=generateLFTriggered("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 5)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+# funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 0)
+funcName=generateLFTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/strangeparticlelist.gun", 5)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg
-; config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
+; config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_ropes_136tev.cfg
 
 [DecayerPythia8]
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/PWGLF/ini/GeneratorLFXipp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFXipp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3312, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLFXipp.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFXipp.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived.C
 funcName=generateLongLived(3312, 10)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_Coalescence.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Coalescence.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_coalescence.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_coalescence.C
 funcName = generateCoalescence(5)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_Coalescence.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Coalescence.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_coalescence.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_coalescence.C
 funcName = generateCoalescence(5)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_ExoticResonances_pp1360.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_ExoticResonances_pp1360.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/exoticresonancegun.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/exoticresonancegun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_ExoticResonances_pp1360.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_ExoticResonances_pp1360.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/exoticresonancegun.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/exoticresonancegun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_HighPt.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_HighPt.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt.C
 funcName = generateHighPt(-2212,5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_HighPt.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_HighPt.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt.C
 funcName = generateHighPt(-2212,5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json", true, 4)
 
 # [GeneratorPythia8]
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj_pbpb.json", true, 4)
 
 # [GeneratorPythia8]
 # config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json", true, 4)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_PbPb5360_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig_pbpb.json", true, 4)
 
 [GeneratorPythia8]
 config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+# config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp1360_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_136tev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+# config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_injection.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_inj.json", true, 4)
 
 # [GeneratorPythia8] # if triggered then this will be used as the background event
-# config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+# config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_trigger.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Resonances_pp900_trigger.ini
@@ -1,10 +1,10 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
-funcName=generateLF("${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+funcName=generateLF("${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonancelistgun_trig.json", true, 4)
 
 [GeneratorPythia8] # if triggered then this will be used as the background event
-config=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/pythia8_inel_pp900gev.cfg
 
 [DecayerPythia8] # after for transport code!
-config[0]=${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1]=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg
+config[0]=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[1]=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator/resonances.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Strangeness_PbPb5360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Strangeness_PbPb5360_injection.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
 funcName=generator_extraStrangeness()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_Strangeness_PbPb5360_injection.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_Strangeness_PbPb5360_injection.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
 funcName=generator_extraStrangeness()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_SyntheFlow.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_SyntheFlow.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
 funcName=generator_syntheFlow()
 
 [GeneratorPythia8]
-config=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_SyntheFlow.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_SyntheFlow.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
 funcName=generator_syntheFlow()
 
 [GeneratorPythia8]
-config=${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config=${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg

--- a/MC/config/PWGLF/ini/GeneratorLF_antid_and_highpt.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_antid_and_highpt.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_antid_and_highpt.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_antid_and_highpt.C
 funcName = generateAntidAndHighPt(0.3,5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_antid_and_highpt.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_antid_and_highpt.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_antid_and_highpt.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_antid_and_highpt.C
 funcName = generateAntidAndHighPt(0.3,5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_highpt_strangeness.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_highpt_strangeness.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt_strangeness.C
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt_strangeness.C
 funcName = generateHighPtAndStrangeHadron(5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGLF/ini/GeneratorLF_highpt_strangeness.ini
+++ b/MC/config/PWGLF/ini/GeneratorLF_highpt_strangeness.ini
@@ -1,5 +1,5 @@
 [GeneratorExternal]
-fileName = ${O2DPG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt_strangeness.C
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_highpt_strangeness.C
 funcName = generateHighPtAndStrangeHadron(5.0)
 
 [GeneratorPythia8]

--- a/MC/config/PWGUD/ini/GenStarlight_kCohJpsiToMu_PbPb_5360_Muon.ini
+++ b/MC/config/PWGUD/ini/GenStarlight_kCohJpsiToMu_PbPb_5360_Muon.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal] 
-fileName = ${O2DPG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlight.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlight.C 
 funcName = GeneratorStarlight("kCohJpsiToMu", 5360.000000, 82, 208, 82, 208)  
 [TriggerExternal] 
-fileName = ${O2DPG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
 funcName = selectDaughterPartInAcc(-4.0,-2.5) 

--- a/MC/config/PWGUD/ini/GenStarlight_kCohJpsiToMu_PbPb_5360_Muon.ini
+++ b/MC/config/PWGUD/ini/GenStarlight_kCohJpsiToMu_PbPb_5360_Muon.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal] 
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlight.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlight.C 
 funcName = GeneratorStarlight("kCohJpsiToMu", 5360.000000, 82, 208, 82, 208)  
 [TriggerExternal] 
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
 funcName = selectDaughterPartInAcc(-4.0,-2.5) 

--- a/MC/config/PWGUD/ini/GenStarlight_kCohPsi2sToElPi_PbPb_5360_Cent.ini
+++ b/MC/config/PWGUD/ini/GenStarlight_kCohPsi2sToElPi_PbPb_5360_Cent.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal] 
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C 
 funcName = GeneratorStarlightToEvtGen("kCohPsi2sToElPi", 5360.000000, 82, 208, 82, 208)  
 [TriggerExternal] 
-fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
 funcName = selectMotherPartInAcc(-0.9,0.9) 

--- a/MC/config/PWGUD/ini/GenStarlight_kCohPsi2sToElPi_PbPb_5360_Cent.ini
+++ b/MC/config/PWGUD/ini/GenStarlight_kCohPsi2sToElPi_PbPb_5360_Cent.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal] 
-fileName = ${O2DPG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C 
 funcName = GeneratorStarlightToEvtGen("kCohPsi2sToElPi", 5360.000000, 82, 208, 82, 208)  
 [TriggerExternal] 
-fileName = ${O2DPG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
+fileName = ${O2DPG_MC_CFG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C 
 funcName = selectMotherPartInAcc(-0.9,0.9) 

--- a/MC/config/common/ini/basic.ini
+++ b/MC/config/common/ini/basic.ini
@@ -10,4 +10,4 @@ width[2]=6.0
 ### The setup uses the base configuration of the decayer which is loaded from the file specified by config[0].
 
 [DecayerPythia8]
-config[0] = ${O2DPG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/common/ini/basic.ini
+++ b/MC/config/common/ini/basic.ini
@@ -10,4 +10,4 @@ width[2]=6.0
 ### The setup uses the base configuration of the decayer which is loaded from the file specified by config[0].
 
 [DecayerPythia8]
-config[0] = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
+config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg

--- a/MC/config/examples/ini/adaptive_pythia8.ini
+++ b/MC/config/examples/ini/adaptive_pythia8.ini
@@ -4,11 +4,11 @@
 ### number of primary particles in the background event
 
 [GeneratorExternal]
-fileName=${O2DPG_ROOT}/MC/config/examples/external/generator/adaptive_pythia8.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/examples/external/generator/adaptive_pythia8.C
 funcName=adaptive_pythia8("0.002 * x")
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the underlying Pythia8 configuration.
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/adaptive_pythia8.ini
+++ b/MC/config/examples/ini/adaptive_pythia8.ini
@@ -4,11 +4,11 @@
 ### number of primary particles in the background event
 
 [GeneratorExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/examples/external/generator/adaptive_pythia8.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/external/generator/adaptive_pythia8.C
 funcName=adaptive_pythia8("0.002 * x")
 
 ### The external generator derives from GeneratorPythia8.
 ### This part configures the underlying Pythia8 configuration.
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/trigger_mpi.ini
+++ b/MC/config/examples/ini/trigger_mpi.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/trigger_mpi.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/external/trigger/trigger_mpi.C
 funcName=trigger_mpi(10)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/trigger_mpi.ini
+++ b/MC/config/examples/ini/trigger_mpi.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/common/external/trigger/trigger_mpi.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/trigger_mpi.C
 funcName=trigger_mpi(10)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/trigger_multiplicity.ini
+++ b/MC/config/examples/ini/trigger_multiplicity.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/common/external/trigger/trigger_multiplicity.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/trigger_multiplicity.C
 funcName=trigger_multiplicity(-0.8, 0.8, 100)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/trigger_multiplicity.ini
+++ b/MC/config/examples/ini/trigger_multiplicity.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/trigger_multiplicity.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/external/trigger/trigger_multiplicity.C
 funcName=trigger_multiplicity(-0.8, 0.8, 100)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel.cfg

--- a/MC/config/examples/ini/trigger_multiplicity_stableparticles_inFIT.ini
+++ b/MC/config/examples/ini/trigger_multiplicity_stableparticles_inFIT.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_ROOT}/MC/config/common/external/trigger/multiplicity_stableparticles_inFIT.C
+fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/multiplicity_stableparticles_inFIT.C
 funcName=multiplicity_stableparticles_inFIT(5350)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg

--- a/MC/config/examples/ini/trigger_multiplicity_stableparticles_inFIT.ini
+++ b/MC/config/examples/ini/trigger_multiplicity_stableparticles_inFIT.ini
@@ -3,10 +3,10 @@
 ### according to the specified function call
 
 [TriggerExternal]
-fileName=${O2DPG_MC_CFG_ROOT}/MC/config/common/external/trigger/multiplicity_stableparticles_inFIT.C
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/external/trigger/multiplicity_stableparticles_inFIT.C
 funcName=multiplicity_stableparticles_inFIT(5350)
 
 ### This part configures Pythia8
 
 [GeneratorPythia8]
-config = ${O2DPG_MC_CFG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg
+config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_hi.cfg


### PR DESCRIPTION
O2DPG_MC_CFG_ROOT is going to replace O2DPG_ROOT inside the config files. This will make the system more flexible by allowing the user to change this variable on-the-fly, and hence not be limited by the loaded version of O2DPG. At environment loading it will be by default equal to O2DPG_ROOT, as specified in PR [5649](https://github.com/alisw/alidist/pull/5649)