### PR TITLE
MCH: add Clusters task in async

### DIFF
--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -23,13 +23,42 @@
             }
         },
         "tasks": {
+	    "MCHClusters": {
+		"active": "true",
+		"taskName": "Clusters",
+		"className": "o2::quality_control_modules::muonchambers::ClustersTask",
+		"moduleName": "QcMuonChambers",
+		"detectorName": "MCH",
+		"cycleDurationSeconds": "300",
+                "maxNumberCycles": "-1",
+		"dataSource": {
+		    "type": "direct",
+		    "query": "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS"
+		},
+                "movingWindows": [
+                    "ClusterSizePerChamber",
+                    "ClustersPerChamber",
+                    "ClustersPerTrack"
+                ],
+		"taskParameters": {},
+		"grpGeomRequest": {
+		    "geomRequest": "Aligned",
+		    "askGRPECS": "false",
+		    "askGRPLHCIF": "false",
+		    "askGRPMagField": "false",
+		    "askMatLUT": "false",
+		    "askTime": "false",
+		    "askOnceAllButField": "true",
+		    "needPropagatorD": "false"
+		}
+	    },
             "MCHTracks": {
                 "active": "true",
                 "taskName": "Tracks",
                 "className": "o2::quality_control_modules::muon::TracksTask",
                 "moduleName": "QcMUONCommon",
                 "detectorName": "MCH",
-                "cycleDurationSeconds": "180",
+                "cycleDurationSeconds": "300",
                 "maxNumberCycles": "-1",
                 "dataSource": {
                     "type": "direct",


### PR DESCRIPTION
Add the Clusters task to the async configuration, using parameters similar to those already validated in online.
The task also adds three moving window plots that are updated every 5 minutes.