### PR TITLE
Several tooling improvements

### DIFF
--- a/GRID/utils/getReproducerScript.sh
+++ b/GRID/utils/getReproducerScript.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+ALIEN_PID=$1
+
+if [ ${JALIEN_TOKEN_CERT} ]; then
+  TOKENCERT=${JALIEN_TOKEN_CERT}
+  TOKENKEY=${JALIEN_TOKEN_KEY}
+else
+  if [ -f ${TMPDIR:-/tmp}/tokencert_`id -u`.pem ]; then
+    TOKENCERT=${TMPDIR:-/tmp}/tokencert_`id -u`.pem;
+  fi
+  if [ -f ${TMPDIR:-/tmp}/tokenkey_`id -u`.pem ]; then
+    TOKENKEY=${TMPDIR:-/tmp}/tokenkey_`id -u`.pem;
+  fi
+fi
+
+if [ ! ${TOKENCERT} ]; then
+  echo "This needs a tokencert and tokenkey file in the tmp folder"
+  exit 1
+fi
+
+SCRIPT=reproducer_script_${ALIEN_PID}.sh
+# talk to MonaLisa to fetch the script provided by Costin
+curl 'https://alimonitor.cern.ch/users/jobenv.jsp?pid='${ALIEN_PID}                                                                      \
+  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36' \
+  --insecure --cert ${TOKENCERT} --key ${TOKENKEY} -o ${SCRIPT}
+
+# Define the Apptainer injection block which makes sure
+# that the job script is automatically executed in apptainer
+INJECTION='
+export ALIEN_PID=#ALIEN_PID#
+# Check if the script is running inside an Apptainer (Singularity) container
+if [ -z "$APPTAINER_NAME" ] && [ -z "$SINGULARITY_NAME" ]; then
+  # Relaunch this script inside the container
+
+  export WORKDIR=/tmp/foo-${ALIEN_PID}
+  if [ ! -d ${WORKDIR} ]; then
+    mkdir ${WORKDIR}
+  fi
+
+  # - copy the certificate token into /tmp/ inside the container
+  mkdir ${WORKDIR}/tmp
+  cp /tmp/token*pem ${WORKDIR}/tmp
+
+  # - copy the job script into workdir
+  cp $0 ${WORKDIR}
+
+  # detect architecture (ARM or X86)
+  ARCH=$(uname -i)
+  if [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "x86_64" ]; then
+    echo "Detected hardware architecture : $ARCH"
+  else
+    echo "Invalid architecture ${ARCH} detected. Exiting"
+    exit 1
+  fi
+  if [ "$ARCH" == "aarch64" ]; then
+    ISAARCH64="1"
+  fi
+
+  CONTAINER="/cvmfs/alice.cern.ch/containers/fs/apptainer/compat_el9-${ARCH}"
+  APPTAINER_EXEC="/cvmfs/alice.cern.ch/containers/bin/apptainer/${ARCH}/current/bin/apptainer"
+
+  # we can actually analyse the local JDL to find the package and set it up for the container
+  ${APPTAINER_EXEC} exec -C -B /cvmfs:/cvmfs,${WORKDIR}:/workdir,${WORKDIR}/tmp:/tmp --pwd /workdir -C ${CONTAINER} "$0"
+  exit $?
+fi
+'
+
+# Inject the block after the first line (shebang)
+awk -v block="$INJECTION" 'NR==1 {print; print block; next} 1' "$SCRIPT" > tmpfile && mv tmpfile "$SCRIPT"
+
+# take out sandboxing structure
+sed -i "/echo \"Create a fresh sandbox at every attempt of running the job: alien-job-$ALIEN_PID\"/d" "$SCRIPT"
+sed -i "/rm -rf alien-job-$ALIEN_PID/d" "$SCRIPT"
+sed -i "/mkdir -p alien-job-$ALIEN_PID\/tmp/d" "$SCRIPT"
+sed -i "/cd alien-job-$ALIEN_PID/d" "$SCRIPT"
+
+# replace the PID
+sed -i "s/#ALIEN_PID#/${ALIEN_PID}/g" "$SCRIPT"
+
+chmod +x "${SCRIPT}"

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -144,6 +144,13 @@ fi
 [ -z "${CYCLE}" ] && { echo_error "Set CYCLE" ; exit 1 ; }
 [ -z "${PRODSPLIT}" ] && { echo_error "Set PRODSPLIT" ; exit 1 ; }
 
+
+# this generates an exact reproducer script for this job
+# that can be used locally for debugging etc.
+if [[ -n "${ALIEN_PROC_ID}" && -n "${JALIEN_WSPORT}" ]]; then
+  ${O2DPG_ROOT}/GRID/utils/getReproducerScript.sh ${ALIEN_PROC_ID}
+fi
+
 # also for this keep a real default
 NWORKERS=${NWORKERS:-8}
 # set a default seed if not given
@@ -370,7 +377,7 @@ fi
 # full logs tar-ed for output, regardless the error code or validation - to catch also QC logs...
 #
 if [[ -n "$ALIEN_PROC_ID" ]]; then
-  find ./ \( -name "*.log*" -o -name "*mergerlog*" -o -name "*serverlog*" -o -name "*workerlog*" -o -name "pythia8.cfg" \) | tar -czvf debug_log_archive.tgz -T -
+  find ./ \( -name "*.log*" -o -name "*mergerlog*" -o -name "*serverlog*" -o -name "*workerlog*" -o -name "pythia8.cfg" -o -name "reproducer*.sh" \) | tar -czvf debug_log_archive.tgz -T -
   if [[ "$ALIEN_JDL_CREATE_TAR_IN_MC" == "1" ]]; then
     find ./ \( -name "*.log*" -o -name "*mergerlog*" -o -name "*serverlog*" -o -name "*workerlog*" -o -name "*.root" \) | tar -czvf debug_full_archive.tgz -T -
   fi


### PR DESCRIPTION
* cleanup, fixes and adjustments in grid_submit
* a new script getReproducerScript.sh, which downloads a GRID reproducer script and modifies it to ensure automatic execution in apptainer:

  - the script needs a ALIEN_PROC_ID
  - creates a script reproducer_script_${ALIEN_PROC_ID}.sh which executes the job of ALIEN_PROC_ID within an apptainer environment (just as on the GRID)

* anchorMC now creates a reproducer script automatically