### PR TITLE
MUON: added dataSampling policies for muon tracks in async QC configuration

### DIFF
--- a/DATA/production/qc-async/mftmchmid-tracks.json
+++ b/DATA/production/qc-async/mftmchmid-tracks.json
@@ -67,11 +67,6 @@
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
         "movingWindows": [
-            "MFT-MCH/WithCuts/TracksPerTF",
-            "MFT-MCH/WithCuts/TrackPt",
-            "MFT-MCH/WithCuts/TrackEta",
-            "MFT-MCH/WithCuts/TrackPhi",
-            "MFT-MCH/WithCuts/Minv",
             "MCH-MID/WithCuts/TracksPerTF",
             "MCH-MID/WithCuts/TrackPt",
             "MCH-MID/WithCuts/TrackEta",
@@ -95,7 +90,7 @@
                  "matchChi2MaxMFT": "45",
                  "diMuonTimeCut": "100",
                  "fullHistos": "0",
-                 "GID" : "MCH,MFT-MCH,MCH-MID,MFT-MCH-MID"
+                 "GID" : "MCH-MID,MFT-MCH-MID"
                },
         "grpGeomRequest": {
           "geomRequest": "Aligned",

--- a/DATA/production/qc-async/mftmchmid-tracks.json
+++ b/DATA/production/qc-async/mftmchmid-tracks.json
@@ -11,6 +11,8 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
+          "_type": "dataSamplingPolicy",
+          "name": "muon-tracks",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
         "movingWindows": [
@@ -59,7 +61,9 @@
         "cycleDurationSeconds": "300",
         "maxNumberCycles": "-1",
         "dataSource": {
-          "type": "direct",
+          "_type": "direct",
+          "type": "dataSamplingPolicy",
+          "name": "glo-mu-tracks",
           "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID"
         },
         "movingWindows": [
@@ -106,5 +110,35 @@
         "location": "remote"
       }
     }
-  }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "muon-tracks",
+      "active": "true",
+      "machines": [],
+      "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "0"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "glo-mu-tracks",
+      "active": "true",
+      "machines": [],
+      "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;trackMFT:MFT/TRACKS;trackMFTROF:MFT/MFTTrackROF;trackMFTClIdx:MFT/TRACKCLSID;alpparMFT:MFT/ALPIDEPARAM/0?lifetime=condition&ccdb-path=MFT/Config/AlpideParam;fwdtracks:GLO/GLFWD;trackMID:MID/TRACKS;trackMIDROF:MID/TRACKROFS;trackMIDTRACKCLUSTERS:MID/TRACKCLUSTERS;trackClMIDROF:MID/TRCLUSROFS;matchMCHMID:GLO/MTC_MCHMID",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "0"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
 }


### PR DESCRIPTION
The GLO-MUONTracksMFT QC task has been reported to use 100% CPU in some async reconstructions, thus reducing the overall CPU efficiency of the production.

The input data for this task is now sampled to 10%. A similar sampling is also introduced, but not enabled by default, for the GLO-MUONTracks task.

See https://its.cern.ch/jira/browse/O2-5931 for further details.