### PR TITLE
Add option to have AO2Ds with prepropagated tracks

### DIFF
--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -803,7 +803,7 @@ if [[ $ALIEN_JDL_THINAODS == "1" ]] ; then
 fi
 
 if [[ $ALIEN_JDL_PREPROPAGATE == "1" ]] ; then
-  export ARGS_EXTRA_PROCESS_o2_aod_producer_workflow+=" --propagate-tracks 1 --propagate-tracks-max-xiu 5"
+  export ARGS_EXTRA_PROCESS_o2_aod_producer_workflow+=" --propagate-tracks --propagate-tracks-max-xiu 5"
 fi
 
 # Enabling QC


### PR DESCRIPTION
Uses https://github.com/AliceO2Group/AliceO2/pull/14544 to allow for tracks that have IB contributions to be pre-propagated at AO2D creation time. Tracks that only have OB contributions are kept as they are to allow for maximum flexibility when handling those while still taking advantage of the pre-propagation for most primary track analyses. 