### PR TITLE
Workaround crash in TPC digitization

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1001,6 +1001,8 @@ for tf in range(1, NTIMEFRAMES + 1):
    TPCDigitask=createTask(name='tpcdigi_'+str(tf), needs=tpcdigineeds,
                           tf=tf, cwd=timeframeworkdir, lab=["DIGI"], cpu=NWORKERS_TF, mem=str(tpcdigimem))
    TPCDigitask['cmd'] = ('','ln -nfs ../bkg_HitsTPC.root . ;')[doembedding]
+   TPCDigitask['cmd'] += '${O2_ROOT}/bin/o2-ccdb-downloadccdbfile --host http://alice-ccdb.cern.ch -p TPC/Config/RunInfoV2 --timestamp '   \
+                         + str(args.timestamp) + ' --created-not-after ' + str(args.condition_not_after) + ' -d ${ALICEO2_CCDB_LOCALCACHE} ; '
    TPCDigitask['cmd'] += '${O2_ROOT}/bin/o2-sim-digitizer-workflow ' + getDPL_global_options() + ' -n ' + str(args.ns) + simsoption       \
                          + ' --onlyDet TPC --TPCuseCCDB --interactionRate ' + str(INTRATE) + '  --tpc-lanes ' + str(NWORKERS_TF)             \
                          + ' --incontext ' + str(CONTEXTFILE) + ' --disable-write-ini --early-forward-policy always --forceSelectedDets ' \


### PR DESCRIPTION
TPC digitization currently crashes when multiple workers try to load FEEConfig via TPC/Config/RunInfoV2.

Recently the TPC code was changed to use this redirecting object. The hypothesis is that there is a problem in the CcdbApi when using CCDB redirects which is bypassing semaphore syncronization of CCDB loads. This leads to race conditions and corrupted CCDB snapshots.

This commit reduces such a race condition by pre-downloading TPC/Config/RunInfoV2 before launching multi-process TPC digitization procedures.

We can take the change back once a proper fix is available in O2-CCDB.