### PR TITLE
EMC ClustersTrend should publish only complete trends

### DIFF
--- a/DATA/production/qc-postproc-async/emc.json
+++ b/DATA/production/qc-postproc-async/emc.json
@@ -496,7 +496,7 @@
                 "moduleName": "QualityControl",
                 "detectorName": "EMC",
                 "resumeTrend": "false",
-                "producePlotsOnUpdate": "true",
+                "producePlotsOnUpdate": "false",
                 "dataSources": [
                     {
                         "type": "repository",


### PR DESCRIPTION
EMC ClustersTrend configuration is changed to publish trends only once all input objects are processed, there is no need for intermediate versions.