### PR TITLE
Fix injection gap math

### DIFF
--- a/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
@@ -161,14 +161,7 @@ class GeneratorPythia8LF : public o2::eventgen::GeneratorPythia8
       LOG(info) << "Using config container ";
       cfg.print();
       if (mUseTriggering) {   // Do the triggering
-        bool doSignal = true; // Do signal or gap
-        if (mGapBetweenInjection > 0) {
-          if (mGapBetweenInjection == 1 && mEventCounter % 2 == 0) {
-            doSignal = false;
-          } else if (mEventCounter % (mGapBetweenInjection + 1) != 0) {
-            doSignal = false;
-          }
-        }
+        bool doSignal{mEventCounter % (mGapBetweenInjection + 1) == 0}; // Do signal or gap
 
         if (doSignal) {
           LOG(info) << "Generating triggered signal event for particle";

--- a/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
+++ b/MC/config/PWGLF/pythia8/generator_pythia8_LF.C
@@ -165,7 +165,7 @@ class GeneratorPythia8LF : public o2::eventgen::GeneratorPythia8
         if (mGapBetweenInjection > 0) {
           if (mGapBetweenInjection == 1 && mEventCounter % 2 == 0) {
             doSignal = false;
-          } else if (mEventCounter % mGapBetweenInjection + 1 != 0) {
+          } else if (mEventCounter % (mGapBetweenInjection + 1) != 0) {
             doSignal = false;
           }
         }


### PR DESCRIPTION
The change introduced in #1431 had the side effect that no signal events were present in recent productions using this generator, as for operator precedence one could never satisfy the condition of the if regulating the generation of signal events.

@njacazio @ddobrigk 