### PR TITLE
MUON: added MW objects to MCH and MUON tracks tasks

### DIFF
--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -35,6 +35,17 @@
                     "type": "direct",
                     "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS"
                 },
+                "movingWindows": [
+                    "TracksPerTF",
+                    "TrackPt",
+                    "TrackEta",
+                    "TrackPhi",
+                    "WithCuts/TracksPerTF",
+                    "WithCuts/TrackPt",
+                    "WithCuts/TrackEta",
+                    "WithCuts/TrackPhi",
+                    "WithCuts/Minv"
+                ],
                 "taskParameters": {
                     "maxTracksPerTF": "600",
                     "GID": "MCH"

--- a/DATA/production/qc-async/mchmid-tracks.json
+++ b/DATA/production/qc-async/mchmid-tracks.json
@@ -13,6 +13,18 @@
           "type": "direct",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
+        "movingWindows": [
+            "WithCuts/TracksPerTF",
+            "WithCuts/TrackPt",
+            "WithCuts/TrackEta",
+            "WithCuts/TrackPhi",
+            "WithCuts/Minv",
+            "MCH-MID/WithCuts/TracksPerTF",
+            "MCH-MID/WithCuts/TrackPt",
+            "MCH-MID/WithCuts/TrackEta",
+            "MCH-MID/WithCuts/TrackPhi",
+            "MCH-MID/WithCuts/Minv"
+        ],
         "taskParameters": {
           "maxTracksPerTF": "600",
           "GID" : "MCH,MID,MCH-MID"

--- a/DATA/production/qc-async/mftmch-tracks.json
+++ b/DATA/production/qc-async/mftmch-tracks.json
@@ -13,6 +13,18 @@
           "type": "direct",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD"
         },
+        "movingWindows": [
+            "WithCuts/TracksPerTF",
+            "WithCuts/TrackPt",
+            "WithCuts/TrackEta",
+            "WithCuts/TrackPhi",
+            "WithCuts/Minv",
+            "MFT-MCH/WithCuts/TracksPerTF",
+            "MFT-MCH/WithCuts/TrackPt",
+            "MFT-MCH/WithCuts/TrackEta",
+            "MFT-MCH/WithCuts/TrackPhi",
+            "MFT-MCH/WithCuts/Minv"
+        ],
         "taskParameters": {
           "maxTracksPerTF": "600",
           "GID" : "MCH,MFT,MFT-MCH"

--- a/DATA/production/qc-async/mftmchmid-tracks.json
+++ b/DATA/production/qc-async/mftmchmid-tracks.json
@@ -13,6 +13,18 @@
           "type": "direct",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
+        "movingWindows": [
+            "WithCuts/TracksPerTF",
+            "WithCuts/TrackPt",
+            "WithCuts/TrackEta",
+            "WithCuts/TrackPhi",
+            "WithCuts/Minv",
+            "MCH-MID/WithCuts/TracksPerTF",
+            "MCH-MID/WithCuts/TrackPt",
+            "MCH-MID/WithCuts/TrackEta",
+            "MCH-MID/WithCuts/TrackPhi",
+            "MCH-MID/WithCuts/Minv"
+        ],
         "taskParameters": {
                  "maxTracksPerTF": "600",
                  "cutRAbsMin": "17.6",
@@ -50,6 +62,23 @@
           "type": "direct",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
+        "movingWindows": [
+            "MFT-MCH/WithCuts/TracksPerTF",
+            "MFT-MCH/WithCuts/TrackPt",
+            "MFT-MCH/WithCuts/TrackEta",
+            "MFT-MCH/WithCuts/TrackPhi",
+            "MFT-MCH/WithCuts/Minv",
+            "MCH-MID/WithCuts/TracksPerTF",
+            "MCH-MID/WithCuts/TrackPt",
+            "MCH-MID/WithCuts/TrackEta",
+            "MCH-MID/WithCuts/TrackPhi",
+            "MCH-MID/WithCuts/Minv",
+            "MFT-MCH-MID/WithCuts/TracksPerTF",
+            "MFT-MCH-MID/WithCuts/TrackPt",
+            "MFT-MCH-MID/WithCuts/TrackEta",
+            "MFT-MCH-MID/WithCuts/TrackPhi",
+            "MFT-MCH-MID/WithCuts/Minv"
+        ],
         "taskParameters": {
                  "maxTracksPerTF": "600",
                  "cutRAbsMin": "26.5",


### PR DESCRIPTION
Added several moving window objects to the MCH and global MUON aQC:
* TracksPerTF
* TrackPt
* TrackEta
* TrackPhi
* Minv (mu-mu invariant mass)

For the global MUON tasks, the MW objects are only associated to plots after the track selection cuts.

The QC cycle duration is 300 seconds for all the tasks.