### PR TITLE
[PWGHF] Add configurations for non-prompt Omega MCs (gen only, no gap trigger)

### DIFF
--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Mode2_OmegaC_to_Omega.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_Mode2_OmegaC_to_Omega.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredBeauty(1, -1.5, 1.5, -1.5, 1.5, {4332})
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC_to_Omega.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC_to_Omega.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredCharm(1, -1.5, 1.5, -1.5, 1.5, {4332})
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_Mode2_OmegaC_to_Omega.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_Mode2_OmegaC_to_Omega.C
@@ -1,0 +1,86 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuarkOne = 5;
+
+    int checkPdgHadron{4332};
+    int checkHadronDecays{3334};
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsInj{};
+    int nQuarks{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == checkPdgQuark) {
+                nEventsInj++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::abs(pdg) == checkPdgQuark) {
+                nQuarks++;
+                continue;
+            }
+            if (std::abs(pdg) == checkPdgHadron) { // found signal
+                nSignals++; // count signal PDG
+
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    if (std::abs(pdgDau) == checkHadronDecays) {
+                        nSignalGoodDecay;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuark) << nEventsInj << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuark) << nQuarks << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+
+    if (nEventsInj < nEvents) {
+        std::cerr << "Number of generated events with triggered events different than expected\n";
+        return 1;
+    }
+
+    if (nQuarks < nEvents) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuark << " lower than expected\n";
+        return 1;
+    }
+
+    if (nSignals < nEvents) {
+        std::cerr << "Number of generated signals lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (it should not happen, but to be conservative)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_Mode2_OmegaC_to_Omega.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_Mode2_OmegaC_to_Omega.C
@@ -1,0 +1,86 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuarkOne = 4;
+
+    int checkPdgHadron{4332};
+    int checkHadronDecays{3334};
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsInj{};
+    int nQuarks{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == checkPdgQuark) {
+                nEventsInj++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::abs(pdg) == checkPdgQuark) {
+                nQuarks++;
+                continue;
+            }
+            if (std::abs(pdg) == checkPdgHadron) { // found signal
+                nSignals++; // count signal PDG
+
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    if (std::abs(pdgDau) == checkHadronDecays) {
+                        nSignalGoodDecay;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuark) << nEventsInj << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuark) << nQuarks << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+
+    if (nEventsInj < nEvents) {
+        std::cerr << "Number of generated events with triggered events different than expected\n";
+        return 1;
+    }
+
+    if (nQuarks < nEvents) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuark << " lower than expected\n";
+        return 1;
+    }
+
+    if (nSignals < nEvents) {
+        std::cerr << "Number of generated signals lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (it should not happen, but to be conservative)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
@@ -1,0 +1,45 @@
+### configuration for Omega from OmegaC
+
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13600. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+### switching on Pythia Mode2
+ColourReconnection:mode 1
+ColourReconnection:allowDoubleJunRem off
+ColourReconnection:m0 0.3
+ColourReconnection:allowJunctions on
+ColourReconnection:junctionCorrection 1.20
+ColourReconnection:timeDilationMode 2
+ColourReconnection:timeDilationPar 0.18
+StringPT:sigma 0.335
+StringZ:aLund 0.36
+StringZ:bLund 0.56
+StringFlav:probQQtoQ 0.078
+StringFlav:ProbStoUD 0.2
+StringFlav:probQQ1toQQ0join 0.0275,0.0275,0.0275,0.0275
+MultiPartonInteractions:pT0Ref 2.15
+BeamRemnants:remnantMode 1
+BeamRemnants:saturation 5
+
+# Correct decay lengths (wrong in PYTHIA8 decay table)
+# Lb
+5122:tau0 = 0.4390
+# Xic0
+4132:tau0 = 0.0455
+# OmegaC
+4332:tau0 = 0.0803
+
+### switch off OmegaC decays
+4332:onMode = off
+
+### Omega_c -> Omega pi
+4332:onIfAny = 3334

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_Omegac_to_Omega.cfg
@@ -41,5 +41,5 @@ BeamRemnants:saturation 5
 ### switch off OmegaC decays
 4332:onMode = off
 
-### Omega_c -> Omega pi
+### Omega_c -> Omega + X
 4332:onIfAny = 3334


### PR DESCRIPTION
Hi @mpuccio @atriolo, this PR adds the configurations to produce a pool of generated events triggered on an OmegaC decaying to Omega + X. Could you please check that it's ok?

@creetz16 @pstahlhu @mfaggin @fcatalan92 @stefanopolitano we should do the same for OmegaC and Xic with forced decays (only `ini` files to be added, for the decay table we can use the usual config file).
