### PR TITLE
Fix path to file in consul

### DIFF
--- a/DATA/production/calib/mid-badchannels.sh
+++ b/DATA/production/calib/mid-badchannels.sh
@@ -44,7 +44,7 @@ workflow_has_parameter CTF && {
 add_W o2-mid-calibration-workflow "" "" 0
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path=\"$CCDB_POPULATOR_UPLOAD_PATH\" --sspec-min 0 --sspec-max 0"
 add_W o2-calibration-ccdb-populator-workflow "--ccdb-path=\"$CCDB_POPULATOR_UPLOAD_PATH_DCS\" --sspec-min 1 --sspec-max 1 --name-extention dcs"
-workflow_has_parameter QC && add_QC_from_apricot "/o2/components/qc/ANY/any/mid-calib-qcmn" "--local --host localhost"
+workflow_has_parameter QC && add_QC_from_apricot "components/qc/ANY/any/mid-calib-qcmn" "--local --host localhost"
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 
 if [ "$WORKFLOWMODE" == "print" ]; then


### PR DESCRIPTION
With the PR https://github.com/AliceO2Group/O2DPG/pull/1914 , the MID calibration run was changed in order to use QC files from apricot. However, this led to a bug since the path to consul had to be changed as well.
This PR should solve the issue, allowing to launch calibration runs at P2.