### PR TITLE
gen_topo scripts: on error, print the last stderr message first

### DIFF
--- a/DATA/tools/epn/gen_topo.sh
+++ b/DATA/tools/epn/gen_topo.sh
@@ -61,6 +61,5 @@ fi
 # Run stage 2 of GenTopo, which does the PDP part, still from hardcoded updatable RPM path
 /opt/alisw/el9/GenTopo/bin/gen_topo_o2dpg.sh
 if [ $? != 0 ]; then
-  echo topology generation failed 1>&2
   exit 1
 fi

--- a/DATA/tools/epn/gen_topo_logged.sh
+++ b/DATA/tools/epn/gen_topo_logged.sh
@@ -26,6 +26,8 @@ if [[ ! -z $GEN_TOPO_LOGDATE ]]; then
     while read STDERRLINE; do
       echo "$GEN_TOPO_LOGDATE $ECS_ENVIRONMENT_ID :     $STDERRLINE" >> /var/log/topology/gen-topo.log
     done < $STDERRFILE
+    echo "FATAL $(tail -n 1 $STDERRFILE)" 1>&2
+    echo -e "\n - full stderr output:" 1>&2
   fi
 fi
 

--- a/DATA/tools/epn/gen_topo_o2dpg.sh
+++ b/DATA/tools/epn/gen_topo_o2dpg.sh
@@ -134,7 +134,7 @@ if [[ ! -z "$GEN_TOPO_ODC_EPN_TOPO_POST_CACHING_CMD" ]] && [[ "0$WORKFLOWMODE" !
   fi
   TMP_POST_CACHING_CMD+=" -o $GEN_TOPO_WORKDIR/output.xml.new $GEN_TOPO_WORKDIR/output.xml"
   echo "Running post-caching topo-merger command: $TMP_POST_CACHING_CMD" 1>&2
-  eval $TMP_POST_CACHING_CMD 1>&2 || { echo Error during EPN topology-merger resource allocation 1>&2; exit 1; }
+  eval $TMP_POST_CACHING_CMD 1>&2 || { echo Error during EPN resource allocation 1>&2; exit 1; }
   mv -f $GEN_TOPO_WORKDIR/output.xml.new $GEN_TOPO_WORKDIR/output.xml 1>&2
 fi
 


### PR DESCRIPTION
in case of topology generation error, this does the following:
1) in InfoLogger GUI, it prints the last message from the gen_topo scripts stderr first, directly after the "Topology generation script failed" message from ODC, as a fatal so it is displayed as level 1 and, afterwards, the full stderr message stream will be printed as it is now.
2) the error string in AliECS GUI contains the first one or two lines of the gen_topo scripts stderr output. With this, the last line of the gen_topo stderr output will be printed first also in the AliECS GUI error string.

The scripts contain a few foreseen error sources for which we print a corresponding error message. Especially for these cases, this should help the shifter to distinguish between different topology failure reasons.

Two examples of AliECS GUI error strings

a) EPN resource allocation error (this triggered me to look into this)
```
# current
cannot create new environment: critical hook failed at trigger after_DEPLOY: EPN PartitionInitialize call failed. REASON: status ERROR from ODC with error code 111 from ODC: Failed topology (Incorrect topology provided: Topology generation script failed with exit code: 1, stderr: "Reusing cached XML topology 6a8ce85e53cff1a07fa786ee7e0aa590 Running post-caching topo-merger command: env - PYTHONPATH+=/usr/local/lib/python

# with this PR
cannot create new environment: critical hook failed at trigger after_DEPLOY: EPN PartitionInitialize call failed. REASON: status ERROR from ODC with error code 111 from ODC: Failed topology (Incorrect topology provided: Topology generation script failed with exit code: 1, stderr: "FATAL Error during EPN resource allocation - full stderr output: Running topology generation to temporary file /var/tmp/gen_topo/1_1/output.xm
```

b) workflow parsing error
```
# current
cannot create new environment: critical hook failed at trigger after_DEPLOY: EPN PartitionInitialize call failed. REASON: status ERROR from ODC with error code 111 from ODC: Failed topology (Incorrect topology provided: Topology generation script failed with exit code: 1, stderr: "Running topology generation to temporary file /var/tmp/gen_topo/1_1/output.xml Loading O2PDPSuite/epn-20250605.2-DDv1.6.9-QCv1.176.0-flp-suite

# with this PR
cannot create new environment: critical hook failed at trigger after_DEPLOY: EPN PartitionInitialize call failed. REASON: status ERROR from ODC with error code 111 from ODC: Failed topology (Incorrect topology provided: Topology generation script failed with exit code: 1, stderr: "FATAL Error during workflow description parsing - full stderr output: Running topology generation to temporary file /var/tmp/gen_topo/1_1/outp
```