### PR TITLE
workflow-multiplicities.sh: use two mch-data-decoder instances by default in synchronous pp and PbPb processing

### DIFF
--- a/DATA/production/workflow-multiplicities.sh
+++ b/DATA/production/workflow-multiplicities.sh
@@ -192,6 +192,7 @@ elif [[ $EPNPIPELINES != 0 ]]; then
     if [[ "${GEN_TOPO_AUTOSCALE_PROCESSES:-}" == "1" && $RUNTYPE == "PHYSICS" ]]; then
       N_MCHCL=$(math_max $((6 * 100 / $RECO_NUM_NODES_WORKFLOW_CMP)) 1)
     fi
+    N_MCHRAWDEC=2
     if [[ "$HIGH_RATE_PP" == "1" ]]; then
       N_TPCITS=$(math_max $((5 * $EPNPIPELINES * $NGPUS / 4)) 1)
       N_TPCENT=$(math_max $((4 * $EPNPIPELINES * $NGPUS / 4)) 1)
@@ -208,6 +209,7 @@ elif [[ $EPNPIPELINES != 0 ]]; then
   else
     if [[ $BEAMTYPE == "PbPb" ]]; then
       N_ITSTRK=$(math_max $((2 * $EPNPIPELINES * $NGPUS / 4)) 1)
+      N_MCHRAWDEC=2
     elif [[ $BEAMTYPE == "cosmic" ]]; then
       N_ITSTRK=$(math_max $((4 * $EPNPIPELINES * $NGPUS / 4)) 1)
     fi


### PR DESCRIPTION
needs https://github.com/AliceO2Group/AliceO2/pull/14625 to be effective