### PR TITLE
DPMJET and other new processes in STARlight

### DIFF
--- a/MC/config/PWGUD/external/generator/DecayTablesEvtGen/TAUTAU.EL3PI.DEC
+++ b/MC/config/PWGUD/external/generator/DecayTablesEvtGen/TAUTAU.EL3PI.DEC
@@ -1,0 +1,7 @@
+Decay tau-
+1.0 e-      anti-nu_e nu_tau                        PHOTOS TAULNUNU; #[Reconstructed PDG2011]
+Enddecay
+Decay tau+
+1.0 pi+     pi+     pi-     anti-nu_tau                  TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4; #[Reconstructed PDG2011]
+Enddecay
+End

--- a/MC/config/PWGUD/external/generator/DecayTablesEvtGen/TAUTAU.PO3PI.DEC
+++ b/MC/config/PWGUD/external/generator/DecayTablesEvtGen/TAUTAU.PO3PI.DEC
@@ -1,0 +1,7 @@
+Decay tau-
+1.0 pi-     pi-     pi+     nu_tau                  TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4; #[Reconstructed PDG2011]
+Enddecay
+Decay tau+
+1.0 e+      anti-nu_tau nu_e                        PHOTOS TAULNUNU; #[Reconstructed PDG2011]
+Enddecay
+End

--- a/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C
+++ b/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C
@@ -16,11 +16,13 @@ FairGenerator*
   gen->selectConfiguration(configuration);
   gen->setCollisionSystem(energyCM, beam1Z, beam1A, beam2Z, beam2A);
   
-  gen->SetSizePdg(3);
+  gen->SetSizePdg(5);
   gen->AddPdg(443,0);
   gen->AddPdg(100443,1);
   gen->AddPdg(223,2);
-  gen->SetPolarization(1); //Transversal
+  gen->AddPdg(15,3);
+  gen->AddPdg(-15,4);
+  if (configuration.find("kTau") == std::string::npos) gen->SetPolarization(1); //Transversal
   
   TString pathO2 = gSystem->ExpandPathName("$O2DPG_ROOT/MC/config/PWGUD/external/generator/DecayTablesEvtGen");
   if      (configuration.find("Psi2sToMuPi") != std::string::npos) gen->SetDecayTable(Form("%s/PSI2S.MUMUPIPI.DEC",pathO2.Data()));
@@ -28,6 +30,8 @@ FairGenerator*
   else if (configuration.find("RhoPrime") != std::string::npos)    gen->SetDecayTable(Form("%s/RHOPRIME.RHOPIPI.DEC",pathO2.Data()));
   else if (configuration.find("OmegaTo3Pi") != std::string::npos)  gen->SetDecayTable(Form("%s/OMEGA.3PI.DEC",pathO2.Data()));
   else if (configuration.find("JpsiToElRad") != std::string::npos) gen->SetDecayTable(Form("%s/JPSI.EE.DEC",pathO2.Data()));
+  else if (configuration.find("ToEl3Pi") != std::string::npos) gen->SetDecayTable(Form("%s/TAUTAU.EL3PI.DEC",pathO2.Data()));
+  else if (configuration.find("ToPo3Pi") != std::string::npos) gen->SetDecayTable(Form("%s/TAUTAU.PO3PI.DEC",pathO2.Data()));
  
   return gen;
 }

--- a/MC/config/PWGUD/ini/dpmjet_PbPb5360.ini
+++ b/MC/config/PWGUD/ini/dpmjet_PbPb5360.ini
@@ -1,0 +1,45 @@
+**********************************************************************
+* Example for a DTUNUC input file.
+* Uncomment the input-cards according to your requirements.
+*
+* Format: A10,6E10.0,A8
+*        (except for the section enclosed by "PHOINPUT" and "ENDINPUT"
+*         which is format-free)
+*         lines starting with "*" are comment lines
+**********************************************************************
+*
+* projectile / target / Energy
+* -------------------
+*        1         2         3         4         5         6         7
+*23456789012345678901234567890123456789012345678901234567890123456789012345678
+PROJPAR          0.0                                                  PHOTON
+TARPAR         208.0      82.0
+ENERGY        1000.0  600000.0
+*ENERGY         100.0
+* Initialize the random number generator
+RNDMINIT        55.0     101.0      15.0      73.0              
+*
+*
+* PHOJET-specific input
+* ---------------------
+* The following lines control the event-generation with PHOJET for
+* individual photon/nucleon-nucleon collisions.
+* For details see the PHOJET-manual available at
+*        http://lepton.bartol.udel.edu/~eng/phojet.html
+* Any options explained in the PHOJET-manual can be used in between
+* the "PHOINPUT" and "ENDINPUT" cards.
+PHOINPUT
+PROCESS           1 0 1 1 1 1 1 1
+ENDINPUT
+*
+* Output
+* ------
+*   some default output (particle multiplicities etc.)
+HISTOGRAM      101.0     102.0
+*
+* Start of event generation
+* -------------------------
+*START         5000.0       0.0
+START         100.0       0.0
+STOP
+*...+....1....+....2....+....3....+....4....+....5....+....6....+....7...

--- a/MC/config/PWGUD/ini/makeStarlightConfig.py
+++ b/MC/config/PWGUD/ini/makeStarlightConfig.py
@@ -17,7 +17,7 @@ parser.add_argument('--eCM', type=float, default='5360',
 parser.add_argument('--rapidity', default='cent', choices=['cent_rap', 'muon_rap', 'cent_eta', 'muon_eta'],
                     help='Rapidity to select')
 
-parser.add_argument('--process',default=None, choices=['kTwoGammaToMuLow', 'kTwoGammaToElLow', 'kTwoGammaToMuMedium', 'kTwoGammaToElMedium', 'kTwoGammaToMuHigh', 'kTwoGammaToElHigh', 'kTwoGammaToRhoRho', 'kTwoGammaToF2', 'kCohRhoToPi', 'kCohRhoToElEl', 'kCohRhoToMuMu', 'kCohRhoToPiWithCont', 'kCohRhoToPiFlat', 'kCohPhiToKa', 'kDirectPhiToKaKa','kCohOmegaTo2Pi', 'kCohOmegaTo3Pi', 'kCohOmegaToPiPiPi', 'kCohJpsiToMu', 'kCohJpsiToEl', 'kCohJpsiToElRad', 'kCohJpsiToProton', 'kCohPsi2sToMu','kCohPsi2sToEl', 'kCohPsi2sToMuPi', 'kCohPsi2sToElPi', 'kCohUpsilonToMu', 'kCohUpsilonToEl', 'kIncohRhoToPi', 'kIncohRhoToElEl', 'kIncohRhoToMuMu', 'kIncohRhoToPiWithCont', 'kIncohRhoToPiFlat', 'kIncohPhiToKa', 'kIncohOmegaTo2Pi', 'kIncohOmegaTo3Pi', 'kIncohOmegaToPiPiPi', 'kIncohJpsiToMu', 'kIncohJpsiToEl', 'kIncohJpsiToElRad', 'kIncohJpsiToProton', 'kIncohJpsiToLLbar', 'kIncohPsi2sToMu', 'kIncohPsi2sToEl', 'kIncohPsi2sToMuPi', 'kIncohPsi2sToElPi', 'kIncohUpsilonToMu', 'kIncohUpsilonToEl'],
+parser.add_argument('--process',default=None, choices=['kTwoGammaToMuLow', 'kTwoGammaToElLow', 'kTwoGammaToMuMedium', 'kTwoGammaToElMedium', 'kTwoGammaToMuHigh', 'kTwoGammaToElHigh', 'kTwoGammaToRhoRho', 'kTwoGammaToF2', 'kCohRhoToPi', 'kCohRhoToElEl', 'kCohRhoToMuMu', 'kCohRhoToPiWithCont', 'kCohRhoToPiFlat', 'kCohPhiToKa', 'kDirectPhiToKaKa','kCohOmegaTo2Pi', 'kCohOmegaTo3Pi', 'kCohOmegaToPiPiPi', 'kCohJpsiToMu', 'kCohJpsiToEl', 'kCohJpsiToElRad', 'kCohJpsiToProton', 'kCohPsi2sToMu','kCohPsi2sToEl', 'kCohPsi2sToMuPi', 'kCohPsi2sToElPi', 'kCohUpsilonToMu', 'kCohUpsilonToEl', 'kIncohRhoToPi', 'kIncohRhoToElEl', 'kIncohRhoToMuMu', 'kIncohRhoToPiWithCont', 'kIncohRhoToPiFlat', 'kIncohPhiToKa', 'kIncohOmegaTo2Pi', 'kIncohOmegaTo3Pi', 'kIncohOmegaToPiPiPi', 'kIncohJpsiToMu', 'kIncohJpsiToEl', 'kIncohJpsiToElRad', 'kIncohJpsiToProton', 'kIncohJpsiToLLbar', 'kIncohPsi2sToMu', 'kIncohPsi2sToEl', 'kIncohPsi2sToMuPi', 'kIncohPsi2sToElPi', 'kIncohUpsilonToMu', 'kIncohUpsilonToEl', 'kDpmjetSingle',  'kTauLowToEl3Pi', 'kTauLowToPo3Pi', 'kTauMediumToEl3Pi', 'kTauMediumToPo3Pi' ,'kTauHighToEl3Pi' ,'kTauHighToPo3Pi'],
                     help='Process to switch on')
                     
                     
@@ -68,7 +68,7 @@ fout = open(args.output, 'w')
 
 ### Generator
 fout.write('[GeneratorExternal] \n')
-if  'Psi2sToMuPi' in args.process or 'Psi2sToElPi' in args.process or 'RhoPrime' in args.process or 'OmegaTo3Pi' in args.process or 'JpsiToElRad' in args.process :
+if  'Psi2sToMuPi' in args.process or 'Psi2sToElPi' in args.process or 'RhoPrime' in args.process or 'OmegaTo3Pi' in args.process or 'JpsiToElRad' in args.process or 'kTau' in args.process:
     fout.write('fileName = ${O2DPG_ROOT}/MC/config/PWGUD/external/generator/GeneratorStarlightToEvtGen.C \n')
     fout.write('funcName = GeneratorStarlightToEvtGen("%s", %f, %d, %d, %d, %d)  \n' % (args.process,args.eCM ,pZ,pA,tZ,tA))
 else:
@@ -78,7 +78,7 @@ else:
 ###Trigger
 fout.write('[TriggerExternal] \n')
 fout.write('fileName = ${O2DPG_ROOT}/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C \n')
-if 'kTwoGamma' in args.process:
+if 'kTwoGamma' in args.process or 'kTau' in args.process:
     if args.rapidity == 'cent_eta':
         fout.write('funcName = selectDirectPartInAcc(-0.9,0.9) \n')
     if args.rapidity == 'muon_eta':

--- a/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C
+++ b/MC/config/PWGUD/trigger/selectParticlesInAcceptance.C
@@ -24,10 +24,21 @@ o2::eventgen::Trigger selectDaughterPartInAcc(double etaMin = -1., double etaMax
     for (const auto& particle : particles) {
       if (particle.GetFirstMother() == -1)
         if ((particle.Y() < etaMin) || (particle.Y() > etaMax)) return kFALSE;
-	  if (particle.GetFirstMother() != -1 && particle.GetFirstDaughter() == -1 && particle.GetPdgCode() != 22)
+	  if (particle.GetFirstMother() != -1 && particle.GetFirstDaughter() == -1 && particle.GetPdgCode() != 22 && TMath::Abs(particle.GetPdgCode()) != 12 && TMath::Abs(particle.GetPdgCode()) != 14 && TMath::Abs(particle.GetPdgCode()) != 16)
 		  if ((particle.Eta() < etaMin) || (particle.Eta() > etaMax)) return kFALSE; 
     }
     return kTRUE;  
+  };
+}
+
+o2::eventgen::Trigger selectDileptonsInAcc(double etaMin = -1., double etaMax = -1.)
+{
+  return [etaMin, etaMax](const std::vector<TParticle>& particles) -> bool {
+    for (const auto& particle : particles) {
+	  if (particle.GetFirstMother() != -1 && particle.GetFirstDaughter() == -1 && (TMath::Abs(particle.GetPdgCode()) == 11 || TMath::Abs(particle.GetPdgCode() == 13)))
+		  if ((particle.Eta() < etaMin) || (particle.Eta() > etaMax)) return kFALSE;
+    }
+    return kTRUE;
   };
 }
 


### PR DESCRIPTION
Main feature of this commit is to enable DPMJET process in STARlight. 
STARlight can be compiled against DPMJET, in that case a separate library is created (libDpmJetLib) that uses routines from DPMJET to simulate photo-nuclear interactions. UPC group would like to use this mode. Few things are needed on the top of this PR:
1. Update DPMJET in the ALICE fork. Current version in the fork is 19.1.2, the photo-interactions in this version doesn't work (see: https://github.com/DPMJET/DPMJET/pull/20). We need latest version. I tried to do this exercise, there will be several conflicts, for my local test I always took "theirs" version and updated CMakeLists with new list of src files, then it compiles fine and works with STARlight. 

2. Adjust the alidist: I attach here the git patch I used. The STARlight-DPMJET library is somehow not installed and remains in the build directory so I added explicit line to move it, maybe there is other solution...                   
[alidist.patch](https://github.com/user-attachments/files/17291444/alidist.patch)

3. Adjust STARlight: The additional library was build as static, I added option to build it as Shared. There is an issue with "FIND_LIBRARY" in the CMake module when the library path defined as a environment variable in the alidist/starlight.sh is preceded by ENV. Library is then not found when this is build via aliBuild. It definitely works in standalone installation. An expert opinion would be appreciated :) Again I attach here the git patch I used:        
[STARlight.patch](https://github.com/user-attachments/files/17291447/STARlight.patch)

This PR then includes other developments (Tau processes) that are more minor and don't need any special treatment.  
