### PR TITLE
Possibility to set the input specs for GLO QC dynamically, for K0s

### DIFF
--- a/DATA/common/gen_topo_helper_functions.sh
+++ b/DATA/common/gen_topo_helper_functions.sh
@@ -49,6 +49,11 @@ has_detector_matching()
   [[ $WORKFLOW_DETECTORS_MATCHING =~ (^|,)"ALL"(,|$) ]] || [[ $WORKFLOW_DETECTORS_MATCHING =~ (^|,)"$1"(,|$) ]]
 }
 
+has_secvtx_source()
+{
+  [[ $SVERTEXING_SOURCES =~ (^|,)"ALL"(,|$) ]] || [[ $SVERTEXING_SOURCES =~ (^|,)"$1"(,|$) ]]
+}
+
 has_detector_qc()
 {
   has_detector $1 && [[ $WORKFLOW_DETECTORS_QC =~ (^|,)"$1"(,|$) ]]

--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -712,7 +712,10 @@ fi
 if [[ $ALIEN_JDL_QCOFF != "1" ]]; then
   export WORKFLOW_PARAMETERS="QC,${WORKFLOW_PARAMETERS}"
 fi
-export QC_CONFIG_PARAM="--local-batch=QC.root --override-values \"qc.config.Activity.number=$RUNNUMBER;qc.config.Activity.passName=$PASS;qc.config.Activity.periodName=$PERIOD\""
+
+export QC_CONFIG_OVERRIDE+=";qc.config.Activity.number=$RUNNUMBER;qc.config.Activity.passName=$PASS;qc.config.Activity.periodName=$PERIOD;"
+
+export QC_CONFIG_PARAM+=" --local-batch=QC.root "
 export GEN_TOPO_WORKDIR="./"
 #export QC_JSON_FROM_OUTSIDE="QC-20211214.json"
 

--- a/DATA/production/qc-async/itstpc.json
+++ b/DATA/production/qc-async/itstpc.json
@@ -39,7 +39,7 @@
         "dataSource" : {
           "type" : "direct",
           "query_comment" : "checking every matched track",
-          "query" : "trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam"
+          "query" : "trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam;SVParam:GLO/SVPARAM/0?lifetime=condition&ccdb-path=GLO/Config/SVertexerParam;p2decay3body:GLO/PVTX_3BODYREFS/0;decay3body:GLO/DECAYS3BODY/0;decay3bodyIdx:GLO/DECAYS3BODY_IDX/0;p2cascs:GLO/PVTX_CASCREFS/0;cascs:GLO/CASCS/0;cascsIdx:GLO/CASCS_IDX/0;p2v0s:GLO/PVTX_V0REFS/0;v0s:GLO/V0S/0;v0sIdx:GLO/V0S_IDX/0;pvtx_tref:GLO/PVTX_TRMTCREFS/0;pvtx_trmtc:GLO/PVTX_TRMTC/0;pvtx:GLO/PVTX/0;SVParam:GLO/SVPARAM/0?lifetime=condition&ccdb-path=GLO/Config/SVertexerParam;clusTPCoccmap:TPC/TPCOCCUPANCYMAP/0;clusTPC:TPC/CLUSTERNATIVE;clusTPCshmap:TPC/CLSHAREDMAP/0;trigTPC:TPC/TRIGGERWORDS/0;trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0;matchITSTPCTOF:TOF/MTC_ITSTPC/0;matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0;trigTPCTRD:TRD/TRGREC_TPC/0;trackTPCTRD:TRD/MATCH_TPC/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;matchTPCTRDTOF/TOF/MTC_TPCTRD/0;tofcluster:TOF/CLUSTERS/0"
         },
         "taskParameters" : {
           "GID" : "ITS-TPC,ITS",
@@ -55,19 +55,23 @@
           "minDCACutY": "10.f",
           "minPtCut": "0.f",
           "maxPtCut": "1e10f",
-          "etaCut": "1e10f"
+          "etaCut": "1e10f",
+	  "cutK0Mass": "0.05f",
+	  "maxEtaK0": "0.8f",
+	  "doK0QC": "true",
+	  "trackSourcesK0": "ITS,TPC,ITS-TPC,ITS-TPC-TOF,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF"
         },
 	"grpGeomRequest" : {
           "geomRequest": "None",
-          "askGRPECS": "false",
-          "askGRPLHCIF": "false",
+          "askGRPECS": "true",
+          "askGRPLHCIF": "true",
           "askGRPMagField": "true",
           "askMatLUT": "false",
           "askTime": "false",
           "askOnceAllButField": "true",
           "needPropagatorD":  "false"
         },
-        "saveObjectsToFile" : "ITSTPCmatched.root",
+        "saveObjectsToFile" : "ITSTPCmatched_allTracks_enabledK0.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
     }

--- a/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
+++ b/DATA/production/qc-sync/glo-itstpc-mtch-qcmn-epn.json
@@ -32,18 +32,29 @@
         "maxNumberCycles" : "-1",
         "dataSource" : {
           "type" : "dataSamplingPolicy",
-          "name" : "ITSTPCmSamp"
+          "name" : "ITSTPCmSampK0"
         },
         "taskParameters" : {
-          "GID" : "ITS-TPC,ITS",
-          "verbose" : "false",
-          "minPtCut" : "0.1f",
-          "etaCut" : "1.4f",
-          "minNTPCClustersCut" : "60",
-          "minDCACut" : "100.f",
-          "minDCACutY" : "10.f"
+          "GID": "ITS-TPC,ITS",
+          "verbose": "false",
+          "minPtITSCut": "0.f",
+          "etaITSCut": "1e10f",
+          "minNITSClustersCut": "0",
+          "maxChi2PerClusterITS": "100000",
+          "minPtTPCCut": "0.1f",
+          "etaTPCCut": "0.9f",
+          "minNTPCClustersCut": "60",
+          "minDCACut": "100.f",
+          "minDCACutY": "10.f",
+          "minPtCut": "0.f",
+          "maxPtCut": "1e10f",
+          "etaCut": "1e10f",
+          "cutK0Mass": "0.05f",
+          "maxEtaK0": "0.8f",
+          "doK0QC": "true",
+          "trackSourcesK0": ""
         },
-	"grpGeomRequest" : {
+        "grpGeomRequest" : {
           "geomRequest": "None",
           "askGRPECS": "false",
           "askGRPLHCIF": "false",
@@ -54,23 +65,23 @@
           "needPropagatorD":  "false"
         },
         "location" : "local",
-	  "localMachines": [
+          "localMachines": [
             "epn",
-	    "localhost"
+            "localhost"
           ],
         "remoteMachine": "alio2-cr1-qc07.cern.ch",
-	"remotePort": "47761",
-	"localControl": "odc"
+        "remotePort": "47761",
+        "localControl": "odc"
       }
     }
   },
   "dataSamplingPolicies" : [
     {
-      "id" : "ITSTPCmSamp",
+      "id" : "ITSTPCmSampK0",
       "active" : "true",
       "machines" : [],
       "query_comment" : "checking every 10% matched track",
-      "query" : "trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam",
+      "query" : "",
       "samplingConditions" : [
          {
            "condition" : "random",

--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -273,52 +273,62 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
         else
           # replace the input sources depending on the detector compostition and matching detectors
           ITSTPCMatchQuery="trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS/0;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam;SVParam:GLO/SVPARAM/0?lifetime=condition&ccdb-path=GLO/Config/SVertexerParam"
-	  if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
-            HAS_K0_ENABLED=$(jq -r .qc.tasks.MTCITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
-	  else
-            HAS_K0_ENABLED=$(jq -r .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
-          fi
           TRACKSOURCESK0="ITS,TPC,ITS-TPC"
-          if [[ $HAS_K0_ENABLED == "true" ]]; then
-            ITSTPCMatchQuery+=";p2decay3body:GLO/PVTX_3BODYREFS/0;decay3body:GLO/DECAYS3BODY/0;decay3bodyIdx:GLO/DECAYS3BODY_IDX/0;p2cascs:GLO/PVTX_CASCREFS/0;cascs:GLO/CASCS/0;cascsIdx:GLO/CASCS_IDX/0;p2v0s:GLO/PVTX_V0REFS/0;v0s:GLO/V0S/0;v0sIdx:GLO/V0S_IDX/0;pvtx_tref:GLO/PVTX_TRMTCREFS/0;pvtx_trmtc:GLO/PVTX_TRMTC/0;pvtx:GLO/PVTX/0;clusTPCoccmap:TPC/TPCOCCUPANCYMAP/0;clusTPC:TPC/CLUSTERNATIVE;clusTPCshmap:TPC/CLSHAREDMAP/0;trigTPC:TPC/TRIGGERWORDS/0"
-            if has_secvtx_source ITS-TPC-TRD ; then
-              ITSTPCMatchQuery+=";trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0"
-              TRACKSOURCESK0+=",ITS-TPC-TRD"
+          if has_processing_step MATCH_SECVTX || has_detector_matching SECVTX ; then
+            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
+              HAS_K0_ENABLED=$(jq -r .qc.tasks.MTCITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
+	    else
+              HAS_K0_ENABLED=$(jq -r .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
             fi
-            if has_secvtx_source ITS-TPC-TOF ; then
-              ITSTPCMatchQuery+=";matchITSTPCTOF:TOF/MTC_ITSTPC/0"
-              TRACKSOURCESK0+=",ITS-TPC-TOF"
+            if [[ $HAS_K0_ENABLED == "true" ]]; then
+              ITSTPCMatchQuery+=";p2decay3body:GLO/PVTX_3BODYREFS/0;decay3body:GLO/DECAYS3BODY/0;decay3bodyIdx:GLO/DECAYS3BODY_IDX/0;p2cascs:GLO/PVTX_CASCREFS/0;cascs:GLO/CASCS/0;cascsIdx:GLO/CASCS_IDX/0;p2v0s:GLO/PVTX_V0REFS/0;v0s:GLO/V0S/0;v0sIdx:GLO/V0S_IDX/0;pvtx_tref:GLO/PVTX_TRMTCREFS/0;pvtx_trmtc:GLO/PVTX_TRMTC/0;pvtx:GLO/PVTX/0;clusTPCoccmap:TPC/TPCOCCUPANCYMAP/0;clusTPC:TPC/CLUSTERNATIVE;clusTPCshmap:TPC/CLSHAREDMAP/0;trigTPC:TPC/TRIGGERWORDS/0"
+              if has_secvtx_source ITS-TPC-TRD ; then
+		ITSTPCMatchQuery+=";trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0"
+		TRACKSOURCESK0+=",ITS-TPC-TRD"
+              fi
+              if has_secvtx_source ITS-TPC-TOF ; then
+		ITSTPCMatchQuery+=";matchITSTPCTOF:TOF/MTC_ITSTPC/0"
+		TRACKSOURCESK0+=",ITS-TPC-TOF"
+              fi
+              if has_secvtx_source ITS-TPC-TRD-TOF ; then
+		ITSTPCMatchQuery+=";matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0"
+		TRACKSOURCESK0+=",ITS-TPC-TRD-TOF"
+              fi
+              if has_secvtx_source TPC-TRD ; then
+		ITSTPCMatchQuery+=";trigTPCTRD:TRD/TRGREC_TPC/0;trackTPCTRD:TRD/MATCH_TPC/0"
+		TRACKSOURCESK0+=",TPC-TRD"
+              fi
+              if has_secvtx_source TPC-TOF ; then
+		ITSTPCMatchQuery+=";matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0"
+		TRACKSOURCESK0+=",TPC-TOF"
+              fi
+              if has_secvtx_source TPC-TRD-TOF ; then
+		ITSTPCMatchQuery+=";matchTPCTRDTOF/TOF/MTC_TPCTRD/0"
+		TRACKSOURCESK0+=",TPC-TRD-TOF"
+              fi
+              if has_secvtx_source TOF ; then
+		ITSTPCMatchQuery+=";tofcluster:TOF/CLUSTERS/0"
+		TRACKSOURCESK0+=",TOF"
+              fi
+              if has_secvtx_source TRD ; then
+		TRACKSOURCESK0+=",TRD"
+              fi
             fi
-            if has_secvtx_source ITS-TPC-TRD-TOF ; then
-              ITSTPCMatchQuery+=";matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0"
-              TRACKSOURCESK0+=",ITS-TPC-TRD-TOF"
+            TEMP_FILE=$(mktemp "${i}"_XXXXXXX)
+            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
+              cat "${!DET_JSON_FILE}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
+            else
+              cat "${!DET_JSON_FILE}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
             fi
-            if has_secvtx_source TPC-TRD ; then
-              ITSTPCMatchQuery+=";trigTPCTRD:TRD/TRGREC_TPC/0;trackTPCTRD:TRD/MATCH_TPC/0"
-              TRACKSOURCESK0+=",TPC-TRD"
+	  else
+	    # we need to force that the K0s part is disabled
+            TEMP_FILE=$(mktemp "${i}"_XXXXXXX)
+            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
+              cat "${!DET_JSON_FILE}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.MTCITSTPC.taskParameters.doK0QC = \"false\"" > "$TEMP_FILE"
+            else
+              cat "${!DET_JSON_FILE}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC = \"false\"" > "$TEMP_FILE"
             fi
-            if has_secvtx_source TPC-TOF ; then
-              ITSTPCMatchQuery+=";matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0"
-              TRACKSOURCESK0+=",TPC-TOF"
-            fi
-            if has_secvtx_source TPC-TRD-TOF ; then
-              ITSTPCMatchQuery+=";matchTPCTRDTOF/TOF/MTC_TPCTRD/0"
-              TRACKSOURCESK0+=",TPC-TRD-TOF"
-            fi
-            if has_secvtx_source TOF ; then
-              ITSTPCMatchQuery+=";tofcluster:TOF/CLUSTERS/0"
-              TRACKSOURCESK0+=",TOF"
-            fi
-            if has_secvtx_source TRD ; then
-              TRACKSOURCESK0+=",TRD"
-            fi
-          fi
-          TEMP_FILE=$(mktemp "${i}"_XXXXXXX)
-          if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
-            cat "${!DET_JSON_FILE}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
-          else
-            cat "${!DET_JSON_FILE}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
-          fi
+	  fi
           DET_JSON_FILE=TEMP_FILE
           JSON_TEMP_FILES+=("$TEMP_FILE")
         fi


### PR DESCRIPTION
@shahor02 @f3sch

It was tested in the FST enabling the sec vtx:

```
export PRINT_WORKFLOW=1
export NHBPERTF=32
export SHMSIZE=8000000000
export NJOBS="$JOBS"
export DPL_REPORT_PROCESSING=1
export ARGS_EXTRA_PROCESS_o2_secondary_vertexing_workflow='--disable-cascade-finder --disable-3body-finder --disable-strangeness-tracker'

export WORKFLOW_EXTRA_PROCESSING_STEPS=TPC_DEDX,MFT_RECO,MID_RECO,MCH_RECO,MATCH_MFTMCH,MATCH_MCHMID,MUON_SYNC_RECO,ZDC_RECO,MATCH_SECVTX,MATCH_TPCTOF 
export FST_SYNC_EXTRA_WORKFLOW_PARAMETERS=QC,CALIB_LOCAL_AGGREGATOR,CALIB_LOCAL_INTEGRATED_AGGREGATOR 
export QC_REDIRECT_MERGER_TO_LOCALHOST=1 
export GEN_TOPO_WORKDIR=`pwd` 
export ALICE_O2SIM_DUMPLOG=1 
export NEvents=5 
export NEventsQED=100 
export O2SIMSEED=12345 
export QC_CONFIG_PARAM="--local-batch=QC.root"
$O2_ROOT/prodtests/full_system_test.sh
```

During the FST, there were issues with MFTdigits (when saving the QC output to file via the `--local-batch=QC.root` option) and also the TOF raw QC (which was then disabled).
For the FST, to enable sec vtx, I set:

`WORKFLOW_EXTRA_PROCESSING_STEPS=...MATCH_SECVTX,MATCH_TPCTOF `

where `MATCH_TPCTOF` can also be omitted. This same `WORKFLOW_EXTRA_PROCESSING_STEPS=...MATCH_SECVTX` would then be needed in online. 

Note that the reco_ASYNC in the FST also needs a change in the fst script, see https://github.com/AliceO2Group/AliceO2/pull/13770, since we need strangeness tracking in ASYNC for the AODs (disabled above by `export ARGS_EXTRA_PROCESS_o2_secondary_vertexing_workflow='--disable-cascade-finder --disable-3body-finder --disable-strangeness-tracker'`)

async reco was then tested on one run from zzo. 