### PR TITLE
More resilient logic in determining MC events from AO2D file

### DIFF
--- a/MC/bin/o2dpg_determine_eventstat.py
+++ b/MC/bin/o2dpg_determine_eventstat.py
@@ -87,20 +87,34 @@ def read_AO2D_eventcount(file):
 
     # Open the ROOT file
     tfile = ROOT.TFile.Open(file)
- 
+
     # Get the list of keys (TKeys) in the ROOT files
     keys = tfile.GetListOfKeys()
 
     # Iterate through the keys "DF_" keys and accumulate
     # stored MC collisions
+    colfound = 0
+
     for key in keys:
       key_name = key.GetName()
       if key_name.startswith("DF_"):
         obj = key.ReadObj()
-        # the O2mccollision tree contains the simulated collisions
-        coltree = obj.Get("O2mccollision")
-        if coltree and isinstance(coltree, ROOT.TTree):
-          eventcount = eventcount + coltree.GetEntries()
+
+        # get the list of keys of available tables
+        tablelist = obj.GetListOfKeys()
+        for tab in tablelist:
+          # the O2mccollision_ tree contains the simulated collisions
+          # but the version number might change so better to loop over keys and do matching
+          tabname = tab.GetName()
+          if tabname.startswith("O2mccollision_"):
+            coltreekey = obj.GetKey(tabname)
+            coltree = coltreekey.ReadObj()
+            if coltree and isinstance(coltree, ROOT.TTree):
+              eventcount = eventcount + coltree.GetEntries()
+              colfound = colfound + 1
+
+    if colfound != 1:
+      print ("ERROR in extracting the expected amount of MC collision tables")
 
     # Close the files
     tfile.Close()


### PR DESCRIPTION
Fixing a problem in detecting the right number of events from AO2D due to a recent name change O2mccollision --> O2mccolision_001 in the AOD format.