### PR TITLE
[O2DPG,UTILS,O2-5725] Expand macros to find corrupted AO2Ds

### DIFF
--- a/UTILS/checkCorruptedAO2Ds.C
+++ b/UTILS/checkCorruptedAO2Ds.C
@@ -4,6 +4,17 @@
 #include <TTreeReader.h>
 #include <TGrid.h>
 #include <iostream>
+#include <TError.h>
+#include <cstring>
+
+bool gWarningDetected = false; // Global flag to track the warning
+
+void MyErrorHandler(int level, Bool_t abort, const char *location, const char *msg) {
+    if (strstr(msg, "repair") != nullptr) {
+        gWarningDetected = true;
+    }
+    DefaultErrorHandler(level, abort, location, msg); // Call ROOT’s default handler
+}
 
 int checkCorruptedAO2Ds(TString infileName = "/alice/sim/2024/LHC24h2/535545/AOD/005/AO2D.root", bool fromAlien = true) {
 
@@ -41,6 +52,10 @@ int checkCorruptedAO2Ds(TString infileName = "/alice/sim/2024/LHC24h2/535545/AOD
                         if (tree->GetEntry(iEntry) < 0) {
                             std::cout << "Found corrupted file! DF: " << dirKey->GetName() << " Tree:" << pair.first.data() << " Branch:" << branchName.data() << std::endl;
                             return -1;
+                        }
+                        if (gWarningDetected) {
+                            std::cout << "Found file in need of repair! DF: " << dirKey->GetName() << " Tree:" << pair.first.data() << " Branch:" << branchName.data() << std::endl;
+                            return -2;
                         }
                     }
                 }

--- a/UTILS/checkCorruptedAO2Ds.C
+++ b/UTILS/checkCorruptedAO2Ds.C
@@ -16,7 +16,9 @@ void MyErrorHandler(int level, Bool_t abort, const char *location, const char *m
     DefaultErrorHandler(level, abort, location, msg); // Call ROOT’s default handler
 }
 
-int checkCorruptedAO2Ds(TString infileName = "/alice/sim/2024/LHC24h2/535545/AOD/005/AO2D.root", bool fromAlien = true) {
+int checkCorruptedAO2Ds(TString infileName = "AO2D_FZK.root", bool fromAlien = false) {
+    
+    SetErrorHandler(MyErrorHandler);
 
     if (fromAlien) {
         TGrid::Connect("alien://");
@@ -32,7 +34,7 @@ int checkCorruptedAO2Ds(TString infileName = "/alice/sim/2024/LHC24h2/535545/AOD
 
     // all VLA branches in the AO2Ds.root
     std::map<std::string, std::vector<std::string>> branchesToCheck = {
-        {"O2mcparticle_001", std::vector<std::string>{"fIndexArray_Mothers"}},
+        {"O2mcparticle_001", std::vector<std::string>{"fIndexArray_Mothers", "fVx", "fIndexMcCollisions"}},
         {"O2ft0", std::vector<std::string>{"fAmplitudeA", "fChannelA", "fAmplitudeC", "fChannelC"}},
         {"O2fv0a", std::vector<std::string>{"fAmplitude", "fChannel"}},
         {"O2mccalolabel_001", std::vector<std::string>{"fIndexArrayMcParticles", "fAmplitudeA"}},

--- a/UTILS/checkCorruptedAO2Ds.C
+++ b/UTILS/checkCorruptedAO2Ds.C
@@ -16,7 +16,7 @@ void MyErrorHandler(int level, Bool_t abort, const char *location, const char *m
     DefaultErrorHandler(level, abort, location, msg); // Call ROOT’s default handler
 }
 
-int checkCorruptedAO2Ds(TString infileName = "AO2D_FZK.root", bool fromAlien = false) {
+int checkCorruptedAO2Ds(TString infileName = "/alice/sim/2024/LHC24h2/535545/AOD/005/AO2D.root", bool fromAlien = true) {
     
     SetErrorHandler(MyErrorHandler);
 

--- a/UTILS/findCorruptedAO2Ds.sh
+++ b/UTILS/findCorruptedAO2Ds.sh
@@ -20,7 +20,7 @@ else
 fi
 mapfile -t FILESTOCHECK < files_to_check.txt
 
-process AO2Ds
+# process AO2Ds
 process_file() {
   IFS='/' read -a num <<< "$1"
   INPUT=$1

--- a/UTILS/findCorruptedAO2Ds.sh
+++ b/UTILS/findCorruptedAO2Ds.sh
@@ -2,9 +2,10 @@
 
 # Simple script to find corrupted AO2Ds using the checkCorruptedAO2Ds.C macro
 
-PRODUCTION=LHC24h2
+PRODUCTION=LHC24f3c
 RUN=* # use * for all runs
-NJOBS=90
+NJOBS=20
+PRODUCTIONCYCLE=0
 
 OUTPUTFILE=corrupted_files_$PRODUCTION.txt
 if [ -e "$OUTPUTFILE" ]; then
@@ -12,18 +13,18 @@ if [ -e "$OUTPUTFILE" ]; then
 fi
 
 # find all files in alien
-if [ "$variable" == "*" ]; then
-  alien_find alien:///alice/sim/2024/${PRODUCTION} 5*/AOD/*/AO2D.root > files_to_check.txt
+if [ "$RUN" == "*" ]; then
+  alien_find alien:///alice/sim/2024/${PRODUCTION}/${PRODUCTIONCYCLE}/5*/AOD/*/AO2D.root > files_to_check.txt
 else
-  alien_find alien:///alice/sim/2024/${PRODUCTION} ${RUN}/AOD/*/AO2D.root > files_to_check.txt
+  alien_find alien:///alice/sim/2024/${PRODUCTION}/${PRODUCTIONCYCLE}/${RUN}/AOD/*/AO2D.root > files_to_check.txt
 fi
 mapfile -t FILESTOCHECK < files_to_check.txt
 
-# process AO2Ds
+process AO2Ds
 process_file() {
   IFS='/' read -a num <<< "$1"
   INPUT=$1
-  echo '.x checkCorruptedAO2Ds.C("'${INPUT}'", true)' | root -l -b > log_${num[5]}_${num[7]}
+  echo '.x checkCorruptedAO2Ds.C("'${INPUT}'", true)' | root -l -b > log_${num[6]}_${num[8]}
   echo '.q'
 }
 export -f process_file
@@ -36,12 +37,12 @@ ERRORSTR="Found corrupted file!"
 REPAIRSTR="Found file in need of repair!"
 for FILE in "${FILESTOCHECK[@]}"; do
   IFS='/' read -a num <<< "$FILE"
-  if grep -q "$ERRORSTR" log_${num[5]}_${num[7]}; then
-    echo $FILE >> $OUTPUTFILE
-  else grep -q "$REPAIRSTR" log_${num[5]}_${num[7]}; then
-    echo $FILE >> $OUTPUTFILE
+  if grep -q "$ERRORSTR" log_${num[6]}_${num[8]}; then
+    echo $FILE " is corrupted!" >> $OUTPUTFILE
+  elif grep -q "$REPAIRSTR" log_${num[6]}_${num[8]}; then
+    echo $FILE " is broken!" >> $OUTPUTFILE
   fi
 done
 
 rm files_to_check.txt
-rm log*
+rm log_*

--- a/UTILS/findCorruptedAO2Ds.sh
+++ b/UTILS/findCorruptedAO2Ds.sh
@@ -33,9 +33,12 @@ parallel -j $NJOBS process_file ::: "${FILESTOCHECK[@]}"
 # create list of corrupted files
 touch $OUTPUTFILE
 ERRORSTR="Found corrupted file!"
+REPAIRSTR="Found file in need of repair!"
 for FILE in "${FILESTOCHECK[@]}"; do
   IFS='/' read -a num <<< "$FILE"
   if grep -q "$ERRORSTR" log_${num[5]}_${num[7]}; then
+    echo $FILE >> $OUTPUTFILE
+  else grep -q "$REPAIRSTR" log_${num[5]}_${num[7]}; then
     echo $FILE >> $OUTPUTFILE
   fi
 done


### PR DESCRIPTION
- Added check for "repair" messages in the `checkCorruptedAO2Ds.C` macro to also catch files, where some problem appears and root tries to repair on the fly. This addition is made based on the recent report by Nicolas on the JIRA ticket O2-5725 that we see still some AO2D files with problems that can not be catched with the old version of `checkCorruptedAO2Ds.C`.
- Modified `findCorruptedAO2Ds.sh` to correctly read those cases and identify them as "broken" aswell.