### PR TITLE
[PWGHF] Add possibility to replace particles in the stack for HF generator

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -23,9 +23,9 @@ public:
     mGeneratedEvents = 0;
     mInverseTriggerRatio = inputTriggerRatio;
     mQuarkRapidityMin = -1.5;
-    mQuarkRapidityMax = -1.5;
+    mQuarkRapidityMax = 1.5;
     mHadRapidityMin = -1.5;
-    mHadRapidityMax = -1.5;
+    mHadRapidityMax = 1.5;
     mQuarkPdg = 0;
     mHadronPdg = 0;
     mQuarkPdgList = quarkPdgList;
@@ -266,7 +266,6 @@ protected:
     }
 
     int charge = mPythia.event[iPartToReplace].id() / std::abs(mPythia.event[iPartToReplace].id());
-    int status = mPythia.event[iPartToReplace].status();
     float px = mPythia.event[iPartToReplace].px();
     float py = mPythia.event[iPartToReplace].py();
     float pz = mPythia.event[iPartToReplace].pz();
@@ -293,12 +292,15 @@ protected:
     mPythia.event[iPartToReplace].undoDecay();
     mPythia.event.remove(iPartToReplace, iPartToReplace, true); // we remove the original particle
 
+    int status = std::abs(mPythia.event[iPartToReplace].status());
+    if (status < 81) {
+      status = 81;
+    }
     mPythia.event.append(charge * pdgCodeNew, status, mothers[0], mothers[1], 0, 0, 0, 0, px, py, pz, energy, mass);
     mPythia.moreDecays(); // we need to decay the new particle
+
     return true;
   }
-
-  // id:all = name antiName spinType chargeType colType m0 mWidth mMin mMax tau0
 
   private:
   // Interface to override import particles

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -2,6 +2,7 @@
 #include "Generators/GeneratorPythia8.h"
 #include "Pythia8/Pythia.h"
 #include "TRandom.h"
+#include "TDatabasePDG.h"
 #include <fairlogger/Logger.h>
 
 #include <string>
@@ -16,7 +17,7 @@ public:
   GeneratorPythia8GapTriggeredHF() = default;
 
   /// constructor
-  GeneratorPythia8GapTriggeredHF(int inputTriggerRatio = 5, std::vector<int> quarkPdgList = {}, std::vector<int> hadronPdgList = {})
+  GeneratorPythia8GapTriggeredHF(int inputTriggerRatio = 5, std::vector<int> quarkPdgList = {}, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {})
   {
 
     mGeneratedEvents = 0;
@@ -29,8 +30,22 @@ public:
     mHadronPdg = 0;
     mQuarkPdgList = quarkPdgList;
     mHadronPdgList = hadronPdgList;
+    mPartPdgToReplaceList = partPdgToReplaceList;
+    mFreqReplaceList = freqReplaceList;
+    // Ds1*(2700), Ds1*(2860), Ds3*(2860), Xic(3055), Xic(3080)
+    mCustomPartPdgs = {30433, 40433, 437, 4325, 4326};
+    mCustomPartMasses[30433] = 2.714f;
+    mCustomPartMasses[40433] =  2.859f;
+    mCustomPartMasses[437] = 2.860f;
+    mCustomPartMasses[4325] = 3.0559f;
+    mCustomPartMasses[4326] = 3.0772f;
+    mCustomPartWidths[30433] = 0.122f;
+    mCustomPartWidths[40433] =  0.160f;
+    mCustomPartWidths[437] = 0.053f;
+    mCustomPartWidths[4325] = 0.0078f;
+    mCustomPartWidths[4326] = 0.0036f;
     Print();
-  }
+  }  
 
   ///  Destructor
   ~GeneratorPythia8GapTriggeredHF() = default;
@@ -54,6 +69,11 @@ public:
     {
       LOG(info)<<Form("* %d ", pdg);
     }
+    LOG(info)<<Form("* Replacements: ");
+    for (auto iRepl{0u}; iRepl<mPartPdgToReplaceList.size(); ++iRepl)
+    {
+      LOGP(info, "* {} -> {} (freq. {})", mPartPdgToReplaceList[iRepl].at(0), mPartPdgToReplaceList[iRepl].at(1), mFreqReplaceList[iRepl]);
+    }
     LOG(info)<<"***********************************************************************";
   }
 
@@ -62,6 +82,21 @@ public:
     addSubGenerator(0, "Minimum bias");
     addSubGenerator(4, "Charm injected");
     addSubGenerator(5, "Beauty injected");
+
+    std::vector<int> pdgToReplace{};
+    for (auto iRepl{0u}; iRepl<mPartPdgToReplaceList.size(); ++iRepl)
+    {
+      for (auto iPdgRep{0u}; iPdgRep<pdgToReplace.size(); ++iPdgRep) {
+        if (mPartPdgToReplaceList[iRepl].at(0) == pdgToReplace[iPdgRep]) {
+          mFreqReplaceList[iRepl] += mFreqReplaceList[iPdgRep];
+        }
+      }
+      if (mFreqReplaceList[iRepl] > 1.f) {
+        LOGP(fatal, "Replacing more than 100% of a particle!");
+      }
+      pdgToReplace.push_back(mPartPdgToReplaceList[iRepl].at(0));
+    }
+
     return o2::eventgen::GeneratorPythia8::Init();
   }
 
@@ -115,7 +150,7 @@ protected:
       {
         if (GeneratorPythia8::generateEvent())
         {
-          genOk = selectEvent(mPythia.event);
+          genOk = selectEvent();
         }
       }
       notifySubGenerator(mQuarkPdg);
@@ -136,34 +171,35 @@ protected:
     return true;
   }
 
-  bool selectEvent(const Pythia8::Event &event)
+  bool selectEvent()
   {
 
     bool isGoodAtPartonLevel{mQuarkPdgList.size() == 0};
     bool isGoodAtHadronLevel{mHadronPdgList.size() == 0};
+    bool anyPartToReplace{mPartPdgToReplaceList.size() > 0};
 
-    for (auto iPart{0}; iPart < event.size(); ++iPart)
+    for (auto iPart{0}; iPart < mPythia.event.size(); ++iPart)
     {
 
       // search for Q-Qbar mother with at least one Q in rapidity window
       if (!isGoodAtPartonLevel)
       {
-        auto daughterList = event[iPart].daughterList();
+        auto daughterList = mPythia.event[iPart].daughterList();
         bool hasQ = false, hasQbar = false, atSelectedY = false;
         for (auto iDau : daughterList)
         {
-          if (event[iDau].id() == mQuarkPdg)
+          if (mPythia.event[iDau].id() == mQuarkPdg)
           {
             hasQ = true;
-            if ((event[iDau].y() > mQuarkRapidityMin) && (event[iDau].y() < mQuarkRapidityMax))
+            if ((mPythia.event[iDau].y() > mQuarkRapidityMin) && (mPythia.event[iDau].y() < mQuarkRapidityMax))
             {
               atSelectedY = true;
             }
           }
-          if (event[iDau].id() == -mQuarkPdg)
+          if (mPythia.event[iDau].id() == -mQuarkPdg)
           {
             hasQbar = true;
-            if ((event[iDau].y() > mQuarkRapidityMin) && (event[iDau].y() < mQuarkRapidityMax))
+            if ((mPythia.event[iDau].y() > mQuarkRapidityMin) && (mPythia.event[iDau].y() < mQuarkRapidityMax))
             {
               atSelectedY = true;
             }
@@ -178,26 +214,89 @@ protected:
       // search for hadron in rapidity window
       if (!isGoodAtHadronLevel)
       {
-        int id = std::abs(event[iPart].id());
-        float rap = event[iPart].y();
+        int id = std::abs(mPythia.event[iPart].id());
+        float rap = mPythia.event[iPart].y();
         if (id == mHadronPdg && rap > mHadRapidityMin && rap < mHadRapidityMax)
         {
           isGoodAtHadronLevel = true;
         }
       }
 
-      // we send the trigger
-      if (isGoodAtPartonLevel && isGoodAtHadronLevel)
+      // if requested, we replace the particle
+      const double pseudoRndm = mPythia.event[iPart].pT() * 1000. - (int64_t)(mPythia.event[iPart].pT() * 1000);
+      for (auto iPartToReplace{0u}; iPartToReplace<mPartPdgToReplaceList.size(); ++iPartToReplace) {
+        if (std::abs(mPythia.event[iPart].id()) == mPartPdgToReplaceList[iPartToReplace][0] && pseudoRndm < mFreqReplaceList[iPartToReplace]) {
+          LOGP(debug, "REPLACING PARTICLE {} WITH {}, BEING RNDM {}", mPartPdgToReplaceList[iPartToReplace][0], mPartPdgToReplaceList[iPartToReplace][1], pseudoRndm);
+          replaceParticle(iPart, mPartPdgToReplaceList[iPartToReplace][1]);
+          break;
+        }
+      }
+
+      // we send the trigger immediately (if there are no particles to replace, that can be different from the trigger ones)
+      if (isGoodAtPartonLevel && isGoodAtHadronLevel && !anyPartToReplace)
       {
-        LOG(debug)<<"EVENT SELECTED: Found particle "<<event[iPart].id()<<" at rapidity "<<event[iPart].y()<<"\n";
+        LOG(debug)<<"EVENT SELECTED: Found particle "<<mPythia.event[iPart].id()<<" at rapidity "<<mPythia.event[iPart].y()<<"\n";
         return true;
       }
+    }
+
+    // we send the trigger
+    if (isGoodAtPartonLevel && isGoodAtHadronLevel) {
+      return true;
     }
 
     return false;
   };
 
-private:
+  bool replaceParticle(int iPartToReplace, int pdgCodeNew) {
+
+    std::array<int, 2> mothers = {mPythia.event[iPartToReplace].mother1(), mPythia.event[iPartToReplace].mother2()};
+
+    std::array<int, 25> pdgDiquarks = {1103, 2101, 2103, 2203, 3101, 3103, 3201, 3203, 3303, 4101, 4103, 4201, 4203, 4301, 4303, 4403, 5101, 5103, 5201, 5203, 5301, 5303, 5401, 5403, 5503};
+
+    for (auto const& mother: mothers) {
+      auto pdgMother = std::abs(mPythia.event[mother].id());
+      if (pdgMother > 100 && std::find(pdgDiquarks.begin(), pdgDiquarks.end(), pdgMother) == pdgDiquarks.end()) {
+        return false;
+      }
+    }
+
+    int charge = mPythia.event[iPartToReplace].id() / std::abs(mPythia.event[iPartToReplace].id());
+    int status = mPythia.event[iPartToReplace].status();
+    float px = mPythia.event[iPartToReplace].px();
+    float py = mPythia.event[iPartToReplace].py();
+    float pz = mPythia.event[iPartToReplace].pz();
+    float mass = 0.f;
+
+    if (std::find(mCustomPartPdgs.begin(), mCustomPartPdgs.end(), pdgCodeNew) == mCustomPartPdgs.end()) { // not a custom particle
+      float width = TDatabasePDG::Instance()->GetParticle(pdgCodeNew)->Width();
+      float massRest = TDatabasePDG::Instance()->GetParticle(pdgCodeNew)->Mass();
+      if (width > 0.f) {
+        mass = gRandom->BreitWigner(massRest, width);
+      } else {
+        mass = massRest;
+      }
+    } else {
+      if (mCustomPartWidths[pdgCodeNew] > 0.f) {
+        mass = gRandom->BreitWigner(mCustomPartMasses[pdgCodeNew], mCustomPartWidths[pdgCodeNew]);
+      } else {
+        mass = mCustomPartMasses[pdgCodeNew];
+      }
+    }
+    float energy = std::sqrt(px*px + py*py + pz*pz + mass*mass);
+
+    mPythia.event.remove(iPartToReplace, iPartToReplace, true); // we remove the original particle
+    mPythia.event.append(charge * pdgCodeNew, status, 0, 0, 0, 0, 0, 0, px, py, pz, energy, mass);
+    mPythia.event[mPythia.event.size()-1].mother1(mothers[0]);
+    mPythia.event[mPythia.event.size()-1].mother2(mothers[1]);
+    mPythia.moreDecays(); // we need to decay the new particle
+
+    return true;
+  }
+
+  // id:all = name antiName spinType chargeType colType m0 mWidth mMin mMax tau0
+
+  private:
   // Interface to override import particles
   Pythia8::Event mOutputEvent;
 
@@ -209,6 +308,11 @@ private:
   float mHadRapidityMin;
   float mHadRapidityMax;
   unsigned int mUsedSeed;
+  std::vector<std::array<int, 2>> mPartPdgToReplaceList;
+  std::vector<float> mFreqReplaceList;
+  std::vector<int> mCustomPartPdgs;
+  std::map<int, float> mCustomPartMasses;
+  std::map<int, float> mCustomPartWidths;
 
   // Control gap-triggering
   unsigned long long mGeneratedEvents;
@@ -223,9 +327,9 @@ private:
 
 // Predefined generators:
 // Charm-enriched
-FairGenerator *GeneratorPythia8GapTriggeredCharm(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {})
+FairGenerator *GeneratorPythia8GapTriggeredCharm(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {})
 {
-  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{4}, hadronPdgList);
+  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{4}, hadronPdgList, partPdgToReplaceList, freqReplaceList);
   auto seed = (gRandom->TRandom::GetSeed() % 900000000);
   myGen->setUsedSeed(seed);
   myGen->readString("Random:setSeed on");
@@ -239,9 +343,9 @@ FairGenerator *GeneratorPythia8GapTriggeredCharm(int inputTriggerRatio, float yQ
 }
 
 // Beauty-enriched
-FairGenerator *GeneratorPythia8GapTriggeredBeauty(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {})
+FairGenerator *GeneratorPythia8GapTriggeredBeauty(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {})
 {
-  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{5}, hadronPdgList);
+  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{5}, hadronPdgList, partPdgToReplaceList, freqReplaceList);
   auto seed = (gRandom->TRandom::GetSeed() % 900000000);
   myGen->setUsedSeed(seed);
   myGen->readString("Random:setSeed on");
@@ -255,9 +359,9 @@ FairGenerator *GeneratorPythia8GapTriggeredBeauty(int inputTriggerRatio, float y
 }
 
 // Charm and beauty enriched (with same ratio)
-FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeauty(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {})
+FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeauty(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {})
 {
-  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{4, 5}, hadronPdgList);
+  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{4, 5}, hadronPdgList, partPdgToReplaceList, freqReplaceList);
   auto seed = (gRandom->TRandom::GetSeed() % 900000000);
   myGen->setUsedSeed(seed);
   myGen->readString("Random:setSeed on");
@@ -270,13 +374,13 @@ FairGenerator *GeneratorPythia8GapTriggeredCharmAndBeauty(int inputTriggerRatio,
   return myGen;
 }
 
-FairGenerator *GeneratorPythia8GapHF(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> quarkPdgList = {}, std::vector<int> hadronPdgList = {})
+FairGenerator *GeneratorPythia8GapHF(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> quarkPdgList = {}, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {})
 {
   if (hadronPdgList.size() == 0 && quarkPdgList.size() == 0)
   {
     LOG(fatal) << "GeneratorPythia8GapHF: At least one quark or hadron PDG code must be specified";
   }
-  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, quarkPdgList, hadronPdgList);
+  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, quarkPdgList, hadronPdgList, partPdgToReplaceList, freqReplaceList);
   auto seed = (gRandom->TRandom::GetSeed() % 900000000);
   myGen->setUsedSeed(seed);
   myGen->readString("Random:setSeed on");

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -32,20 +32,24 @@ public:
     mHadronPdgList = hadronPdgList;
     mPartPdgToReplaceList = partPdgToReplaceList;
     mFreqReplaceList = freqReplaceList;
-    // Ds1*(2700), Ds1*(2860), Ds3*(2860), Xic(3055), Xic(3080)
-    mCustomPartPdgs = {30433, 40433, 437, 4325, 4326};
+    // Ds1*(2700), Ds1*(2860), Ds3*(2860), Xic(3055)+, Xic(3080)+, Xic(3055)0, Xic(3080)0
+    mCustomPartPdgs = {30433, 40433, 437, 4315, 4316, 4325, 4326};
     mCustomPartMasses[30433] = 2.714f;
     mCustomPartMasses[40433] =  2.859f;
     mCustomPartMasses[437] = 2.860f;
+    mCustomPartMasses[4315] = 3.0590f;
+    mCustomPartMasses[4316] = 3.0799f;
     mCustomPartMasses[4325] = 3.0559f;
     mCustomPartMasses[4326] = 3.0772f;
     mCustomPartWidths[30433] = 0.122f;
     mCustomPartWidths[40433] =  0.160f;
     mCustomPartWidths[437] = 0.053f;
+    mCustomPartWidths[4315] = 0.0064f;
+    mCustomPartWidths[4316] = 0.0056f;
     mCustomPartWidths[4325] = 0.0078f;
     mCustomPartWidths[4326] = 0.0036f;
     Print();
-  }  
+  }    
 
   ///  Destructor
   ~GeneratorPythia8GapTriggeredHF() = default;
@@ -285,10 +289,12 @@ protected:
     }
     float energy = std::sqrt(px*px + py*py + pz*pz + mass*mass);
 
+    // we remove particle to replace and its daughters
+    mPythia.event[iPartToReplace].undoDecay();
     mPythia.event.remove(iPartToReplace, iPartToReplace, true); // we remove the original particle
+
     mPythia.event.append(charge * pdgCodeNew, status, mothers[0], mothers[1], 0, 0, 0, 0, px, py, pz, energy, mass);
     mPythia.moreDecays(); // we need to decay the new particle
-
     return true;
   }
 

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -286,9 +286,7 @@ protected:
     float energy = std::sqrt(px*px + py*py + pz*pz + mass*mass);
 
     mPythia.event.remove(iPartToReplace, iPartToReplace, true); // we remove the original particle
-    mPythia.event.append(charge * pdgCodeNew, status, 0, 0, 0, 0, 0, 0, px, py, pz, energy, mass);
-    mPythia.event[mPythia.event.size()-1].mother1(mothers[0]);
-    mPythia.event[mPythia.event.size()-1].mother2(mothers[1]);
+    mPythia.event.append(charge * pdgCodeNew, status, mothers[0], mothers[1], 0, 0, 0, 0, px, py, pz, energy, mass);
     mPythia.moreDecays(); // we need to decay the new particle
 
     return true;

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -293,7 +293,7 @@ protected:
     mPythia.event.remove(iPartToReplace, iPartToReplace, true); // we remove the original particle
 
     int status = std::abs(mPythia.event[iPartToReplace].status());
-    if (status < 81) {
+    if (status < 81 || status > 89) {
       status = 81;
     }
     mPythia.event.append(charge * pdgCodeNew, status, mothers[0], mothers[1], 0, 0, 0, 0, px, py, pz, energy, mass);

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.ini
@@ -1,0 +1,8 @@
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {10433, 435}, {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}}, {0.1, 0.1, 0.1, 0.1})
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg
+includePartonEvent=true

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.ini
@@ -1,7 +1,7 @@
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
-funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {10433, 435}, {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}}, {0.1, 0.1, 0.1, 0.1})
+funcName=GeneratorPythia8GapTriggeredCharmAndBeauty(5, -1.5, 1.5, -1.5, 1.5, {10433, 435}, {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}, {425, 4315}, {425, 4316}}, {0.1, 0.1, 0.1, 0.1, 0.5, 0.5})
 
 [GeneratorPythia8]
 config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -82,13 +82,15 @@ int External() {
 
                 std::vector<int> pdgsDecay{};
                 std::vector<int> pdgsDecayAntiPart{};
-                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
-                    auto pdgDau = tracks->at(j).GetPdgCode();
-                    pdgsDecay.push_back(pdgDau);
-                    if (pdgDau != 333) { // phi is antiparticle of itself
-                        pdgsDecayAntiPart.push_back(-pdgDau);
-                    } else {
-                        pdgsDecayAntiPart.push_back(pdgDau);
+                if (track.getFirstDaughterTrackId() >= 0 && track.getLastDaughterTrackId() >= 0) {
+                    for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                        auto pdgDau = tracks->at(j).GetPdgCode();
+                        pdgsDecay.push_back(pdgDau);
+                        if (pdgDau != 333) { // phi is antiparticle of itself
+                            pdgsDecayAntiPart.push_back(-pdgDau);
+                        } else {
+                            pdgsDecayAntiPart.push_back(pdgDau);
+                        }
                     }
                 }
 

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -1,0 +1,150 @@
+int External() {
+    std::string path{"o2sim_Kine.root"};
+
+    int checkPdgQuarkOne{4};
+    int checkPdgQuarkTwo{5};
+    float ratioTrigger = 1./5.; // one event triggered out of 5
+    std::array<std::array<int, 2>, 4> pdgReplParticles = {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}};
+    std::array<std::array<int, 2>, 4> pdgReplPartCounters = {{0, 0}, {0, 0}, {0, 0}, {0, 0}};
+    std::array<float, 4> freqRepl = {0.1, 0.1, 0.1, 0.1}; // one event triggered out of 5
+
+    std::vector<int> checkPdgHadron{10433, 30433, 435, 437, 4325, 4326};
+    std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
+        {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
+        {435, {{311, 413}, {311, 411}}}, // Ds2*(2573)
+        {10433, {{311, 413}}}, // Ds1(2536)
+        {30433, {{311, 413}}}, // Ds1*(2700)
+        {437, {{311, 413}}}, // Ds3*(2860)
+        {4325, {{411, 3122}}}, // Xic(3055)
+        {4326, {{411, 3122}}}, // Xic(3080)
+        {531, {{-435, -11, 12}, {-10433, -11, 12}, {-435, -13, 14}, {-10433, -13, 14}, {-435, -15, 16}, {-10433, -15, 16}, {-435, 211}}}// Bs0
+    };
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsMB{}, nEventsInjOne{}, nEventsInjTwo{};
+    int nQuarksOne{}, nQuarksTwo{}, nSignals{}, nSignalGoodDecay{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == 0) {
+                nEventsMB++;
+            } else if (subGeneratorId == checkPdgQuarkOne) {
+                nEventsInjOne++;
+            } else if (subGeneratorId == checkPdgQuarkTwo) {
+                nEventsInjTwo++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            auto absPdg = std::abs(pdg);
+            if (absPdg == checkPdgQuarkOne) {
+                nQuarksOne++;
+                continue;
+            }
+            if (absPdg == checkPdgQuarkTwo) {
+                nQuarksTwo++;
+                continue;
+            }
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+                nSignals++; // count signal PDG
+
+                if (subGeneratorId == checkPdgQuarkOne) { // replacement only for prompt
+                    for (int iRepl{0}; iRepl<4; ++iRepl) {
+                        if (absPdg == pdgReplParticles[iRepl][0]) {
+                            pdgReplPartCounters[iRepl][0]++;
+                        } else if (absPdg == pdgReplParticles[iRepl][1]) {
+                            pdgReplPartCounters[iRepl][1]++;
+                        }
+                    }
+                }
+
+                std::vector<int> pdgsDecay{};
+                std::vector<int> pdgsDecayAntiPart{};
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    pdgsDecay.push_back(pdgDau);
+                    if (pdgDau != 333) { // phi is antiparticle of itself
+                        pdgsDecayAntiPart.push_back(-pdgDau);
+                    } else {
+                        pdgsDecayAntiPart.push_back(pdgDau);
+                    }
+                }
+
+                std::sort(pdgsDecay.begin(), pdgsDecay.end());
+                std::sort(pdgsDecayAntiPart.begin(), pdgsDecayAntiPart.end());
+
+                for (auto &decay : checkHadronDecays[std::abs(pdg)]) {
+                    if (pdgsDecay == decay || pdgsDecayAntiPart == decay) {
+                        nSignalGoodDecay++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << "# MB events: " << nEventsMB << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkOne) << nEventsInjOne << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuarkTwo) << nEventsInjTwo << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkOne) << nQuarksOne << "\n";
+    std::cout << Form("# %d (anti)quarks: ", checkPdgQuarkTwo) << nQuarksTwo << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+
+    if (nEventsMB < nEvents * (1 - ratioTrigger) * 0.95 || nEventsMB > nEvents * (1 - ratioTrigger) * 1.05) { // we put some tolerance since the number of generated events is small
+        std::cerr << "Number of generated MB events different than expected\n";
+        return 1;
+    }
+    if (nEventsInjOne < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjOne > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkOne << " different than expected\n";
+        return 1;
+    }
+    if (nEventsInjTwo < nEvents * ratioTrigger * 0.5 * 0.95 || nEventsInjTwo > nEvents * ratioTrigger * 0.5 * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuarkTwo << " different than expected\n";
+        return 1;
+    }
+
+    if (nQuarksOne < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkOne << " lower than expected\n";
+        return 1;
+    }
+    if (nQuarksTwo < nEvents * ratioTrigger) { // we expect anyway more because the same quark is repeated several time, after each gluon radiation
+        std::cerr << "Number of generated (anti)quarks " << checkPdgQuarkTwo << " lower than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = float(nSignalGoodDecay) / nSignals;
+    if (fracForcedDecays < 0.9) { // we put some tolerance (e.g. due to oscillations which might change the final state)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    for (int iRepl{0}; iRepl<4; ++iRepl) {
+        if (std::abs(pdgReplPartCounters[iRepl][1] - freqRepl[iRepl] * pdgReplPartCounters[iRepl][0]) > 2 * std::sqrt(freqRepl[iRepl] * pdgReplPartCounters[iRepl][0])) { // 2 sigma compatibility
+            std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << pdgReplPartCounters[iRepl][1] / pdgReplPartCounters[iRepl][0] <<" (expected "<< freqRepl[iRepl] << ")\n";
+            return 1;    
+        }
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -7,6 +7,7 @@ int External() {
     std::array<std::array<int, 2>, 6> pdgReplParticles = {std::array{10433, 30433}, std::array{10433, 437}, std::array{435, 4325}, std::array{435, 4326}, std::array{425, 4315}, std::array{425, 4316}};
     std::array<std::array<int, 2>, 6> pdgReplPartCounters = {std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}};
     std::array<float, 6> freqRepl = {0.1, 0.1, 0.1, 0.1, 0.5, 0.5};
+    std::map<int, int> sumOrigReplacedParticles = {{10433, 0}, {435, 0}, {425, 0}};
 
     std::array<int, 11> checkPdgHadron{411, 421, 10433, 30433, 435, 437, 4325, 4326, 4315, 4316, 531};
     std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
@@ -74,8 +75,10 @@ int External() {
                     for (int iRepl{0}; iRepl<6; ++iRepl) {
                         if (absPdg == pdgReplParticles[iRepl][0]) {
                             pdgReplPartCounters[iRepl][0]++;
+                            sumOrigReplacedParticles[pdgReplParticles[iRepl][0]]++;
                         } else if (absPdg == pdgReplParticles[iRepl][1]) {
                             pdgReplPartCounters[iRepl][1]++;
+                            sumOrigReplacedParticles[pdgReplParticles[iRepl][0]]++;
                         }
                     }
                 }
@@ -146,8 +149,12 @@ int External() {
     }
 
     for (int iRepl{0}; iRepl<6; ++iRepl) {
-        if (std::abs(pdgReplPartCounters[iRepl][1] - freqRepl[iRepl] * pdgReplPartCounters[iRepl][0]) > 2 * std::sqrt(freqRepl[iRepl] * pdgReplPartCounters[iRepl][0])) { // 2 sigma compatibility
-            std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << float(pdgReplPartCounters[iRepl][1]) / pdgReplPartCounters[iRepl][0] <<" (expected "<< freqRepl[iRepl] << ")\n";
+        if (std::abs(pdgReplPartCounters[iRepl][1] - freqRepl[iRepl] * sumOrigReplacedParticles[pdgReplParticles[iRepl][0]]) > 2 * std::sqrt(freqRepl[iRepl] * sumOrigReplacedParticles[pdgReplParticles[iRepl][0]])) { // 2 sigma compatibility
+            float fracMeas = 0.;
+            if (sumOrigReplacedParticles[pdgReplParticles[iRepl][0]] > 0.) {
+                fracMeas = float(pdgReplPartCounters[iRepl][1]) / sumOrigReplacedParticles[pdgReplParticles[iRepl][0]];
+            } 
+            std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << fracMeas <<" (expected "<< freqRepl[iRepl] << ")\n";
             return 1;    
         }
     }

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -1,14 +1,14 @@
 int External() {
-    std::string path{"o2sim_Kine.root"};
+    std::string path{"tf1/sgn_Kine.root"};
 
     int checkPdgQuarkOne{4};
     int checkPdgQuarkTwo{5};
     float ratioTrigger = 1./5.; // one event triggered out of 5
-    std::array<std::array<int, 2>, 6> pdgReplParticles = {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}, {425, 4315}, {425, 4316}};
-    std::array<std::array<int, 2>, 6> pdgReplPartCounters = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
-    std::array<float, 4> freqRepl = {0.1, 0.1, 0.1, 0.1, 0.5, 0.5}; // one event triggered out of 5
+    std::array<std::array<int, 2>, 6> pdgReplParticles = {std::array{10433, 30433}, std::array{10433, 437}, std::array{435, 4325}, std::array{435, 4326}, std::array{425, 4315}, std::array{425, 4316}};
+    std::array<std::array<int, 2>, 6> pdgReplPartCounters = {std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}, std::array{0, 0}};
+    std::array<float, 6> freqRepl = {0.1, 0.1, 0.1, 0.1, 0.5, 0.5};
 
-    std::vector<int> checkPdgHadron{10433, 30433, 435, 437, 4325, 4326, 4315, 4316};
+    std::array<int, 11> checkPdgHadron{411, 421, 10433, 30433, 435, 437, 4325, 4326, 4315, 4316, 531};
     std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
         {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
         {421, {{-321, 211}, {-321, 211, 111}}}, // D0
@@ -43,9 +43,10 @@ int External() {
         tree->GetEntry(i);
 
         // check subgenerator information
+        int subGeneratorId{-1};
         if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
             bool isValid = false;
-            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
             if (subGeneratorId == 0) {
                 nEventsMB++;
             } else if (subGeneratorId == checkPdgQuarkOne) {
@@ -66,11 +67,11 @@ int External() {
                 nQuarksTwo++;
                 continue;
             }
-            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), absPdg) != checkPdgHadron.end()) { // found signal
                 nSignals++; // count signal PDG
 
                 if (subGeneratorId == checkPdgQuarkOne) { // replacement only for prompt
-                    for (int iRepl{0}; iRepl<4; ++iRepl) {
+                    for (int iRepl{0}; iRepl<6; ++iRepl) {
                         if (absPdg == pdgReplParticles[iRepl][0]) {
                             pdgReplPartCounters[iRepl][0]++;
                         } else if (absPdg == pdgReplParticles[iRepl][1]) {
@@ -142,7 +143,7 @@ int External() {
         return 1;
     }
 
-    for (int iRepl{0}; iRepl<4; ++iRepl) {
+    for (int iRepl{0}; iRepl<6; ++iRepl) {
         if (std::abs(pdgReplPartCounters[iRepl][1] - freqRepl[iRepl] * pdgReplPartCounters[iRepl][0]) > 2 * std::sqrt(freqRepl[iRepl] * pdgReplPartCounters[iRepl][0])) { // 2 sigma compatibility
             std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << pdgReplPartCounters[iRepl][1] / pdgReplPartCounters[iRepl][0] <<" (expected "<< freqRepl[iRepl] << ")\n";
             return 1;    

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -147,7 +147,7 @@ int External() {
 
     for (int iRepl{0}; iRepl<6; ++iRepl) {
         if (std::abs(pdgReplPartCounters[iRepl][1] - freqRepl[iRepl] * pdgReplPartCounters[iRepl][0]) > 2 * std::sqrt(freqRepl[iRepl] * pdgReplPartCounters[iRepl][0])) { // 2 sigma compatibility
-            std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << pdgReplPartCounters[iRepl][1] / pdgReplPartCounters[iRepl][0] <<" (expected "<< freqRepl[iRepl] << ")\n";
+            std::cerr << "Fraction of replaced " << pdgReplParticles[iRepl][0] << " into " << pdgReplParticles[iRepl][1] << " is " << float(pdgReplPartCounters[iRepl][1]) / pdgReplPartCounters[iRepl][0] <<" (expected "<< freqRepl[iRepl] << ")\n";
             return 1;    
         }
     }

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -4,19 +4,22 @@ int External() {
     int checkPdgQuarkOne{4};
     int checkPdgQuarkTwo{5};
     float ratioTrigger = 1./5.; // one event triggered out of 5
-    std::array<std::array<int, 2>, 4> pdgReplParticles = {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}};
-    std::array<std::array<int, 2>, 4> pdgReplPartCounters = {{0, 0}, {0, 0}, {0, 0}, {0, 0}};
-    std::array<float, 4> freqRepl = {0.1, 0.1, 0.1, 0.1}; // one event triggered out of 5
+    std::array<std::array<int, 2>, 6> pdgReplParticles = {{10433, 30433}, {10433, 437}, {435, 4325}, {435, 4326}, {425, 4315}, {425, 4316}};
+    std::array<std::array<int, 2>, 6> pdgReplPartCounters = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
+    std::array<float, 4> freqRepl = {0.1, 0.1, 0.1, 0.1, 0.5, 0.5}; // one event triggered out of 5
 
-    std::vector<int> checkPdgHadron{10433, 30433, 435, 437, 4325, 4326};
+    std::vector<int> checkPdgHadron{10433, 30433, 435, 437, 4325, 4326, 4315, 4316};
     std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
         {411, {{-321, 211, 211}, {-313, 211}, {211, 311}, {211, 333}}}, // D+
+        {421, {{-321, 211}, {-321, 211, 111}}}, // D0
         {435, {{311, 413}, {311, 411}}}, // Ds2*(2573)
         {10433, {{311, 413}}}, // Ds1(2536)
         {30433, {{311, 413}}}, // Ds1*(2700)
         {437, {{311, 413}}}, // Ds3*(2860)
-        {4325, {{411, 3122}}}, // Xic(3055)
-        {4326, {{411, 3122}}}, // Xic(3080)
+        {4325, {{411, 3122}}}, // Xic(3055)+
+        {4326, {{411, 3122}}}, // Xic(3080)+
+        {4315, {{421, 3122}}}, // Xic(3055)+
+        {4316, {{421, 3122}}}, // Xic(3080)+
         {531, {{-435, -11, 12}, {-10433, -11, 12}, {-435, -13, 14}, {-10433, -13, 14}, {-435, -15, 16}, {-10433, -15, 16}, {-435, 211}}}// Bs0
     };
 

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_ccbar_and_bbbar_gap5_DResoTrigger.C
@@ -1,5 +1,5 @@
 int External() {
-    std::string path{"tf1/sgn_Kine.root"};
+    std::string path{"o2sim_Kine.root"};
 
     int checkPdgQuarkOne{4};
     int checkPdgQuarkTwo{5};

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg
@@ -1,0 +1,136 @@
+### author: Stefano Politano, Luca Aglietta (stefano.politano@cern.ch, luca.aglietta@cern.ch)
+### since:  July 2024
+
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13600. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+# parameters to boost resonances production
+StringFlav:mesonCL1S0J1= 3 
+StringFlav:mesonCL1S1J2= 5
+
+### add resonances not present in PYTHIA
+### id:all = name antiName spinType chargeType colType m0 mWidth mMin mMax tau0
+### Ds1*(2700)
+30433:all = D*_s1(2700)+ D*_s1(2700)- 3 3 0 2.714 0.122 2.51 10. 0.
+30433:mayDecay = on
+
+### Ds1*(2860)
+40433:all = D*_s1(2860)+ D*_s1(2860)- 3 3 0 2.859 0.160 2.51 10. 0.
+40433:mayDecay = on
+
+### Ds3*(2860)
+437:all = D*_s3(2860)+ D*_s3(2860)- 7 3 0 2.860 0.053 2.51 10. 0.
+437:mayDecay = on
+
+### Xic(3055)
+4325:all = Xi_c(3055)+ Xi_cbar(3055)- 4 3 0 3.0559 0.0078 2.986 10. 0.
+4325:mayDecay = on
+
+### Xic(3080)
+4326:all = Xi_c(3080)+ Xi_cbar(3080)- 2 3 0 3.0772 0.0036 2.986 10. 0.
+4326:mayDecay = on
+
+### turn off all charm resonances decays
+10433:onMode = off  # Ds1(2536)
+435:onMode = off    # Ds2*(2573)
+30433:onMode = off  # Ds1*(2700)
+40433:onMode = off  # Ds1*(2860)
+437:onMode = off  # Ds3*(2860)
+4325:onMode = off  # Xic(3055)
+4326:onMode = off  # Xic(3080)
+
+### turn off all beauty hadron decays
+531:onMode = off
+521:onMode = off
+
+### add Ds1(2536)
+10433:oneChannel = 1 1 0 413 311
+10433:onIfMatch = 413 311
+
+### add Ds2*(2573)
+435:oneChannel = 1 0.1000000 0 413 311
+435:addChannel = 1 0.9000000 0 411 311
+435:onIfMatch = 413 311
+435:onIfMatch = 411 311
+
+### add Ds1*(2700)
+30433:oneChannel = 1 1 0 413 311
+30433:onIfMatch = 413 311
+
+### add Ds1*(2860)
+40433:oneChannel = 1 1 0 413 311
+40433:onIfMatch = 413 311
+
+### add Ds3*(2860)
+437:oneChannel = 1 1 0 413 311
+437:onIfMatch = 413 311
+
+### add Xic(3055)
+4325:oneChannel = 1 1 0 411 3122
+4325:onIfMatch = 411 3122
+
+### add Xic(3080)
+4326:oneChannel = 1 1 0 411 3122
+4326:onIfMatch = 411 3122
+
+### add Bs0
+531:oneChannel = 1 0.0070000 0 12 -11 -435 
+531:addChannel = 1 0.0070000 0 12 -11 -10433
+531:addChannel = 1 0.0070000 0 14 -13 -435
+531:addChannel = 1 0.0070000 0 14 -13 -10433
+531:addChannel = 1 0.0028000 0 16 -15 -435
+531:addChannel = 1 0.0028000 0 16 -15 -10433
+531:addChannel = 1 0.0013000 0 -435 211
+
+531:onIfMatch = 12 11 435 
+531:onIfMatch = 12 11 10433
+531:onIfMatch = 14 13 435
+531:onIfMatch = 14 13 10433
+531:onIfMatch = 16 15 435
+531:onIfMatch = 16 15 10433
+531:onIfMatch = 435 211
+
+# Correct decay lengths (wrong in PYTHIA8 decay table)
+# Lb
+5122:tau0 = 0.4390
+# Xic0
+4132:tau0 = 0.0455
+# OmegaC
+4332:tau0 = 0.0803
+
+### Force golden charm hadrons decay modes for D2H studies
+### add D+ decays absent in PYTHIA8 decay table and set BRs from PDG for other
+411:oneChannel = 1 0.0752 0 -321 211 211
+411:addChannel = 1 0.0104 0 -313 211
+411:addChannel = 1 0.0156 0 311 211
+411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
+
+### K* -> K pi
+313:onMode = off
+313:onIfAll = 321 211
+### for Ds -> Phi pi+
+333:onMode = off
+333:onIfAll = 321 321
+
+### switch off all decay channels
+411:onMode = off
+421:onMode = off
+
+### D0 -> K pi
+421:onIfMatch = 321 211
+
+### D+/- -> K pi pi 
+411:onIfMatch = 321 211 211
+### D+/- -> K* pi
+411:onIfMatch = 313 211
+### D+/- -> phi pi
+411:onIfMatch = 333 211

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_DResoTrigger.cfg
@@ -31,13 +31,21 @@ StringFlav:mesonCL1S1J2= 5
 437:all = D*_s3(2860)+ D*_s3(2860)- 7 3 0 2.860 0.053 2.51 10. 0.
 437:mayDecay = on
 
-### Xic(3055)
+### Xic(3055)+
 4325:all = Xi_c(3055)+ Xi_cbar(3055)- 4 3 0 3.0559 0.0078 2.986 10. 0.
 4325:mayDecay = on
 
-### Xic(3080)
+### Xic(3080)+
 4326:all = Xi_c(3080)+ Xi_cbar(3080)- 2 3 0 3.0772 0.0036 2.986 10. 0.
 4326:mayDecay = on
+
+### Xic(3055)0
+4315:all = Xi_c(3055)0 Xi_cbar(3055)0 4 0 0 3.0590 0.0064 2.981 10. 0.
+4315:mayDecay = on
+
+### Xic(3080)0
+4316:all = Xi_c(3080)0 Xi_cbar(3080)0 2 0 0 3.0799 0.0056 2.981 10. 0.
+4316:mayDecay = on
 
 ### turn off all charm resonances decays
 10433:onMode = off  # Ds1(2536)
@@ -45,8 +53,10 @@ StringFlav:mesonCL1S1J2= 5
 30433:onMode = off  # Ds1*(2700)
 40433:onMode = off  # Ds1*(2860)
 437:onMode = off  # Ds3*(2860)
-4325:onMode = off  # Xic(3055)
-4326:onMode = off  # Xic(3080)
+4325:onMode = off  # Xic(3055)+
+4326:onMode = off  # Xic(3080)+
+4315:onMode = off  # Xic(3055)0
+4316:onMode = off  # Xic(3080)0
 
 ### turn off all beauty hadron decays
 531:onMode = off
@@ -74,13 +84,21 @@ StringFlav:mesonCL1S1J2= 5
 437:oneChannel = 1 1 0 413 311
 437:onIfMatch = 413 311
 
-### add Xic(3055)
+### add Xic(3055)+
 4325:oneChannel = 1 1 0 411 3122
 4325:onIfMatch = 411 3122
 
-### add Xic(3080)
+### add Xic(3080)+
 4326:oneChannel = 1 1 0 411 3122
 4326:onIfMatch = 411 3122
+
+### add Xic(3055)0
+4315:oneChannel = 1 1 0 421 3122
+4315:onIfMatch = 421 3122
+
+### add Xic(3080)0
+4316:oneChannel = 1 1 0 421 3122
+4316:onIfMatch = 421 3122
 
 ### add Bs0
 531:oneChannel = 1 0.0070000 0 12 -11 -435 
@@ -113,6 +131,9 @@ StringFlav:mesonCL1S1J2= 5
 411:addChannel = 1 0.0104 0 -313 211
 411:addChannel = 1 0.0156 0 311 211
 411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
+### set D0 BRs
+421:oneChannel = 1 0.9 0 -321 211
+421:addChannel = 1 0.1 0 -321 211 111
 
 ### K* -> K pi
 313:onMode = off
@@ -127,6 +148,8 @@ StringFlav:mesonCL1S1J2= 5
 
 ### D0 -> K pi
 421:onIfMatch = 321 211
+### D0 -> K pi pi0
+421:onIfMatch = 321 211 111
 
 ### D+/- -> K pi pi 
 411:onIfMatch = 321 211 211


### PR DESCRIPTION
This PR adds the possibility to replace particles in the PYTHIA stack with a given frequency. Custom particles, not present in PYTHIA, are also allowed (specifically for the moment Ds1* and Ds3* states and Xic resonances).

It also adds a config for the MC production needed for the analyses of Ds and Xic excited states with 2024 pp triggered data (Ds1+, Ds2*+ and excited Xic states)

Please @Luca610 check the forced decays, in case we want to add something.
