### PR TITLE
MC/PWGEM: O2DPG_ROOT --> O2DPG_MC_CONFIG_ROOT

### DIFF
--- a/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
+++ b/MC/config/PWGEM/external/generator/GeneratorEMCocktailV2.C
@@ -435,11 +435,11 @@ GenerateEMCocktail(Int_t collisionsSystem = GeneratorParamEMlibV2::kpp7TeV,
                    Double_t yGenRange = 0.1, TString useLMeeDecaytable = "",
                    Int_t weightingMode = 1) {
 
-  TString O2DPG_ROOT = TString(getenv("O2DPG_ROOT"));
-  paramFile=paramFile.ReplaceAll("$O2DPG_ROOT",O2DPG_ROOT);
-  paramFile=paramFile.ReplaceAll("${O2DPG_ROOT}",O2DPG_ROOT);
-  useLMeeDecaytable=useLMeeDecaytable.ReplaceAll("$O2DPG_ROOT",O2DPG_ROOT);
-  useLMeeDecaytable=useLMeeDecaytable.ReplaceAll("${O2DPG_ROOT}",O2DPG_ROOT);
+  TString O2DPG_MC_CONFIG_ROOT = TString(getenv("O2DPG_MC_CONFIG_ROOT"));
+  paramFile=paramFile.ReplaceAll("$O2DPG_MC_CONFIG_ROOT",O2DPG_MC_CONFIG_ROOT);
+  paramFile=paramFile.ReplaceAll("${O2DPG_MC_CONFIG_ROOT}",O2DPG_MC_CONFIG_ROOT);
+  useLMeeDecaytable=useLMeeDecaytable.ReplaceAll("$O2DPG_MC_CONFIG_ROOT",O2DPG_MC_CONFIG_ROOT);
+  useLMeeDecaytable=useLMeeDecaytable.ReplaceAll("${O2DPG_MC_CONFIG_ROOT}",O2DPG_MC_CONFIG_ROOT);
   if (paramFile.BeginsWith("alien://")){
     TGrid::Connect("alien://");
   }


### PR DESCRIPTION
fix the path of the LMee decaytable after introducing a new environment variable in https://github.com/AliceO2Group/O2DPG/pull/1756