### PR TITLE
Publish MCProdInfo

### DIFF
--- a/MC/prodinfo/README.md
+++ b/MC/prodinfo/README.md
@@ -1,0 +1,9 @@
+This directory contains scripts and function to collect, define and upload
+CCDB meta data objects for (official) MC productions.
+
+This meta data can be queried in other stages, such as analysis, for the purpose of further data processing.
+
+TODO:
+
+- include cycle number in data
+- include software versions (2tag or not)

--- a/MC/prodinfo/mcprodinfo_ccdb_upload.py
+++ b/MC/prodinfo/mcprodinfo_ccdb_upload.py
@@ -1,0 +1,144 @@
+import json
+import os
+import requests
+import subprocess
+
+import dataclasses # to define the MCProdInfo data layout and convert it to dict
+from dataclasses import dataclass, field, asdict, fields
+from typing import Optional
+import hashlib
+
+@dataclass(frozen=True)
+class MCProdInfo:
+    """
+    struct for MonteCarlo production info
+    """
+    LPMProductionTag: str
+    Col: int
+    IntRate: float   # only indicative of some interaction rate (could vary within the run)
+    RunNumber: int
+    OrbitsPerTF: int
+    # max_events_per_tf: Optional[int] = -1
+    Comment: Optional[str] = None
+    Hash: Optional[str] = field(default=None)
+
+    def __post_init__(self):
+        if self.Hash == None:
+           # Hash only the meaningful fields
+            data_to_hash = {
+                k: v for k, v in asdict(self).items()
+                if k != 'hash'
+            }
+            hash_str = hashlib.sha256(
+                json.dumps(data_to_hash, sort_keys=True).encode()
+            ).hexdigest()
+            object.__setattr__(self, 'hash', hash_str)
+
+
+import re
+
+def extract_metadata_blocks_from_CCDB(text: str):
+    blocks = []
+    # Split on 'Metadata:\n' and iterate over each block
+    sections = text.split('Metadata:\n')
+    for section in sections[1:]:  # skip the first chunk (before any Metadata:)
+        metadata = {}
+        for line in section.splitlines():
+            if not line.strip():  # stop at first blank line
+                break
+            match = re.match(r'\s*(\w+)\s*=\s*(.+)', line)
+            if match:
+                key, val = match.groups()
+                # Type conversion
+                if val == "None":
+                    val = None
+                elif val.isdigit() or (val.startswith('-') and val[1:].isdigit()):
+                    val = int(val)
+                else:
+                    try:
+                        val = float(val)
+                    except ValueError:
+                        val = val.strip()
+                metadata[key] = val
+        if metadata:
+            blocks.append(metadata)
+    return blocks
+
+
+
+def query_mcprodinfo(base_url, user, run_number, lpm_prod_tag, cert_dir="/tmp"):
+    """
+    Queries MCProdInfo from CCDB. Returns object or None
+    """
+    # check if the tokenfiles are there
+    key_path = os.environ.get("JALIEN_TOKEN_KEY")
+    cert_path = os.environ.get("JALIEN_TOKEN_CERT")
+    if key_path == None and cert_path == None:
+       uid = os.getuid()
+       cert_path = os.path.join(cert_dir, f"tokencert_{uid}.pem")
+       key_path = os.path.join(cert_dir, f"tokenkey_{uid}.pem")
+
+    # Build full URL
+    user_path = 'Users/' + user[0] + '/' + user
+    start = run_number
+    stop = run_number + 1 
+    url = f"{base_url}/browse/{user_path}/MCProdInfo/{lpm_prod_tag}/{start}/{stop}"
+
+    response = requests.get(url, cert=(cert_path, key_path), verify=False)
+    if response.status_code != 404:
+        meta = extract_metadata_blocks_from_CCDB(response.content.decode('utf-8'))
+        if (len(meta) > 0):
+          def filter_known_fields(cls, data: dict) -> dict:
+            valid_keys = {f.name for f in fields(cls)}
+            return {k: v for k, v in data.items() if k in valid_keys}
+        
+          clean_meta = filter_known_fields(MCProdInfo, meta[0])
+          return MCProdInfo(**clean_meta)
+       
+    return None
+
+
+def upload_mcprodinfo_meta(base_url, user, run_number, lpm_prod_tag, keys, cert_dir="/tmp"):
+    """
+    Uploads an empty .dat file using client certificates.
+
+    Parameters:
+    - base_url (str): The base HTTPS URL, e.g., "https://URL"
+    - user (str): The uploader --> Determines location "Users/f/foo_bar/MCProdInfo/..."
+    - keys (dict): Dictionary with meta information to upload, e.g., {"key1": "var1", "key2": "var2"}
+    - cert_dir (str): Directory where the .pem files are located (default: /tmp)
+
+    Returns:
+    - Response object from the POST request
+    """
+    # Create an empty file
+    empty_file = "empty.dat"
+    with open(empty_file, "w") as f:
+        f.write("0")
+
+    # Construct user ID-specific cert and key paths
+    key_path = os.environ.get("JALIEN_TOKEN_KEY")
+    cert_path = os.environ.get("JALIEN_TOKEN_CERT")
+    if key_path == None and cert_path == None:
+       uid = os.getuid()
+       cert_path = os.path.join(cert_dir, f"tokencert_{uid}.pem")
+       key_path = os.path.join(cert_dir, f"tokenkey_{uid}.pem")
+    
+    # Build full URL
+    query = "/".join(f"{k}={v}" for k, v in keys.items())
+    user_path = 'Users/' + user[0] + '/' + user
+    start = run_number
+    stop = run_number + 1 
+    url = f"{base_url}/{user_path}/MCProdInfo/{lpm_prod_tag}/{start}/{stop}/{query}"
+
+    print (f"Full {url}")
+    
+    # Prepare request
+    with open(empty_file, 'rb') as f:
+        files = {'blob': f}
+        response = requests.post(url, files=files, cert=(cert_path, key_path), verify=False)
+
+    # Optional: remove the temporary file
+    os.remove(empty_file)
+
+    return response

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -162,7 +162,7 @@ SEED=${ALIEN_PROC_ID:-${SEED:-1}}
 ONCVMFS=0
 
 if [ "${ALIEN_JDL_O2DPG_OVERWRITE}" ]; then
-  echo "Setting O2DPG_ROOT to overwritten path"
+  echo "Setting O2DPG_ROOT to overwritten path ${ALIEN_JDL_O2DPG_OVERWRITE}"
   export O2DPG_ROOT=${ALIEN_JDL_O2DPG_OVERWRITE}
 fi
 
@@ -287,10 +287,21 @@ MODULES="--skipModules ZDC"
 # Since this is used, set it explicitly
 ALICEO2_CCDB_LOCALCACHE=${ALICEO2_CCDB_LOCALCACHE:-$(pwd)/ccdb}
 
+# publish MCPRODINFO for first few jobs of a production
+# if external script exported PUBLISH_MCPRODINFO, it will be published anyways
+if [ -z "$PUBLISH_MCPRODINFO" ] && [ "$SPLITID" -lt 20 ]; then
+  PUBLISH_MCPRODINFO_OPTION="--publish-mcprodinfo"
+  echo "Will publish MCProdInfo"
+  export AOD_ADDITIONAL_METADATA_FILE="mc-prod-meta-file.json"
+
+else
+  echo "Will not publish MCProdInfo"
+fi
+
 # these arguments will be digested by o2dpg_sim_workflow_anchored.py
 baseargs="-tf ${NTIMEFRAMES} --split-id ${SPLITID} --prod-split ${PRODSPLIT} --cycle ${CYCLE} --run-number ${ALIEN_JDL_LPMRUNNUMBER}                                \
           ${ALIEN_JDL_RUN_TIME_SPAN_FILE:+--run-time-span-file ${ALIEN_JDL_RUN_TIME_SPAN_FILE} ${ALIEN_JDL_INVERT_IRFRAME_SELECTION:+--invert-irframe-selection}}   \
-          ${ALIEN_JDL_MC_ORBITS_PER_TF:+--orbitsPerTF ${ALIEN_JDL_MC_ORBITS_PER_TF}}"
+          ${ALIEN_JDL_MC_ORBITS_PER_TF:+--orbitsPerTF ${ALIEN_JDL_MC_ORBITS_PER_TF}} ${PUBLISH_MCPRODINFO_OPTION}"
 
 # these arguments will be passed as well but only eventually be digested by o2dpg_sim_workflow.py which is called from o2dpg_sim_workflow_anchored.py
 remainingargs="-seed ${SEED} -ns ${NSIGEVENTS} --include-local-qc --pregenCollContext"

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -292,8 +292,6 @@ ALICEO2_CCDB_LOCALCACHE=${ALICEO2_CCDB_LOCALCACHE:-$(pwd)/ccdb}
 if [ -z "$PUBLISH_MCPRODINFO" ] && [ "$SPLITID" -lt 20 ]; then
   PUBLISH_MCPRODINFO_OPTION="--publish-mcprodinfo"
   echo "Will publish MCProdInfo"
-  export AOD_ADDITIONAL_METADATA_FILE="mc-prod-meta-file.json"
-
 else
   echo "Will not publish MCProdInfo"
 fi


### PR DESCRIPTION
This commit provides code that publishes
MonteCarlo MetaData "MCProdInfo" describing a production.

The information is stored into CCDB, into folders
specific to the executing user as well as the LPM production tag.

We now also write the username into AO2D.root, so that clients can retrieve the username next to the LPM production tag.

By default upload of MCProdInfo is attempted for the first few JobIDs within a production. This is decided based on the split-id.