### PR TITLE
Added test redirection mechanism for ini generators

### DIFF
--- a/MC/config/PWGGAJE/ini/GeneratorPythia8POWHEG_F2.ini
+++ b/MC/config/PWGGAJE/ini/GeneratorPythia8POWHEG_F2.ini
@@ -1,0 +1,9 @@
+### The external generator derives from GeneratorPythia8.
+## The generator allows to run Pythia8 with POWHEG
+#---> GeneratorPythia8POWHEG
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/external/generator/generator_pythia8_powheg.C
+funcName=getGeneratorJEPythia8POWHEG("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/external/powheg/powheg_beauty_F2.input")
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_powheg.cfg

--- a/MC/config/PWGGAJE/ini/GeneratorPythia8POWHEG_charm.ini
+++ b/MC/config/PWGGAJE/ini/GeneratorPythia8POWHEG_charm.ini
@@ -1,0 +1,9 @@
+### The external generator derives from GeneratorPythia8.
+## The generator allows to run Pythia8 with POWHEG
+#---> GeneratorPythia8POWHEG
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/external/generator/generator_pythia8_powheg.C
+funcName=getGeneratorJEPythia8POWHEG("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/external/powheg/powheg_charm_default.input")
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGGAJE/pythia8/generator/pythia8_powheg.cfg

--- a/test/run_generator_tests.sh
+++ b/test/run_generator_tests.sh
@@ -64,7 +64,16 @@ get_test_script_path_for_ini()
 {
     local ini_path=${1}
     local test_script=$(basename ${ini_path})
-    echo $(dirname ${ini_path})/tests/${test_script%.ini}.C
+    local path_to_test_script=$(dirname ${ini_path})/tests/${test_script%.ini}.C
+    if [[ ! -f ${path_to_test_script} ]] ; then
+        # Check if test redirection is applied inside the ini_path file using the #---> syntax
+        local redirection=$(grep "#--->" ${ini_path})
+        if [[ "${redirection}" != "" ]] ; then
+            test_script=$(echo ${redirection} | awk '{print $2}')
+            path_to_test_script=$(dirname ${ini_path})/tests/${test_script}.C
+        fi
+    fi
+    echo ${path_to_test_script}
 }
 
 


### PR DESCRIPTION
Instead of creating a test macro for each ini file, a redirection mechanism is implemented in those cases in which the external generator can be tested with another test (changing parameters in powheg for example). The syntax to be used is simply 
`#---> TestName` as shown in the two committed examples. This mechanism does not replace the previous one, but adds an additional versatility layer