### PR TITLE
MCH: added MW plots for digits and preclusters async QC

### DIFF
--- a/DATA/production/qc-async/mch-digits.json
+++ b/DATA/production/qc-async/mch-digits.json
@@ -36,7 +36,12 @@
                     "type": "direct",
                     "query": "digits:MCH/DIGITS"
                 },
+                "movingWindows": [
+                    "RateSignalPerDualSampa"
+                ],
                 "taskParameters": {
+                    "Enable1DRateMaps": "true",
+                    "Enable2DRateMaps": "false",
                     "Diagnostic": "false"
                 },
                 "grpGeomRequest": {

--- a/DATA/production/qc-async/mch-reco.json
+++ b/DATA/production/qc-async/mch-reco.json
@@ -49,6 +49,13 @@
                 "dataSource": {
                     "type": "direct",
                     "query": "preclusters:MCH/PRECLUSTERS/0;preclusterdigits:MCH/PRECLUSTERDIGITS/0"
+                },
+                "movingWindows": [
+                    "PseudoeffPerDualSampa"
+                ],
+                "taskParameters": {
+                    "Enable1DPseudoeffMaps": "true",
+                    "Enable2DPseudoeffMaps": "false"
                 }
             },
             "FRofs": {


### PR DESCRIPTION
Two MW plots are added in the MCH async QC configuration, one providing the board-by-board readout rate and the other the board-by-board pseudo-efficiency.

The additional plots have a size equivalent to the `ClustersPerDualSampa` one already included in the `Clusters` task.
The duration of the QC cycle for the MW plots is set to 5 minutes.