### PR TITLE
MCH: add cut random fraction setting for the cases with and without ITS

### DIFF
--- a/DATA/production/workflow-multiplicities.sh
+++ b/DATA/production/workflow-multiplicities.sh
@@ -252,7 +252,21 @@ elif [[ $BEAMTYPE == "PbPb" ]]; then
 else
   : ${CUT_RANDOM_FRACTION_ITS:=0.95}
 fi
-[[ $RUNTYPE != "COSMICS" ]] && : ${CUT_RANDOM_FRACTION_MCH:=0.7}
+
+# Random data sampling fraction for MCH
+if [[ $BEAMTYPE == "pp" ]]; then
+    : ${CUT_RANDOM_FRACTION_MCH_WITH_ITS:=0.5}
+    : ${CUT_RANDOM_FRACTION_MCH_NO_ITS:=0.995}
+elif [[ "$HIGH_RATE_PP" == "1" ]]; then
+    : ${CUT_RANDOM_FRACTION_MCH_WITH_ITS:=0.7}
+    : ${CUT_RANDOM_FRACTION_MCH_NO_ITS:=0.995}
+elif [[ $BEAMTYPE == "PbPb" ]]; then
+    : ${CUT_RANDOM_FRACTION_MCH_WITH_ITS:=0.9}
+    : ${CUT_RANDOM_FRACTION_MCH_NO_ITS:=0.995}
+else
+    : ${CUT_RANDOM_FRACTION_MCH_WITH_ITS:=0.99}
+    : ${CUT_RANDOM_FRACTION_MCH_NO_ITS:=0.99}
+fi
 
 #if [[ "$HIGH_RATE_PP" == "1" ]]; then
   # Extra settings for HIGH_RATE_PP


### PR DESCRIPTION
Two new environment variables are introduced to provide the fraction of rejected MCH events separately for the cases where ITS is either included (CUT_RANDOM_FRACTION_MCH_WITH_ITS) or excluded (CUT_RANDOM_FRACTION_MCH_NO_ITS) from the data taking.

The CUT_RANDOM_FRACTION_MCH variable, as well as the two new ones, can still be overridden by setting them explicitly in the shell environment, therefore the changes are backward compatible.

JIRA ticket: https://its.cern.ch/jira/browse/MCH-18