### PR TITLE
Special TPC settings for digitizer when TPC reco does not have mc-tim…

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -213,3 +213,13 @@ def option_if_available(executable, option, envfile = None):
     """Checks if an option is available for a given executable and returns it as a string. Otherwise empty string"""
     _, inverse_lookup = get_dpl_options_for_executable(executable, envfile)
     return ' ' + option if option in inverse_lookup else ''
+
+
+# helper function to overwrite some values; prints out stuff that it changes
+def overwrite_config(config, mainkey, subkey, value):
+    oldvalue = config.get(mainkey,{}).get(subkey, None)
+    print (f"Overwriting {mainkey}.{subkey}: {'None' if oldvalue is None else oldvalue} -> {value}")
+    if mainkey not in config:
+      # Initialize the main key in the dictionary if it does not already exist
+      config[mainkey] = {}
+    config[mainkey][subkey] = value


### PR DESCRIPTION
…e-gain

Adapt TPC digi setting to a situation when TPC reco does not have mc-time-gain. This can be the case in 2tag scenarios: The digitizer comes from a more recent software release than the reconstruction.

Should address dEdx issue described in https://its.cern.ch/jira/browse/O2-5486