### PR TITLE
Fix for the MC aQC MCH+MFT task to avoid MID active cases

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -113,10 +113,10 @@ def include_all_QC_finalization(ntimeframes, standalone, run, productionTag, con
      add_QC_finalization('MCHTracksTaskQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/mch-tracks-task.json')
   if isActive('MCH') and isActive('MID'):
      add_QC_finalization('MCHMIDTracksTaskQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/mchmid-tracks-task.json')
-  # if isActive('MCH') and isActive('MFT'):
-  #   add_QC_finalization('MCHMFTTaskQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/mftmch-tracks-task.json')
   if isActive('MCH') and isActive('MID') and isActive('MFT'):
      add_QC_finalization('MUONTracksMFTTaskQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/mftmchmid-tracks-task.json')
+  elif isActive('MCH') and isActive('MFT'):
+     add_QC_finalization('MCHMFTTaskQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/mftmch-tracks-task.json')
   if isActive('FT0') and isActive('TRD'):
      add_QC_finalization('tofft0PIDQC', 'json://${O2DPG_ROOT}/MC/config/QC/json/pidft0tof.json')
   elif isActive('FT0'):

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1788,21 +1788,17 @@ for tf in range(1, NTIMEFRAMES + 1):
                 readerCommand='o2-global-track-cluster-reader --track-types "MCH,MID,MCH-MID" --cluster-types "MCH,MID"',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/mchmid-tracks-task.json')
   
-                
-     ### MCH && MFT
-     #if isActive('MCH') and isActive('MFT') :
-     #   addQCPerTF(taskName='MCHMFTTaskQC',
-     #           needs=[MFTMCHMATCHtask['name']],
-     #           readerCommand='o2-global-track-cluster-reader --track-types "MCH,MFT,MFT-MCH" --cluster-types "MCH,MFT"',
-     #           configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/mftmch-tracks-task.json')
-                
-     ### MCH && MID && MFT
+     ### MCH && MID && MFT || MCH && MFT
      if isActive('MCH') and isActive('MID') and isActive('MFT') :
         addQCPerTF(taskName='MUONTracksMFTTaskQC',
                 needs=[MFTMCHMATCHtask['name'], MCHMIDMATCHtask['name']],
                 readerCommand='o2-global-track-cluster-reader --track-types "MFT,MCH,MID,MCH-MID,MFT-MCH,MFT-MCH-MID" --cluster-types "MCH,MID,MFT"',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/mftmchmid-tracks-task.json')
-
+     elif isActive('MCH') and isActive('MFT') :
+        addQCPerTF(taskName='MCHMFTTaskQC',
+                needs=[MFTMCHMATCHtask['name']],
+                readerCommand='o2-global-track-cluster-reader --track-types "MCH,MFT,MFT-MCH" --cluster-types "MCH,MFT"',
+                configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/mftmch-tracks-task.json')
 
  
    #<------------------ TPC - time-series objects


### PR DESCRIPTION
This fix is meant to cure the bug in the nightlies reported in https://its.cern.ch/jira/browse/O2-5885
The aQC MCH+MFT task is enabled only if the MID is not active in the run