### PR TITLE
Created clean-ci.yml

### DIFF
--- a/.github/workflows/clean-ci.yml
+++ b/.github/workflows/clean-ci.yml
@@ -1,0 +1,39 @@
+---
+name: Clean PR builds
+
+'on':
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number in this repo to be cleaned
+        type: string   # can't use number here
+        required: true
+
+      # Warning: GitHub limits the total number of inputs to 10, so a maximum of
+      # 9 checks is allowed here!
+      # Warning: the check_* keys are magic and must consist of the string
+      # "check_" followed by the applicable check name exactly. The
+      # "description" field is only the human-readable label for the input.
+      'check_build/O2DPG/sim/o2':
+        description: build/O2DPG/sim/o2
+        type: boolean
+        default: true
+      'check_build/O2DPG/O2fst/o2':
+        description: build/O2DPG/O2fst/o2
+        type: boolean
+        default: true
+
+permissions: {}
+
+jobs:
+  clean:
+    name: Clean PR checks
+    uses: alisw/ali-bot/.github/workflows/clean-pr-checks.yml@master
+    with:
+      owner: ${{ github.event.repository.owner.login }}
+      repo: ${{ github.event.repository.name }}
+      pr: ${{ github.event.inputs.pr }}
+      checks: ${{ toJSON(github.event.inputs) }}
+    permissions:
+      pull-requests: read  # to get last commit for pr (octokit/graphql-action)
+      statuses: write      # for set-github-status


### PR DESCRIPTION
Added GitHub action to restart PR builds. Useful to restart builds in case the errors are not related to current pull requests (instead of pushing a dummy commit). Basic mechanism is taken from same action in alidist repository. 