### PR TITLE
TRD QC: Do not write tracklets

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1849,9 +1849,10 @@ for tf in range(1, NTIMEFRAMES + 1):
                  configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/tpc-qc-standard-direct.json')
 
      ### TRD
+     # TODO: check if the readerCommand also reperforms tracklet construction (which already done in digitization)
      addQCPerTF(taskName='trdDigitsQC',
                 needs=[TRDDigitask['name']],
-                readerCommand='o2-trd-trap-sim',
+                readerCommand='o2-trd-trap-sim --disable-root-output true',
                 configFilePath='json://${O2DPG_ROOT}/MC/config/QC/json/trd-standalone-task.json')
 
      addQCPerTF(taskName='trdTrackingQC',


### PR DESCRIPTION
While studying file-access graphs in O2DPG MC, I noticed that trdtracklets.root get written twice: Once from the digitizer workflow and once from the TRD-DIGI-QC task. This can corrupt the processing and is probably a bug. QC should only read digits/trdtracklets.

The reason appears to be the use of `o2-trd-trap-sim` as the reader command for digits and tracklets.

For now, the problem can probably be avoided by using `o2-trd-trap-sim --disable-root-output true`.

However, this might still create new trdtracklets in memory which should not be needed as they have been previously created during digitization.

So it would be good to just use a true `o2-trd-sim-artefacts-reader` workflow or similar in the future.