### PR TITLE
MUON: added option for storing nCandidates in the MFT-MCH matching

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -169,6 +169,9 @@ ITSMFT_STROBES=""
 [[ ! -z ${ITS_STROBE:-} ]] && ITSMFT_STROBES+="ITSAlpideParam.roFrameLengthInBC=$ITS_STROBE;"
 [[ ! -z ${MFT_STROBE:-} ]] && ITSMFT_STROBES+="MFTAlpideParam.roFrameLengthInBC=$MFT_STROBE;"
 
+MFTMCH_NCANDIDATES_OPT=
+[[ ! -z ${MUON_MATCHING_NCANDIDATES:-} ]] && MFTMCH_NCANDIDATES_OPT+="FwdMatching.saveMode=3;FwdMatching.nCandidates=${MUON_MATCHING_NCANDIDATES};"
+
 
 # Set active reconstruction steps (defaults added according to SYNCMODE)
 for i in `echo $LIST_OF_GLORECO | sed "s/,/ /g"`; do


### PR DESCRIPTION
The number of candidates to be stored is specified in the `MUON_MATCHING_NCANDIDATES` environment variable.

By default the variable is not set, and no option is passed to the global forward matching workflow for storing multiple candidates.

Hence the default behavior of the forward matching is unchanged.

The new option also requires the changes in https://github.com/AliceO2Group/AliceO2/pull/13977.