### PR TITLE
Allow TPC residual extraction in MC and data corr maps in the reco

### DIFF
--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -393,6 +393,11 @@ if [[ "${MCRC}" == "0" && "${ALIEN_JDL_ADDTIMESERIESINMC}" != "0" ]]; then
   # Note: We could maybe avoid this if-else by including `tpctimes` directly in the workflow-targets above
 fi
 
+if [[ "${MCRC}" == "0" && "${ALIEN_JDL_DOTPCRESIDUALEXTRACTION}" = "1" ]]; then
+  echo_info "Running TPC residuals extraction and aggregation"
+    ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt scdaggreg
+fi
+
 [[ -n "${DISABLE_QC}" ]] && echo_info "QC is disabled, skip it."
 
 if [[ -z "${DISABLE_QC}" && "${MCRC}" == "0" && "${remainingargs}" == *"--include-local-qc"* ]] ; then


### PR DESCRIPTION
1) The TPC residuals extraction/aggregation is triggered by `ALIEN_JDL_DOTPCRESIDUALEXTRACTION=1` env.var, as in the standard cpass. The only difference wrt cpass processing is that the calibration slot duration for the `o2-tpc-scdcalib-interpolation-workflow` is set to 1s (`--sec-per-slot 1 `) to maximise the yield of tracks with residuals (virtually all tracks will be used).
In opposite, the `o2-calibration-residual-aggregator` uses `--sec-per-slot` as in the original anchored workflow.

The output is `o2tpc_residuals_<tsmin>_<tsmax>_<tfmin>_<tfmax>.root` files.

2) if `ALIEN_JDL_REMAPPINGS` is defined, it will be applied as `--condition-remap $ALIEN_JDL_REMAPPINGS` added to all workflows supporting this option.