### PR TITLE
Improved seed and option files handling

### DIFF
--- a/MC/config/examples/ini/GeneratorEPOS4.ini
+++ b/MC/config/examples/ini/GeneratorEPOS4.ini
@@ -3,7 +3,7 @@ fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
 funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator/example.optns", 2147483647)
 
 [GeneratorFileOrCmd]
-cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh -i cfg
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
 bMaxSwitch=none
 
 # Set to version 2 if EPOS4.0.0 is used

--- a/MC/config/examples/ini/GeneratorEPOS4HQ.ini
+++ b/MC/config/examples/ini/GeneratorEPOS4HQ.ini
@@ -4,7 +4,7 @@ fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
 funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator/examplehq.optns", 2147483647)
 
 [GeneratorFileOrCmd]
-cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh -i cfg
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
 bMaxSwitch=none
 
 [HepMC]


### PR DESCRIPTION
Each instance of GeneratorEPOS4 will now have a different seed, based on the call order to the gRandom function, and the options files will be separated for each instance. This should fix some issues when calling the generator in parallel or simply in sequence.