### PR TITLE
[PWGHF] Updating config for pp 13.6, 5.36 TeV and PbPb 5.36 TeV with correlated bkg

### DIFF
--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2.cfg
@@ -41,45 +41,64 @@ BeamRemnants:saturation 5
 # OmegaC
 4332:tau0 = 0.0803
 
-### Force golden charm hadrons decay modes for D2H studies
-### add D0 decays absent in PYTHIA8 decay table and set BRs from PDG for other
-421:oneChannel = 1 0.0389 0 -321 211
-421:addChannel = 1 0.00389 0 -321 211 111
-### add D+ decays absent in PYTHIA8 decay table and set BRs from PDG for other
-411:oneChannel = 1 0.0752 0 -321 211 211
-411:addChannel = 1 0.0104 0 -313 211
-411:addChannel = 1 0.0156 0 311 211
-411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
-## add Lc decays absent in PYTHIA8 decay table and set BRs from PDG for other
-4122:oneChannel = 1 0.0196 100 2212 -313
-4122:addChannel = 1 0.0108 100 2224 -321
-4122:addChannel = 1 0.022 100 102134 211
-4122:addChannel = 1 0.035 0 2212 -321 211
-4122:addChannel = 1 0.0159 0 2212 311
-### add Xic+ decays absent in PYTHIA8 decay table
-4232:addChannel = 1 0.2 0 2212 -313
-4232:addChannel = 1 0.2 0 2212 -321 211
-4232:addChannel = 1 0.2 0 3324 211
-4232:addChannel = 1 0.2 0 3312 211 211
+### HF decays
+### BR are set to yield 50% the golden channel and 50% the correlated bkg ones
+###
+### D0 decays
+421:oneChannel = 1 0.500 0 -321 211             ### D0 -> K- π+
+421:addChannel = 1 0.100 0 -321 211 111         ### D0 -> K- π+ π0
+421:addChannel = 1 0.100 0 -211 211             ### D0 -> π- π+
+421:addChannel = 1 0.100 0 -211 211 111         ### D0 -> π- π+ π0
+421:addChannel = 1 0.100 0 -321 321             ### D0 -> K- K+
+421:addChannel = 1 0.100 0 -321 321 111         ### D0 -> K- K+ π0
+
+### D+ decays
+411:oneChannel = 1 0.50 0 -321 211 211          ### D+ -> K- π+ π+
+411:addChannel = 1 0.17 0 -211 211 211          ### D+ -> π- π+ π+
+411:addChannel = 1 0.16 0  313 211              ### D+ -> K* π+ -> K- π+ π+
+411:addChannel = 1 0.17 0  333 211              ### D+ -> φ π+ -> K- K+ π+
+
+### Ds+ decays
+431:oneChannel = 1 0.500 0  333 211             ### Ds+ -> φ π+ -> K- K+ π+
+431:addChannel = 1 0.125 0  313 321             ### Ds+ -> K* K+ -> K- K+ π+
+431:addChannel = 1 0.125 0 -211 211 211         ### Ds+ -> π- π+ π+
+431:addChannel = 1 0.125 0 -211 321 211         ### Ds+ -> π- K+ π+
+431:addChannel = 1 0.125 0 -321 321 321         ### Ds+ -> K- K+ K+
+
+## Lc decays
+4122:oneChannel = 1 0.2500 2212 -321 211        ### Λc+ -> p K- π+
+4122:addChannel = 1 0.0560 100 2212 -313        ### Λc+ -> p K* -> p K- π+
+4122:addChannel = 1 0.0550 100 2224 -321        ### Λc+ -> Delta++ K- -> p K- π+
+4122:addChannel = 1 0.0550 100 102134 211       ### Λc+ -> Lambda(1520) K- -> p K- π+
+4122:addChannel = 1 0.1670 0 2212 211 211       ### Λc+ -> p π+ π+
+4122:addChannel = 1 0.2500 0 2212 311           ### Λc+ -> p K0s -> p π+ π-
+4122:addChannel = 1 0.1670 0 2212 -321 321      ### Λc+ -> p K- K+
+
+### Ξc+ decays
+4232:oneChannel = 1 0.50 0 2212 -321 211        ### Ξc+ -> p K- π+
+4232:addChannel = 1 0.25 0 -3312 211 211        ### Ξc+ -> Ξ- π+ π+
+4232:addChannel = 1 0.25 0 2212 333             ### Ξc+ -> p φ -> p K- K+
+
 ### add Xic0 decays absent in PYTHIA8 decay table
 4132:addChannel = 1 0.0143 0 3312 211
 ### add OmegaC decays absent in PYTHIA8 decay table
 4332:addChannel = 1 0.5 0 3334 211
 4332:addChannel = 1 0.5 0 3312 211
 
-### K* -> K pi
+# Allow the decay of resonances in the decay chain
+### K* -> K π
 313:onMode = off
 313:onIfAll = 321 211
-### for Ds -> Phi pi+
+### for Ds -> φ π+
 333:onMode = off
 333:onIfAll = 321 321
-### for D0 -> rho0 pi+ k-
+### for D0 -> rho0 π+ k-
 113:onMode = off
 113:onIfAll = 211 211
-### for Lambda_c -> Delta++ K-
+### for Λc -> Delta++ K-
 2224:onMode = off
 2224:onIfAll = 2212 211
-### for Lambda_c -> Lambda(1520) K-
+### for Λc -> Lambda(1520) K-
 102134:onMode = off
 102134:onIfAll = 2212 321
 ### for Xic0 -> pi Xi -> pi pi Lambda -> pi pi pi p 
@@ -91,6 +110,69 @@ BeamRemnants:saturation 5
 ### for Omega_c -> pi Omega -> pi K Lambda -> pi K pi p
 3334:onMode = off
 3334:onIfAll = 3122 -321
+
+### Switch off all decay channels
+411:onMode = off
+421:onMode = off
+431:onMode = off
+4122:onMode = off
+4232:onMode = off
+
+# Allow the decay of HF
+### D0 -> K π
+421:onIfMatch = 321 211
+### D0 -> K π π0
+421:onIfMatch = 321 211 111
+### D0 -> π π
+421:onIfMatch = 211 211
+### D0 -> π π π0
+421:onIfMatch = 211 211 111
+### D0 -> K K
+421:onIfMatch = 321 321
+### D0 -> K K π0
+421:onIfMatch = 321 321 111
+
+### D+/- -> K π π 
+411:onIfMatch = 321 211 211
+### D+/- -> K* π
+411:onIfMatch = 313 211
+### D+/- -> φ π
+411:onIfMatch = 333 211
+### D+/- -> π π π
+411:onIfMatch = 211 211 211
+
+### Ds -> φ π
+431:onIfMatch = 333 211
+### Ds -> K* K
+431:onIfMatch = 321 313
+### Ds -> π π π
+431:onIfMatch = 211 211 211
+### Ds -> K π π
+431:onIfMatch = 321 211 211
+### Ds -> K K K
+431:onIfMatch = 321 321 321
+
+### Λc -> p K π
+4122:onIfMatch = 2212 321 211
+### Λc -> p K*
+4122:onIfMatch = 2212 313
+### Λc -> Delta++ K
+4122:onIfMatch = 2224 321
+### Λc -> Lambda(1520) π
+4122:onIfMatch = 102134 211
+### Λc -> p π π
+4122:onIfMatch = 2212 211 211
+### Λc -> pK0s
+4122:onIfMatch = 2212 311 
+### Λc -> p K K
+4122:onIfMatch = 2212 321 321
+
+### Ξc+ -> p K- π+
+4232:onIfMatch = 2212 321 211
+### Ξc+ -> Ξ- π+ π+
+4232:onIfMatch = 3312 211 211
+### Ξc+ -> p φ
+4232:onIfMatch = 2212 333
 
 ### switch off all decay channels
 411:onMode = off

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_hardQCD_5TeV.cfg
@@ -45,45 +45,64 @@ BeamRemnants:saturation 5
 # OmegaC
 4332:tau0 = 0.0803
 
-### Force golden charm hadrons decay modes for D2H studies
-### add D0 decays absent in PYTHIA8 decay table and set BRs from PDG for other
-421:oneChannel = 1 0.0389 0 -321 211
-421:addChannel = 1 0.00389 0 -321 211 111
-### add D+ decays absent in PYTHIA8 decay table and set BRs from PDG for other
-411:oneChannel = 1 0.0752 0 -321 211 211
-411:addChannel = 1 0.0104 0 -313 211
-411:addChannel = 1 0.0156 0 311 211
-411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
-## add Lc decays absent in PYTHIA8 decay table and set BRs from PDG for other
-4122:oneChannel = 1 0.0196 100 2212 -313
-4122:addChannel = 1 0.0108 100 2224 -321
-4122:addChannel = 1 0.022 100 102134 211
-4122:addChannel = 1 0.035 0 2212 -321 211
-4122:addChannel = 1 0.0159 0 2212 311
-### add Xic+ decays absent in PYTHIA8 decay table
-4232:addChannel = 1 0.2 0 2212 -313
-4232:addChannel = 1 0.2 0 2212 -321 211
-4232:addChannel = 1 0.2 0 3324 211
-4232:addChannel = 1 0.2 0 3312 211 211
+### HF decays
+### BR are set to yield 50% the golden channel and 50% the correlated bkg ones
+###
+### D0 decays
+421:oneChannel = 1 0.500 0 -321 211             ### D0 -> K- π+
+421:addChannel = 1 0.100 0 -321 211 111         ### D0 -> K- π+ π0
+421:addChannel = 1 0.100 0 -211 211             ### D0 -> π- π+
+421:addChannel = 1 0.100 0 -211 211 111         ### D0 -> π- π+ π0
+421:addChannel = 1 0.100 0 -321 321             ### D0 -> K- K+
+421:addChannel = 1 0.100 0 -321 321 111         ### D0 -> K- K+ π0
+
+### D+ decays
+411:oneChannel = 1 0.50 0 -321 211 211          ### D+ -> K- π+ π+
+411:addChannel = 1 0.17 0 -211 211 211          ### D+ -> π- π+ π+
+411:addChannel = 1 0.16 0  313 211              ### D+ -> K* π+ -> K- π+ π+
+411:addChannel = 1 0.17 0  333 211              ### D+ -> φ π+ -> K- K+ π+
+
+### Ds+ decays
+431:oneChannel = 1 0.500 0  333 211             ### Ds+ -> φ π+ -> K- K+ π+
+431:addChannel = 1 0.125 0  313 321             ### Ds+ -> K* K+ -> K- K+ π+
+431:addChannel = 1 0.125 0 -211 211 211         ### Ds+ -> π- π+ π+
+431:addChannel = 1 0.125 0 -211 321 211         ### Ds+ -> π- K+ π+
+431:addChannel = 1 0.125 0 -321 321 321         ### Ds+ -> K- K+ K+
+
+## Lc decays
+4122:oneChannel = 1 0.2500 2212 -321 211        ### Λc+ -> p K- π+
+4122:addChannel = 1 0.0560 100 2212 -313        ### Λc+ -> p K* -> p K- π+
+4122:addChannel = 1 0.0550 100 2224 -321        ### Λc+ -> Delta++ K- -> p K- π+
+4122:addChannel = 1 0.0550 100 102134 211       ### Λc+ -> Lambda(1520) K- -> p K- π+
+4122:addChannel = 1 0.1670 0 2212 211 211       ### Λc+ -> p π+ π+
+4122:addChannel = 1 0.2500 0 2212 311           ### Λc+ -> p K0s -> p π+ π-
+4122:addChannel = 1 0.1670 0 2212 -321 321      ### Λc+ -> p K- K+
+
+### Ξc+ decays
+4232:oneChannel = 1 0.50 0 2212 -321 211        ### Ξc+ -> p K- π+
+4232:addChannel = 1 0.25 0 -3312 211 211        ### Ξc+ -> Ξ- π+ π+
+4232:addChannel = 1 0.25 0 2212 333             ### Ξc+ -> p φ -> p K- K+
+
 ### add Xic0 decays absent in PYTHIA8 decay table
 4132:addChannel = 1 0.0143 0 3312 211
 ### add OmegaC decays absent in PYTHIA8 decay table
 4332:addChannel = 1 0.5 0 3334 211
 4332:addChannel = 1 0.5 0 3312 211
 
-### K* -> K pi
+# Allow the decay of resonances in the decay chain
+### K* -> K π
 313:onMode = off
 313:onIfAll = 321 211
-### for Ds -> Phi pi+
+### for Ds -> φ π+
 333:onMode = off
 333:onIfAll = 321 321
-### for D0 -> rho0 pi+ k-
+### for D0 -> rho0 π+ k-
 113:onMode = off
 113:onIfAll = 211 211
-### for Lambda_c -> Delta++ K-
+### for Λc -> Delta++ K-
 2224:onMode = off
 2224:onIfAll = 2212 211
-### for Lambda_c -> Lambda(1520) K-
+### for Λc -> Lambda(1520) K-
 102134:onMode = off
 102134:onIfAll = 2212 321
 ### for Xic0 -> pi Xi -> pi pi Lambda -> pi pi pi p 
@@ -95,6 +114,69 @@ BeamRemnants:saturation 5
 ### for Omega_c -> pi Omega -> pi K Lambda -> pi K pi p
 3334:onMode = off
 3334:onIfAll = 3122 -321
+
+### Switch off all decay channels
+411:onMode = off
+421:onMode = off
+431:onMode = off
+4122:onMode = off
+4232:onMode = off
+
+# Allow the decay of HF
+### D0 -> K π
+421:onIfMatch = 321 211
+### D0 -> K π π0
+421:onIfMatch = 321 211 111
+### D0 -> π π
+421:onIfMatch = 211 211
+### D0 -> π π π0
+421:onIfMatch = 211 211 111
+### D0 -> K K
+421:onIfMatch = 321 321
+### D0 -> K K π0
+421:onIfMatch = 321 321 111
+
+### D+/- -> K π π 
+411:onIfMatch = 321 211 211
+### D+/- -> K* π
+411:onIfMatch = 313 211
+### D+/- -> φ π
+411:onIfMatch = 333 211
+### D+/- -> π π π
+411:onIfMatch = 211 211 211
+
+### Ds -> φ π
+431:onIfMatch = 333 211
+### Ds -> K* K
+431:onIfMatch = 321 313
+### Ds -> π π π
+431:onIfMatch = 211 211 211
+### Ds -> K π π
+431:onIfMatch = 321 211 211
+### Ds -> K K K
+431:onIfMatch = 321 321 321
+
+### Λc -> p K π
+4122:onIfMatch = 2212 321 211
+### Λc -> p K*
+4122:onIfMatch = 2212 313
+### Λc -> Delta++ K
+4122:onIfMatch = 2224 321
+### Λc -> Lambda(1520) π
+4122:onIfMatch = 102134 211
+### Λc -> p π π
+4122:onIfMatch = 2212 211 211
+### Λc -> pK0s
+4122:onIfMatch = 2212 311 
+### Λc -> p K K
+4122:onIfMatch = 2212 321 321
+
+### Ξc+ -> p K- π+
+4232:onIfMatch = 2212 321 211
+### Ξc+ -> Ξ- π+ π+
+4232:onIfMatch = 3312 211 211
+### Ξc+ -> p φ
+4232:onIfMatch = 2212 333
 
 ### switch off all decay channels
 411:onMode = off

--- a/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_pp_ref.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_pp_ref.cfg
@@ -1,7 +1,7 @@
 ### authors: Fabrizio Grosa (fabrizio.grosa@cern.ch)
 ###          Cristina Terrevoli (cristina.terrevoli@cern.ch)
 ###          Fabio Catalano (fabio.catalano@cern.ch)
-### last update:  November 2023
+### last update:  May 2025
 
 ### beams
 Beams:idA 2212			# proton
@@ -41,45 +41,64 @@ BeamRemnants:saturation 5
 # OmegaC
 4332:tau0 = 0.0803
 
-### Force golden charm hadrons decay modes for D2H studies
-### add D0 decays absent in PYTHIA8 decay table and set BRs from PDG for other
-421:oneChannel = 1 0.0389 0 -321 211
-421:addChannel = 1 0.00389 0 -321 211 111
-### add D+ decays absent in PYTHIA8 decay table and set BRs from PDG for other
-411:oneChannel = 1 0.0752 0 -321 211 211
-411:addChannel = 1 0.0104 0 -313 211
-411:addChannel = 1 0.0156 0 311 211
-411:addChannel = 1 0.0752 0 333 211 # to have the same amount of D+->KKpi and D+->Kpipi
-## add Lc decays absent in PYTHIA8 decay table and set BRs from PDG for other
-4122:oneChannel = 1 0.0196 100 2212 -313
-4122:addChannel = 1 0.0108 100 2224 -321
-4122:addChannel = 1 0.022 100 102134 211
-4122:addChannel = 1 0.035 0 2212 -321 211
-4122:addChannel = 1 0.0159 0 2212 311
-### add Xic+ decays absent in PYTHIA8 decay table
-4232:addChannel = 1 0.2 0 2212 -313
-4232:addChannel = 1 0.2 0 2212 -321 211
-4232:addChannel = 1 0.2 0 3324 211
-4232:addChannel = 1 0.2 0 3312 211 211
+### HF decays
+### BR are set to yield 50% the golden channel and 50% the correlated bkg ones
+###
+### D0 decays
+421:oneChannel = 1 0.500 0 -321 211             ### D0 -> K- π+
+421:addChannel = 1 0.100 0 -321 211 111         ### D0 -> K- π+ π0
+421:addChannel = 1 0.100 0 -211 211             ### D0 -> π- π+
+421:addChannel = 1 0.100 0 -211 211 111         ### D0 -> π- π+ π0
+421:addChannel = 1 0.100 0 -321 321             ### D0 -> K- K+
+421:addChannel = 1 0.100 0 -321 321 111         ### D0 -> K- K+ π0
+
+### D+ decays
+411:oneChannel = 1 0.50 0 -321 211 211          ### D+ -> K- π+ π+
+411:addChannel = 1 0.17 0 -211 211 211          ### D+ -> π- π+ π+
+411:addChannel = 1 0.16 0  313 211              ### D+ -> K* π+ -> K- π+ π+
+411:addChannel = 1 0.17 0  333 211              ### D+ -> φ π+ -> K- K+ π+
+
+### Ds+ decays
+431:oneChannel = 1 0.500 0  333 211             ### Ds+ -> φ π+ -> K- K+ π+
+431:addChannel = 1 0.125 0  313 321             ### Ds+ -> K* K+ -> K- K+ π+
+431:addChannel = 1 0.125 0 -211 211 211         ### Ds+ -> π- π+ π+
+431:addChannel = 1 0.125 0 -211 321 211         ### Ds+ -> π- K+ π+
+431:addChannel = 1 0.125 0 -321 321 321         ### Ds+ -> K- K+ K+
+
+## Lc decays
+4122:oneChannel = 1 0.2500 2212 -321 211        ### Λc+ -> p K- π+
+4122:addChannel = 1 0.0560 100 2212 -313        ### Λc+ -> p K* -> p K- π+
+4122:addChannel = 1 0.0550 100 2224 -321        ### Λc+ -> Delta++ K- -> p K- π+
+4122:addChannel = 1 0.0550 100 102134 211       ### Λc+ -> Lambda(1520) K- -> p K- π+
+4122:addChannel = 1 0.1670 0 2212 211 211       ### Λc+ -> p π+ π+
+4122:addChannel = 1 0.2500 0 2212 311           ### Λc+ -> p K0s -> p π+ π-
+4122:addChannel = 1 0.1670 0 2212 -321 321      ### Λc+ -> p K- K+
+
+### Ξc+ decays
+4232:oneChannel = 1 0.50 0 2212 -321 211        ### Ξc+ -> p K- π+
+4232:addChannel = 1 0.25 0 -3312 211 211        ### Ξc+ -> Ξ- π+ π+
+4232:addChannel = 1 0.25 0 2212 333             ### Ξc+ -> p φ -> p K- K+
+
 ### add Xic0 decays absent in PYTHIA8 decay table
 4132:addChannel = 1 0.0143 0 3312 211
 ### add OmegaC decays absent in PYTHIA8 decay table
 4332:addChannel = 1 0.5 0 3334 211
 4332:addChannel = 1 0.5 0 3312 211
 
-### K* -> K pi
+# Allow the decay of resonances in the decay chain
+### K* -> K π
 313:onMode = off
 313:onIfAll = 321 211
-### for Ds -> Phi pi+
+### for Ds -> φ π+
 333:onMode = off
 333:onIfAll = 321 321
-### for D0 -> rho0 pi+ k-
+### for D0 -> rho0 π+ k-
 113:onMode = off
 113:onIfAll = 211 211
-### for Lambda_c -> Delta++ K-
+### for Λc -> Delta++ K-
 2224:onMode = off
 2224:onIfAll = 2212 211
-### for Lambda_c -> Lambda(1520) K-
+### for Λc -> Lambda(1520) K-
 102134:onMode = off
 102134:onIfAll = 2212 321
 ### for Xic0 -> pi Xi -> pi pi Lambda -> pi pi pi p 
@@ -91,6 +110,69 @@ BeamRemnants:saturation 5
 ### for Omega_c -> pi Omega -> pi K Lambda -> pi K pi p
 3334:onMode = off
 3334:onIfAll = 3122 -321
+
+### Switch off all decay channels
+411:onMode = off
+421:onMode = off
+431:onMode = off
+4122:onMode = off
+4232:onMode = off
+
+# Allow the decay of HF
+### D0 -> K π
+421:onIfMatch = 321 211
+### D0 -> K π π0
+421:onIfMatch = 321 211 111
+### D0 -> π π
+421:onIfMatch = 211 211
+### D0 -> π π π0
+421:onIfMatch = 211 211 111
+### D0 -> K K
+421:onIfMatch = 321 321
+### D0 -> K K π0
+421:onIfMatch = 321 321 111
+
+### D+/- -> K π π 
+411:onIfMatch = 321 211 211
+### D+/- -> K* π
+411:onIfMatch = 313 211
+### D+/- -> φ π
+411:onIfMatch = 333 211
+### D+/- -> π π π
+411:onIfMatch = 211 211 211
+
+### Ds -> φ π
+431:onIfMatch = 333 211
+### Ds -> K* K
+431:onIfMatch = 321 313
+### Ds -> π π π
+431:onIfMatch = 211 211 211
+### Ds -> K π π
+431:onIfMatch = 321 211 211
+### Ds -> K K K
+431:onIfMatch = 321 321 321
+
+### Λc -> p K π
+4122:onIfMatch = 2212 321 211
+### Λc -> p K*
+4122:onIfMatch = 2212 313
+### Λc -> Delta++ K
+4122:onIfMatch = 2224 321
+### Λc -> Lambda(1520) π
+4122:onIfMatch = 102134 211
+### Λc -> p π π
+4122:onIfMatch = 2212 211 211
+### Λc -> pK0s
+4122:onIfMatch = 2212 311 
+### Λc -> p K K
+4122:onIfMatch = 2212 321 321
+
+### Ξc+ -> p K- π+
+4232:onIfMatch = 2212 321 211
+### Ξc+ -> Ξ- π+ π+
+4232:onIfMatch = 3312 211 211
+### Ξc+ -> p φ
+4232:onIfMatch = 2212 333
 
 ### switch off all decay channels
 411:onMode = off


### PR DESCRIPTION
 Updating config for pp 13.6, 5.36 TeV and PbPb 5.36 TeV with correlated bkg channels to have 50% candidates in the golden channel and the remaining 50% in bkg channels. 