### PR TITLE
Flat Gas external generator under test

### DIFF
--- a/MC/config/common/ini/GeneratorLoopersFlatGas.ini
+++ b/MC/config/common/ini/GeneratorLoopersFlatGas.ini
@@ -1,0 +1,4 @@
+# TPC loopers injector
+[GeneratorExternal]
+fileName = ${O2DPG_MC_CONFIG_ROOT}/MC/config/common/external/generator/TPCLoopers.C
+funcName = Generator_TPCLoopersFlat("ccdb://Users/m/mgiacalo/WGAN_ExtGenPair", "ccdb://Users/m/mgiacalo/WGAN_ExtGenCompton", "${O2DPG_MC_CONFIG_ROOT}/MC/config/common/TPCloopers/ScalerPairParams.json", "${O2DPG_MC_CONFIG_ROOT}/MC/config/common/TPCloopers/ScalerComptonParams.json")


### PR DESCRIPTION
Implemented new loopers external generator based on the previous one (still available): the number of loopers is now adapted to the time interval between one event and the other with a reference set through a parameter in the external gen. The reference loopers number is assigned to the calculated average time interval and a ratio is performed to adjust the loopers event by event. The loopers time is set via a Uniform distribution via a new generateEvent function.
The output from the generator can be found /alice/cern.ch/user/m/mgiacalo/selfjobs/LoopersFlatGasNewExtMean500-20250808-124127. The TPC clusters of this output were processed and they are available here /alice/cern.ch/user/m/mgiacalo/selfjobs/ProcessLoopersNewGenMean500-20250808-141601. 
A flat average of ~10% of loopers clusters is achieved with the default configuration provided by this PR, as shown in the following time plot (in TPC cluster time units).
<img width="986" height="705" alt="image" src="https://github.com/user-attachments/assets/0ac20ed5-d44d-4006-9b31-2526ed0f512d" />
 