### PR TITLE
MUON: add default values for number of MFT-MCH matching candidates

### DIFF
--- a/DATA/common/setenv.sh
+++ b/DATA/common/setenv.sh
@@ -169,9 +169,6 @@ ITSMFT_STROBES=""
 [[ ! -z ${ITS_STROBE:-} ]] && ITSMFT_STROBES+="ITSAlpideParam.roFrameLengthInBC=$ITS_STROBE;"
 [[ ! -z ${MFT_STROBE:-} ]] && ITSMFT_STROBES+="MFTAlpideParam.roFrameLengthInBC=$MFT_STROBE;"
 
-MFTMCH_NCANDIDATES_OPT=
-[[ ! -z ${MUON_MATCHING_NCANDIDATES:-} ]] && MFTMCH_NCANDIDATES_OPT+="FwdMatching.saveMode=3;FwdMatching.nCandidates=${MUON_MATCHING_NCANDIDATES};"
-
 
 # Set active reconstruction steps (defaults added according to SYNCMODE)
 for i in `echo $LIST_OF_GLORECO | sed "s/,/ /g"`; do

--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -583,6 +583,19 @@ if [[ $BEAMTYPE == "pp" ]]; then
   export CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+=";MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7;MCHTracking.sigmaCutForImprovement=6"
 fi
 
+# ad-hoc settings for MFT-MCH matching
+# Number of MFT-MCH matching candidates to be stored in AO2Ds
+# Setting MUON_MATCHING_NCANDIDATES=0 disables the storage of multiple candidates
+if [[ -z "${MUON_MATCHING_NCANDIDATES:-}" ]]; then
+  MUON_MATCHING_NCANDIDATES=0 # disable the saving of nCandidated by default
+  if [[ $BEAMTYPE == "pp" ]]; then MUON_MATCHING_NCANDIDATES=5; fi
+  if [[ $BEAMTYPE == "PbPb" ]]; then MUON_MATCHING_NCANDIDATES=20; fi
+fi
+if [[ "x${MUON_MATCHING_NCANDIDATES}" != "x0" ]]; then
+    export CONFIG_EXTRA_PROCESS_o2_globalfwd_matcher_workflow+=";FwdMatching.saveMode=3;FwdMatching.nCandidates=${MUON_MATCHING_NCANDIDATES};"
+fi
+
+
 # possibly adding calib steps as done online
 # could be done better, so that more could be enabled in one go
 if [[ $ADD_CALIB == "1" ]]; then


### PR DESCRIPTION
The default number of matching candidates to be saved in output AO2Ds is set to 5 for pp and 20 for Pb-Pb. For other beam types it is set to zero, which prevents from adding the `FwdMatching.saveMode` and `FwdMatching.nCandidates` options to the forward matching workflow.

Setting the `MUON_MATCHING_NCANDIDATES` environment variable overrides the default values.