### PR TITLE
Add switch for synthetic flow in standard gap triggered LF generator

### DIFF
--- a/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGapWithFlow.ini
+++ b/MC/config/PWGLF/ini/GeneratorLFHyperNucleiPbPbGapWithFlow.ini
@@ -1,0 +1,7 @@
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator_pythia8_longlived_gaptriggered_flow.C
+funcName=generateLongLivedGapTriggered("${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGLF/pythia8/generator/hypernuclei_pbpb.gun", 1, 1, 1)
+
+[GeneratorPythia8]
+config=${O2_ROOT}/share/Generators/egconfig/pythia8_hi.cfg
+


### PR DESCRIPTION
@lbariogl this adds a `bool` to the standard LF gap-triggered pythia generator such that flow can be added if desired (default: off). Tested to work just fine; also added a corresponding `ini` file following the nuclei prescription. Let me know if there's something that needs adjusting :-) 

N.B.: all particles will have v2 vs pT set to that of inclusive charged particles. Thus, for nuclei, the objective of a MC generated with flow will be to find out the modulation of the efficiency instead (and not directly the fractional change of the v2 reco vs v2 generated). 