### PR TITLE
set pw in test script + toggle ideal ITS in anchored simulation

### DIFF
--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -300,7 +300,7 @@ fi
 
 # -- Create aligned geometry using ITS ideal alignment to avoid overlaps in geant
 ENABLEPW = 0
-if [[ $remainingargs == "GeometryManagerParam.useParallelWorld=1" ]]; then
+if [ ${remainingargs} == *"GeometryManagerParam.useParallelWorld=1"* ]; then
   ENABLEPW=1
 fi
 

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -299,7 +299,7 @@ if [ "${ISEXCLUDED}" ]; then
 fi
 
 # -- Create aligned geometry using ITS ideal alignment to avoid overlaps in geant
-ENABLEPW = 0
+ENABLEPW=0
 if [ ${remainingargs} == *"GeometryManagerParam.useParallelWorld=1"* ]; then
   ENABLEPW=1
 fi

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -299,20 +299,28 @@ if [ "${ISEXCLUDED}" ]; then
 fi
 
 # -- Create aligned geometry using ITS ideal alignment to avoid overlaps in geant
-CCDBOBJECTS_IDEAL_MC="ITS/Calib/Align"
-TIMESTAMP_IDEAL_MC=1
-${O2_ROOT}/bin/o2-ccdb-downloadccdbfile --host http://alice-ccdb.cern.ch/ -p ${CCDBOBJECTS_IDEAL_MC} -d ${ALICEO2_CCDB_LOCALCACHE} --timestamp ${TIMESTAMP_IDEAL_MC}
-CCDB_RC="${?}"
-if [ ! "${CCDB_RC}" == "0" ]; then
-  echo_error "Problem during CCDB prefetching of ${CCDBOBJECTS_IDEAL_MC}. Exiting."
-  exit ${CCDB_RC}
+if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+  CCDBOBJECTS_IDEAL_MC="ITS/Calib/Align"
+  TIMESTAMP_IDEAL_MC=1
+  ${O2_ROOT}/bin/o2-ccdb-downloadccdbfile --host http://alice-ccdb.cern.ch/ -p ${CCDBOBJECTS_IDEAL_MC} -d ${ALICEO2_CCDB_LOCALCACHE} --timestamp ${TIMESTAMP_IDEAL_MC}
+  CCDB_RC="${?}"
+  if [ ! "${CCDB_RC}" == "0" ]; then
+    echo_error "Problem during CCDB prefetching of ${CCDBOBJECTS_IDEAL_MC}. Exiting."
+    exit ${CCDB_RC}
+  fi
 fi
 
 # TODO This can potentially be removed or if needed, should be taken over by o2dpg_sim_workflow_anchored.py and O2_dpg_workflow_runner.py
-echo "run with echo in pipe" | ${O2_ROOT}/bin/o2-create-aligned-geometry-workflow --configKeyValues "HBFUtils.startTime=${TIMESTAMP}" --condition-remap=file://${ALICEO2_CCDB_LOCALCACHE}=ITS/Calib/Align -b --run
+if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+  echo "run with echo in pipe" | ${O2_ROOT}/bin/o2-create-aligned-geometry-workflow --configKeyValues "HBFUtils.startTime=${TIMESTAMP}" --condition-remap=file://${ALICEO2_CCDB_LOCALCACHE}=ITS/Calib/Align -b --run
+else
+  echo "run with echo in pipe" | ${O2_ROOT}/bin/o2-create-aligned-geometry-workflow --configKeyValues "HBFUtils.startTime=${TIMESTAMP}" -b --run
+fi
 mkdir -p $ALICEO2_CCDB_LOCALCACHE/GLO/Config/GeometryAligned
 ln -s -f $PWD/o2sim_geometry-aligned.root $ALICEO2_CCDB_LOCALCACHE/GLO/Config/GeometryAligned/snapshot.root
-[[ -f $PWD/its_GeometryTGeo.root ]] && mkdir -p $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry && ln -s -f $PWD/its_GeometryTGeo.root $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry/snapshot.root
+if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+  [[ -f $PWD/its_GeometryTGeo.root ]] && mkdir -p $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry && ln -s -f $PWD/its_GeometryTGeo.root $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry/snapshot.root
+fi
 [[ -f $PWD/mft_GeometryTGeo.root ]] && mkdir -p $ALICEO2_CCDB_LOCALCACHE/MFT/Config/Geometry && ln -s -f $PWD/mft_GeometryTGeo.root $ALICEO2_CCDB_LOCALCACHE/MFT/Config/Geometry/snapshot.root
 
 # -- RUN THE MC WORKLOAD TO PRODUCE AOD --

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -300,7 +300,7 @@ fi
 
 # -- Create aligned geometry using ITS ideal alignment to avoid overlaps in geant
 ENABLEPW=0
-if [ ${remainingargs} == *"GeometryManagerParam.useParallelWorld=1"* ]; then
+if [[ ${remainingargs} == *"GeometryManagerParam.useParallelWorld=1"* ]]; then
   ENABLEPW=1
 fi
 

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -299,7 +299,12 @@ if [ "${ISEXCLUDED}" ]; then
 fi
 
 # -- Create aligned geometry using ITS ideal alignment to avoid overlaps in geant
-if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+ENABLEPW = 0
+if [[ $remainingargs == "GeometryManagerParam.useParallelWorld=1" ]]; then
+  ENABLEPW=1
+fi
+
+if [ "${ENABLEPW}" == "0" ]; then
   CCDBOBJECTS_IDEAL_MC="ITS/Calib/Align"
   TIMESTAMP_IDEAL_MC=1
   ${O2_ROOT}/bin/o2-ccdb-downloadccdbfile --host http://alice-ccdb.cern.ch/ -p ${CCDBOBJECTS_IDEAL_MC} -d ${ALICEO2_CCDB_LOCALCACHE} --timestamp ${TIMESTAMP_IDEAL_MC}
@@ -311,14 +316,14 @@ if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
 fi
 
 # TODO This can potentially be removed or if needed, should be taken over by o2dpg_sim_workflow_anchored.py and O2_dpg_workflow_runner.py
-if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+if [ "${ENABLEPW}" == "0" ]; then
   echo "run with echo in pipe" | ${O2_ROOT}/bin/o2-create-aligned-geometry-workflow --configKeyValues "HBFUtils.startTime=${TIMESTAMP}" --condition-remap=file://${ALICEO2_CCDB_LOCALCACHE}=ITS/Calib/Align -b --run
 else
   echo "run with echo in pipe" | ${O2_ROOT}/bin/o2-create-aligned-geometry-workflow --configKeyValues "HBFUtils.startTime=${TIMESTAMP}" -b --run
 fi
 mkdir -p $ALICEO2_CCDB_LOCALCACHE/GLO/Config/GeometryAligned
 ln -s -f $PWD/o2sim_geometry-aligned.root $ALICEO2_CCDB_LOCALCACHE/GLO/Config/GeometryAligned/snapshot.root
-if [ "${ENABLE_PARALLEL_WORLD}" == "0" ]; then
+if [ "${ENABLEPW}" == "0" ]; then
   [[ -f $PWD/its_GeometryTGeo.root ]] && mkdir -p $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry && ln -s -f $PWD/its_GeometryTGeo.root $ALICEO2_CCDB_LOCALCACHE/ITS/Config/Geometry/snapshot.root
 fi
 [[ -f $PWD/mft_GeometryTGeo.root ]] && mkdir -p $ALICEO2_CCDB_LOCALCACHE/MFT/Config/Geometry && ln -s -f $PWD/mft_GeometryTGeo.root $ALICEO2_CCDB_LOCALCACHE/MFT/Config/Geometry/snapshot.root

--- a/MC/run/ANCHOR/tests/test_anchor_2023_apass2_pp.sh
+++ b/MC/run/ANCHOR/tests/test_anchor_2023_apass2_pp.sh
@@ -30,6 +30,9 @@ export SEED=5
 # for pp and 50 events per TF, we launch only 4 workers.
 export NWORKERS=2
 
+export ENABLE_PARALLEL_WORLD=1
+export ALIEN_JDL_ANCHOR_SIM_OPTIONS="-gen pythia8 -confKey \"GeometryManagerParam.useParallelWorld=1;GeometryManagerParam.usePwGeoBVH=1;GeometryManagerParam.usePwCaching=1\""
+
 # run the central anchor steering script; this includes
 # * derive timestamp
 # * derive interaction rate

--- a/MC/run/ANCHOR/tests/test_anchor_2023_apass2_pp.sh
+++ b/MC/run/ANCHOR/tests/test_anchor_2023_apass2_pp.sh
@@ -30,7 +30,6 @@ export SEED=5
 # for pp and 50 events per TF, we launch only 4 workers.
 export NWORKERS=2
 
-export ENABLE_PARALLEL_WORLD=1
 export ALIEN_JDL_ANCHOR_SIM_OPTIONS="-gen pythia8 -confKey \"GeometryManagerParam.useParallelWorld=1;GeometryManagerParam.usePwGeoBVH=1;GeometryManagerParam.usePwCaching=1\""
 
 # run the central anchor steering script; this includes


### PR DESCRIPTION
@sawenzel @mconcas @alcaliva 

I opened a new PR on the addition of the parallel world feature to the steering scripts.

As suggested in the previous thread by Sandro, I removed the overriding `confKey` setting in the `anchorMC.sh` script. As an example, the activation of the parallel world feature is shown in the pp test script.

I still include the changes in `anchorMC.sh` that toggle the usage of the ideal geometry for ITS in anchored simulations. First, we avoid fetching the ideal alignment object for ITS from the ccdb in case we require the parallel world. Additionally, if the parallel world is requested, the ITS geometry snapshot is not added to the local ccdb cache, while this is always done for MFT.