### PR TITLE
Common: add OTF inis for special 2025 runs

### DIFF
--- a/MC/config/common/ini/pythia8_NeNe_536.ini
+++ b/MC/config/common/ini/pythia8_NeNe_536.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_NeNe_536.cfg

--- a/MC/config/common/ini/pythia8_OO_536.ini
+++ b/MC/config/common/ini/pythia8_OO_536.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_OO_536.cfg

--- a/MC/config/common/ini/pythia8_pO_961.ini
+++ b/MC/config/common/ini/pythia8_pO_961.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_pO_961.cfg

--- a/MC/config/common/pythia8/generator/pythia8_NeNe_536.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_NeNe_536.cfg
@@ -1,0 +1,14 @@
+### NeNe beams
+Beams:idA = 1000100200  # Neon
+Beams:idB = 1000100200  # Neon
+Beams:eCM = 5360.0                ### energy
+    
+Beams:frameType = 1
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+    
+### To avoid refitting, add the following lines to your configuration file:
+HeavyIon:SigFitNGen = 0
+HeavyIon:SigFitDefPar = 2.15,18.42,0.33
+    
+Random:setSeed = on

--- a/MC/config/common/pythia8/generator/pythia8_OO_536.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_OO_536.cfg
@@ -1,0 +1,15 @@
+### OO beams
+Beams:idA = 1000080160
+Beams:idB = 1000080160           
+Beams:eCM = 5360.0                ### energy
+    
+Beams:frameType = 1
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+
+### Save some CPU at init of jobs
+### To avoid refitting, add the following lines to your configuration file:
+HeavyIon:SigFitNGen = 0
+HeavyIon:SigFitDefPar = 2.15,18.42,0.33
+    
+Random:setSeed = on

--- a/MC/config/common/pythia8/generator/pythia8_pO_961.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_pO_961.cfg
@@ -1,0 +1,15 @@
+### OO beams
+Beams:frameType 2       # back-to-back beams of different energies and particles
+Beams:idA 2212          # proton
+Beams:idB 1000080160    # Oxygen
+Beams:eA 6800.          # Energy of proton beam in GeV moving in the +z direction
+Beams:eB 3400.          # Energy in GeV per Oxygen nucleon (6.8 Z TeV) moving in the -z direction
+
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+    
+### To avoid refitting, add the following lines to your configuration file:
+HeavyIon:SigFitNGen = 0
+HeavyIon:SigFitDefPar = 2.17,17.56,0.30
+    
+Random:setSeed = on


### PR DESCRIPTION
Adds `ini` and `cfg` files such that one can run hyperloop on-the-fly simulations with the 2025 special run configurations. 