### PR TITLE
PWGLF: fix seeding issues

### DIFF
--- a/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_extraStrangeness.C
@@ -278,5 +278,9 @@ private:
 
  FairGenerator *generator_extraStrangeness()
  {
-   return new GeneratorPythia8ExtraStrangeness();
+  auto generator = new GeneratorPythia8ExtraStrangeness();
+  gRandom->SetSeed(0);
+  generator.readString("Random:setSeed = on");
+  generator.readString("Random:seed =" + std::to_string(gRandom->Integer(900000000 - 2) + 1));
+  return generator;
  }

--- a/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlow.C
@@ -99,5 +99,9 @@ private:
 
  FairGenerator *generator_syntheFlow()
  {
-   return new GeneratorPythia8SyntheFlow();
+  auto generator = new GeneratorPythia8SyntheFlow();
+  gRandom->SetSeed(0);
+  generator.readString("Random:setSeed = on");
+  generator.readString("Random:seed =" + std::to_string(gRandom->Integer(900000000 - 2) + 1));
+  return generator;
  }

--- a/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlowXi.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_syntheFlowXi.C
@@ -335,5 +335,9 @@ private:
 
  FairGenerator *generator_syntheFlowXi()
  {
-   return new GeneratorPythia8SyntheFlowXi();
+  auto generator = new GeneratorPythia8SyntheFlowXi();
+  gRandom->SetSeed(0);
+  generator.readString("Random:setSeed = on");
+  generator.readString("Random:seed =" + std::to_string(gRandom->Integer(900000000 - 2) + 1));
+  return generator;
  }


### PR DESCRIPTION
This fixes a seeding issue in a few generators from LF: see plot from current simulations coming from one of them (the `extraStrangeness` one):

<img width="500" alt="image" src="https://github.com/user-attachments/assets/421e0d20-e717-4ed6-b157-a04ce167ca5f">

@sawenzel I think these all inherit from `GeneratorPythia8` so the seeding should have been taken care of automatically, should they not? I am not sure why this was not the case... 