### PR TITLE
MCH: add ClustersPerDualSampa plot to moving windows

### DIFF
--- a/DATA/production/qc-async/mch-tracks.json
+++ b/DATA/production/qc-async/mch-tracks.json
@@ -37,6 +37,7 @@
 		},
                 "movingWindows": [
                     "ClusterSizePerChamber",
+                    "ClustersPerDualSampa",
                     "ClustersPerChamber",
                     "ClustersPerTrack"
                 ],


### PR DESCRIPTION
The addition of the `ClustersPerDualSampa` plot to the moving windows list will allow to use the [cluster-map display](https://github.com/AliceO2Group/QualityControl/blob/master/Modules/MUON/MCH/src/Clustermap-Display.cxx) tool with data from short time ranges.