### PR TITLE
dynamically manipulating always the local json file in GLO QC, for K0s

### DIFF
--- a/DATA/production/qc-workflow.sh
+++ b/DATA/production/qc-workflow.sh
@@ -268,72 +268,72 @@ elif [[ -z ${QC_JSON_FROM_OUTSIDE:-} ]]; then
     DET_JSON_FILE="QC_JSON_GLO_$i"
     if has_matching_qc $i && [ ! -z "${!DET_JSON_FILE:-}" ]; then
       if [[ $i == "PRIMVTX" ]] && ! has_detector_reco ITS; then continue; fi
-      if [[ $i == "ITSTPC" ]] ; then
-        if ! has_detectors_reco ITS TPC; then continue
-        else
-          # replace the input sources depending on the detector compostition and matching detectors
-          ITSTPCMatchQuery="trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS/0;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam;SVParam:GLO/SVPARAM/0?lifetime=condition&ccdb-path=GLO/Config/SVertexerParam"
-          TRACKSOURCESK0="ITS,TPC,ITS-TPC"
-          if has_processing_step MATCH_SECVTX || has_detector_matching SECVTX ; then
-            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
-              HAS_K0_ENABLED=$(jq -r .qc.tasks.MTCITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
-	    else
-              HAS_K0_ENABLED=$(jq -r .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC "${!DET_JSON_FILE}")
-            fi
-            if [[ $HAS_K0_ENABLED == "true" ]]; then
-              ITSTPCMatchQuery+=";p2decay3body:GLO/PVTX_3BODYREFS/0;decay3body:GLO/DECAYS3BODY/0;decay3bodyIdx:GLO/DECAYS3BODY_IDX/0;p2cascs:GLO/PVTX_CASCREFS/0;cascs:GLO/CASCS/0;cascsIdx:GLO/CASCS_IDX/0;p2v0s:GLO/PVTX_V0REFS/0;v0s:GLO/V0S/0;v0sIdx:GLO/V0S_IDX/0;pvtx_tref:GLO/PVTX_TRMTCREFS/0;pvtx_trmtc:GLO/PVTX_TRMTC/0;pvtx:GLO/PVTX/0;clusTPCoccmap:TPC/TPCOCCUPANCYMAP/0;clusTPC:TPC/CLUSTERNATIVE;clusTPCshmap:TPC/CLSHAREDMAP/0;trigTPC:TPC/TRIGGERWORDS/0"
-              if has_secvtx_source ITS-TPC-TRD ; then
-		ITSTPCMatchQuery+=";trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0"
-		TRACKSOURCESK0+=",ITS-TPC-TRD"
-              fi
-              if has_secvtx_source ITS-TPC-TOF ; then
-		ITSTPCMatchQuery+=";matchITSTPCTOF:TOF/MTC_ITSTPC/0"
-		TRACKSOURCESK0+=",ITS-TPC-TOF"
-              fi
-              if has_secvtx_source ITS-TPC-TRD-TOF ; then
-		ITSTPCMatchQuery+=";matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0"
-		TRACKSOURCESK0+=",ITS-TPC-TRD-TOF"
-              fi
-              if has_secvtx_source TPC-TRD ; then
-		ITSTPCMatchQuery+=";trigTPCTRD:TRD/TRGREC_TPC/0;trackTPCTRD:TRD/MATCH_TPC/0"
-		TRACKSOURCESK0+=",TPC-TRD"
-              fi
-              if has_secvtx_source TPC-TOF ; then
-		ITSTPCMatchQuery+=";matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0"
-		TRACKSOURCESK0+=",TPC-TOF"
-              fi
-              if has_secvtx_source TPC-TRD-TOF ; then
-		ITSTPCMatchQuery+=";matchTPCTRDTOF/TOF/MTC_TPCTRD/0"
-		TRACKSOURCESK0+=",TPC-TRD-TOF"
-              fi
-              if has_secvtx_source TOF ; then
-		ITSTPCMatchQuery+=";tofcluster:TOF/CLUSTERS/0"
-		TRACKSOURCESK0+=",TOF"
-              fi
-              if has_secvtx_source TRD ; then
-		TRACKSOURCESK0+=",TRD"
-              fi
-            fi
-            TEMP_FILE=$(mktemp "${i}"_XXXXXXX)
-            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
-              cat "${!DET_JSON_FILE}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
-            else
-              cat "${!DET_JSON_FILE}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" > "$TEMP_FILE"
-            fi
-	  else
-	    # we need to force that the K0s part is disabled
-            TEMP_FILE=$(mktemp "${i}"_XXXXXXX)
-            if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]] ; then
-              cat "${!DET_JSON_FILE}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.MTCITSTPC.taskParameters.doK0QC = \"false\"" > "$TEMP_FILE"
-            else
-              cat "${!DET_JSON_FILE}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC = \"false\"" > "$TEMP_FILE"
-            fi
-	  fi
-          DET_JSON_FILE=TEMP_FILE
-          JSON_TEMP_FILES+=("$TEMP_FILE")
-        fi
-      fi
+      if [[ $i == "ITSTPC" ]] && ! has_detectors_reco ITS TPC; then continue; fi
       add_QC_JSON GLO_$i ${!DET_JSON_FILE}
+   
+      if [[ $i == "ITSTPC" ]]; then
+        LOCAL_FILENAME=${JSON_FILES//*\ /}
+        # replace the input sources depending on the detector compostition and matching detectors
+        ITSTPCMatchQuery="trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS/0;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam;SVParam:GLO/SVPARAM/0?lifetime=condition&ccdb-path=GLO/Config/SVertexerParam"
+        TRACKSOURCESK0="ITS,TPC,ITS-TPC"
+        if has_processing_step MATCH_SECVTX || has_detector_matching SECVTX; then
+          if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]]; then
+            HAS_K0_ENABLED=$(jq -r .qc.tasks.MTCITSTPC.taskParameters.doK0QC "${LOCAL_FILENAME}")
+          else
+            HAS_K0_ENABLED=$(jq -r .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC "${LOCAL_FILENAME}")
+          fi
+          if [[ $HAS_K0_ENABLED == "true" ]]; then
+            ITSTPCMatchQuery+=";p2decay3body:GLO/PVTX_3BODYREFS/0;decay3body:GLO/DECAYS3BODY/0;decay3bodyIdx:GLO/DECAYS3BODY_IDX/0;p2cascs:GLO/PVTX_CASCREFS/0;cascs:GLO/CASCS/0;cascsIdx:GLO/CASCS_IDX/0;p2v0s:GLO/PVTX_V0REFS/0;v0s:GLO/V0S/0;v0sIdx:GLO/V0S_IDX/0;pvtx_tref:GLO/PVTX_TRMTCREFS/0;pvtx_trmtc:GLO/PVTX_TRMTC/0;pvtx:GLO/PVTX/0;clusTPCoccmap:TPC/TPCOCCUPANCYMAP/0;clusTPC:TPC/CLUSTERNATIVE;clusTPCshmap:TPC/CLSHAREDMAP/0;trigTPC:TPC/TRIGGERWORDS/0"
+            if has_secvtx_source ITS-TPC-TRD; then
+              ITSTPCMatchQuery+=";trigITSTPCTRD:TRD/TRGREC_ITSTPC/0;trackITSTPCTRD:TRD/MATCH_ITSTPC/0"
+              TRACKSOURCESK0+=",ITS-TPC-TRD"
+            fi
+            if has_secvtx_source ITS-TPC-TOF; then
+              ITSTPCMatchQuery+=";matchITSTPCTOF:TOF/MTC_ITSTPC/0"
+              TRACKSOURCESK0+=",ITS-TPC-TOF"
+            fi
+            if has_secvtx_source ITS-TPC-TRD-TOF; then
+              ITSTPCMatchQuery+=";matchITSTPCTRDTOF:TOF/MTC_ITSTPCTRD/0"
+              TRACKSOURCESK0+=",ITS-TPC-TRD-TOF"
+            fi
+            if has_secvtx_source TPC-TRD; then
+              ITSTPCMatchQuery+=";trigTPCTRD:TRD/TRGREC_TPC/0;trackTPCTRD:TRD/MATCH_TPC/0"
+              TRACKSOURCESK0+=",TPC-TRD"
+            fi
+            if has_secvtx_source TPC-TOF; then
+              ITSTPCMatchQuery+=";matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0"
+              TRACKSOURCESK0+=",TPC-TOF"
+            fi
+            if has_secvtx_source TPC-TRD-TOF; then
+              ITSTPCMatchQuery+=";matchTPCTRDTOF/TOF/MTC_TPCTRD/0"
+              TRACKSOURCESK0+=",TPC-TRD-TOF"
+            fi
+            if has_secvtx_source TOF; then
+              ITSTPCMatchQuery+=";tofcluster:TOF/CLUSTERS/0"
+              TRACKSOURCESK0+=",TOF"
+            fi
+            if has_secvtx_source TRD; then
+              TRACKSOURCESK0+=",TRD"
+            fi
+          fi
+          TEMP_FILE=$(mktemp "${GEN_TOPO_WORKDIR:+$GEN_TOPO_WORKDIR/}${i}"_XXXXXXX)
+          if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]]; then
+            cat "${LOCAL_FILENAME}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" >"$TEMP_FILE"
+          else
+            cat "${LOCAL_FILENAME}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\"" >"$TEMP_FILE"
+          fi
+        else
+          # we need to force that the K0s part is disabled
+          TEMP_FILE=$(mktemp "${GEN_TOPO_WORKDIR:+$GEN_TOPO_WORKDIR/}${i}"_XXXXXXX)
+          if [[ $SYNCMODE == 1 ]] || [[ $EPNSYNCMODE == 1 ]]; then
+            cat "${LOCAL_FILENAME}" | jq "(.dataSamplingPolicies[] | select(.id == \"ITSTPCmSampK0\") | .query) = \"$ITSTPCMatchQuery\" | .qc.tasks.MTCITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.MTCITSTPC.taskParameters.doK0QC = \"false\"" >"$TEMP_FILE"
+          else
+            cat "${LOCAL_FILENAME}" | jq ".qc.tasks.GLOMatchTrITSTPC.dataSource.query = \"$ITSTPCMatchQuery\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.trackSourcesK0 = \"$TRACKSOURCESK0\" | .qc.tasks.GLOMatchTrITSTPC.taskParameters.doK0QC = \"false\"" >"$TEMP_FILE"
+          fi
+        fi
+        JSON_FILES=${JSON_FILES/$LOCAL_FILENAME/$TEMP_FILE}
+        JSON_TEMP_FILES+=("$TEMP_FILE")
+      fi
     fi
   done
 


### PR DESCRIPTION
and minor formatting changes (spaces instead of tabs)

this is required to make #1834 work also in online
- downloading the json from apricot to local and adding it to the `JSON_FILES`
  - when using local jsons to begin with, they are also added to `JSON_FILES` in the `add_QC_JSON` function
- manipulating the local json taken from `JSON_FILES` and store it in a temporary file
- replace the initial local json with the manipulated temporary file in `JSON_FILES`


**please do not merge yet, should be tested in online first**