### PR TITLE
anchorMC: actually export ALIEN_JDL_LPMPRODUCTIONTAG

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1583,7 +1583,7 @@ for tf in range(1, NTIMEFRAMES + 1):
       f"--info-sources {aodinfosources}",
       "--lpmp-prod-tag ${ALIEN_JDL_LPMPRODUCTIONTAG:-unknown}",
       "--anchor-pass ${ALIEN_JDL_LPMANCHORPASSNAME:-unknown}",
-      "--anchor-prod ${ALIEN_JDL_LPMANCHORPASSNAME:-unknown}",
+      "--anchor-prod ${ALIEN_JDL_LPMANCHORPRODUCTION:-unknown}",
       "--combine-source-devices" if not args.no_combine_dpl_devices else "",
       "--disable-mc" if args.no_mc_labels else "",
       "--enable-truncation 0" if environ.get("O2DPG_AOD_NOTRUNCATE") or environ.get("ALIEN_JDL_O2DPG_AOD_NOTRUNCATE") else "",

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -252,7 +252,7 @@ if [[ ! -f workflowconfig.log ]]; then
   exit 1
 fi
 
-ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMPRODUCTIONTAG_KEEP
+export ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMPRODUCTIONTAG_KEEP
 echo_info "Setting back ALIEN_JDL_LPMPRODUCTIONTAG to $ALIEN_JDL_LPMPRODUCTIONTAG"
 
 # get rid of the temporary software environment


### PR DESCRIPTION
fixes for LPM meta-data in AO2D

ALIEN_JDL_LPMPRODUCTIONTAG was exported to some other value then reset to the original one. However, the change actually needs to be exported to take effect in child processes.