### PR TITLE
Target refactor in anchoredMC; Improvements for early file removal

### DIFF
--- a/MC/bin/o2dpg_qc_finalization_workflow.py
+++ b/MC/bin/o2dpg_qc_finalization_workflow.py
@@ -46,7 +46,7 @@ def include_all_QC_finalization(ntimeframes, standalone, run, productionTag, con
     if standalone == True:
       needs = []
     elif needs == None:
-      needs = [taskName + '_local' + str(tf) for tf in range(1, ntimeframes + 1)]
+      needs = [taskName + '_local_' + str(tf) for tf in range(1, ntimeframes + 1)]
 
     task = createTask(name=QC_finalize_name(taskName), needs=needs, cwd=qcdir, lab=["QC"], cpu=1, mem='2000')
     def remove_json_prefix(path):

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1726,7 +1726,7 @@ for tf in range(1, NTIMEFRAMES + 1):
    if includeFullQC or includeLocalQC:
 
      def addQCPerTF(taskName, needs, readerCommand, configFilePath, objectsFile=''):
-       task = createTask(name=taskName + '_local' + str(tf), needs=needs, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
+       task = createTask(name=taskName + '_local_' + str(tf), needs=needs, tf=tf, cwd=timeframeworkdir, lab=["QC"], cpu=1, mem='2000')
        objectsFile = objectsFile if len(objectsFile) > 0 else taskName + '.root'
 
        def remove_json_prefix(path):


### PR DESCRIPTION
Changes the way we construct targets in anchorMC: Instead of calling different workflows in order (AOD, TPC-time-series, QC), we now execute one single workflow with all necessary targets in one go. This has the advantage that we can apply "early-file-removal" more easily and should also lead to CPU efficiency improvements.

Some other improvements in anchoredMC:
- allow to create just the workflow.json file
- allow to inject additional options for the workflow runner

The changes in o2dpg_workflow_runner.py concern mostly improvements for the early-artefact removal. E.g.:
- do not remove artefacts when they belong to a final target task
- add global disc space monitoring to measure benefit of early-file removal