### PR TITLE
fix to keep parton information

### DIFF
--- a/MC/config/PWGGAJE/ini/GeneratorJE_gapgen5_hook.ini
+++ b/MC/config/PWGGAJE/ini/GeneratorJE_gapgen5_hook.ini
@@ -3,3 +3,7 @@
 [GeneratorExternal]
 fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/external/generator/generator_pythia8_gaptrigger_jets_hook.C
 funcName = getGeneratorPythia8GapGenJE(5,"${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_minbias.cfg","${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet.cfg")
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_jet.cfg
+includePartonEvent=true


### PR DESCRIPTION
keep parton information for jet-jet MB gap simulation 