### PR TITLE
Fix for run_generator_tests.sh using new configuration varibale

### DIFF
--- a/test/run_generator_tests.sh
+++ b/test/run_generator_tests.sh
@@ -409,6 +409,7 @@ popd > /dev/null
 #         [[ -z {ALIBUILD_HEAD_HASH+x} ]] && export O2DPG_ROOT=${REPO_DIR}
 # but let's do the same for both local and CI consistently
 export O2DPG_ROOT=${REPO_DIR}
+export O2DPG_MC_CONFIG_ROOT=${O2DPG_ROOT}
 
 # prepare our local test directory
 rm -rf ${TEST_PARENT_DIR} 2>/dev/null


### PR DESCRIPTION
O2DPG_MC_CONFIG_ROOT is not set in the script, so the CI fails. It is set by default equal to O2DPG_ROOT. This PR should fix the issue seen in https://github.com/AliceO2Group/O2DPG/pull/1756