### PR TITLE
Adding ALICE 3 Pb-Pb generator with forced D0 decays

### DIFF
--- a/MC/config/ALICE3/ini/pythia8_PbPb_D0toKpi.ini
+++ b/MC/config/ALICE3/ini/pythia8_PbPb_D0toKpi.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_D0toKpi.cfg

--- a/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_D0toKpi.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_PbPb_D0toKpi.cfg
@@ -1,0 +1,20 @@
+### Specify beams
+Beams:idA = 1000822080
+Beams:idB = 1000822080            
+Beams:eCM = 5520.0                ### energy
+    
+Beams:frameType = 1
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+    
+### Initialize the Angantyr model to fit the total and semi-includive
+### cross sections in Pythia within some tolerance.
+HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0
+
+### These parameters are typicall suitable for sqrt(S_NN)=5TeV
+HeavyIon:SigFitDefPar = 17.24,2.15,0.33,0.0,0.0,0.0,0.0,0.0
+
+### Force decay of D0 into Kpi
+421:oneChannel = 1 0.0389 0 -321 211
+
+Random:setSeed = on


### PR DESCRIPTION
New .ini and .cfg files for generating Pb-Pb events at 5.52 TeV with PYTHIA 8 Angantyr forcing the D0 decays in Kpi.
Needed to define a dedicated MCGEN, for ALICE3 DDbar studies.