### PR TITLE
Async QC trending example restricted to one period

### DIFF
--- a/DATA/production/o2dpg_qc_postproc_workflow.py
+++ b/DATA/production/o2dpg_qc_postproc_workflow.py
@@ -78,7 +78,7 @@ def QC_postprocessing_workflow(runNumber, periodName, passName, qcdbUrl):
     stages.append(task)
 
   ## The list of QC Post-processing workflows, add the new ones below
-  add_QC_postprocessing('example', 'json://${O2DPG_ROOT}/DATA/production/qc-postproc-async/example.json', needs=[], runSpecific=False, periodSpecific=False, passSpecific=True)
+  add_QC_postprocessing('example', 'json://${O2DPG_ROOT}/DATA/production/qc-postproc-async/example.json', needs=[], runSpecific=False, periodSpecific=True, passSpecific=True)
   add_QC_postprocessing('EMC', 'json://${O2DPG_ROOT}/DATA/production/qc-postproc-async/emc.json', needs=[], runSpecific=False, periodSpecific=True, passSpecific=True)
   add_QC_postprocessing('MCH', 'json://${O2DPG_ROOT}/DATA/production/qc-postproc-async/mch.json', needs=[], runSpecific=True, periodSpecific=True, passSpecific=True)
   add_QC_postprocessing('ZDC', 'json://${O2DPG_ROOT}/DATA/production/qc-postproc-async/zdc.json', needs=[], runSpecific=True, periodSpecific=True, passSpecific=True)


### PR DESCRIPTION
Async QC trending example is restricted to one period to avoid excessive calls to QCDB.