### PR TITLE
Adding option to save multiple MFT-MUON matching candidates

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -80,6 +80,9 @@ def create_sim_config(args):
         add(config, {"FwdMatching.matchFcn" : "matchsXYPhiTanl"})
     if args.fwdmatching_cut_4_param == True:
         add(config, {"FwdMatching.cutFcn" : "cut3SigmaXYAngles"})
+    if int(args.fwdmatchingNcandidates) > 0:
+        add(config, {"FwdMatching.saveMode" : 3})
+        add(config, {"FwdMatching.nCandidates" : int(args.fwdmatchingNcandidates)})
 
     # deal with larger combinatorics
     if args.col == "PbPb" or (args.embedding and args.colBkg == "PbPb"):

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -151,6 +151,7 @@ parser.add_argument('--fwdmatching-cut-4-param', action='store_true', help='appl
 
 # Matching training for machine learning
 parser.add_argument('--fwdmatching-save-trainingdata', action='store_true', help='enables saving parameters at plane for matching training with machine learning')
+parser.add_argument('--fwdmatchingNcandidates', type=int, help='enables saving provided number of matching candidates', default=0)
 
 args = parser.parse_args()
 print (args)


### PR DESCRIPTION
This PR allows to save multiple MFT-MUON matching candidates, which will be used to build machine learning training samples.