### PR TITLE
Add seed number for MC test script

### DIFF
--- a/MC/run/examples/O2DPG_pp_minbias.sh
+++ b/MC/run/examples/O2DPG_pp_minbias.sh
@@ -38,7 +38,7 @@ MEMLIMIT=${MEMLIMIT:+--mem-limit ${MEMLIMIT}}
 CPULIMIT=${CPULIMIT:+--cpu-limit ${CPULIMIT}}
 
 # create workflow
-${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13600  -col pp -gen pythia8 -proc inel -tf ${NTFS} \
+${O2DPG_ROOT}/MC/bin/o2dpg_sim_workflow.py -eCM 13600  -seed 12345 -col pp -gen pythia8 -proc inel -tf ${NTFS} \
                                                        -ns ${NEVENTS} -e ${SIMENGINE} -run 301000  \
                                                        -j ${NWORKERS} -interactionRate ${INTRATE}  \
                                                        --include-qc --include-analysis


### PR DESCRIPTION
Added the seed number to avoid the precollcontext crash. Otherwise a crash on precollcontext:  
`Running: TIME="#walltime %e\n#systime %S\n#usertime %U\n#maxmem %M\n#CPU %P" /usr/bin/time --output=precollcontext.log_time ./precollcontext.log_tmp.sh
the argument ('None') for option '--seed' is invalid`

Please have a look to see if this is ok. 