### PR TITLE
fix detectorList argument for Pb-Pb

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -818,7 +818,7 @@ for tf in range(1, NTIMEFRAMES + 1):
                         + ('', ' --timestamp ' + str(args.timestamp))[args.timestamp!=-1] + ' --run ' + str(args.run) \
                         + ' --seed ' + str(TFSEED)                                                                    \
                         + ' -g extgen '                                                                               \
-                        + ' --detectorList ' + args.detectorList                                                      \
+                        + ' --detectorList ' + args.detectorList + ' '                                                \
                         + QEDCONFKEY
      QED_task['cmd'] += '; RC=$?; QEDXSecCheck=`grep xSectionQED qedgenparam.ini | sed \'s/xSectionQED=//\'`'
      QED_task['cmd'] += '; echo "CheckXSection ' + str(QEDXSecExpected[COLTYPE]) + ' = $QEDXSecCheck"; [[ ${RC} == 0 ]]'


### PR DESCRIPTION
In #2128, I introduced a bug where the detectorList argument did not have a separating space after it.
This leads to an incorrect construction of the cmd string `--detectorList ALICE2--configKeyValues` for the qed background sim. I only tested my changes in pp not in Pb-Pb...sorry