### PR TITLE
Come back to no forced open-beauty hadron decays first

### DIFF
--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
-funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;511;521;531;5122;5132;5232;5332")
+funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
 config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail.cfg
@@ -10,4 +10,4 @@ includePartonEvent=true
 
 [DecayerPythia8]
 config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp13.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp13.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
-funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;511;521;531;5122;5132;5232;5332")
+funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
 config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail_pp13.cfg
@@ -10,4 +10,4 @@ includePartonEvent=true
 
 [DecayerPythia8]
 config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp502.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp502.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
-funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;511;521;531;5122;5132;5232;5332")
+funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
 config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail_pp502.cfg
@@ -10,4 +10,4 @@ includePartonEvent=true
 
 [DecayerPythia8]
 config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg

--- a/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp536.ini
+++ b/MC/config/PWGEM/ini/Pythia8_Beauty_Cocktail_pp536.ini
@@ -1,6 +1,6 @@
 [GeneratorExternal]
 fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/external/generator/Generator_pythia8_forcedDecays.C
-funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332;511;521;531;5122;5132;5232;5332")
+funcName=GeneratePythia8ForcedDecays("411;421;431;4122;4232;4132;4332")
 
 [GeneratorPythia8]
 config = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/generator/pythia8_hf_cocktail_pp536.cfg
@@ -10,4 +10,4 @@ includePartonEvent=true
 
 [DecayerPythia8]
 config[0] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/decayer/base.cfg
-config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic.cfg
+config[1] = ${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGEM/pythia8/decayer/force_semileptonic_charm.cfg


### PR DESCRIPTION
Come back first to the no forced open-beauty hadron decay case due to a bug in the weighting in the case open-charm and open-beauty are forced to decay simultaneously.