### PR TITLE
PWGHF: Smoothen number of injected signal events vs impact parameter for Pb-Pb collision MC

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
@@ -111,7 +111,7 @@ public:
         LOG(info) << "[notifyEmbedding] ----- Collision impact parameter: " << x;
 
         /// number of events to be embedded in a background event
-        mNumSigEvs = std::max(1.,120.*(x<5.)+80.*(1.-x/20.)*(x>5.)*(x<11.)+240.*(1.-x/13.)*(x>11.));
+        mNumSigEvs = 5 + 0.886202881*std::pow(std::max(0.0f, 17.5f - x),1.7);
         LOG(info) << "[notifyEmbedding] ----- generating " << mNumSigEvs << " signal events " << std::endl;
     };
 


### PR DESCRIPTION
After discussing with @fgrosa we decided to replace the discontinuous function that determines the number of injected signal events to be embedded in a background Pb-Pb event with a smooth function. We also changed the asymptotic behaviour in peripheral events, increasing the number of injected events from 1 to 5, to increase the amount of signal in these collisions. 

Here you can find the comparison between the old (green) and new (red) function:
<img width="1421" height="921" alt="image" src="https://github.com/user-attachments/assets/bd0e6c6e-5108-4363-aad6-d380aea32eae" />

Tagging also @mfaggin for information
