### PR TITLE
anchorMC: Improve checking of essential variables

### DIFF
--- a/MC/prodinfo/mcprodinfo_ccdb_upload.py
+++ b/MC/prodinfo/mcprodinfo_ccdb_upload.py
@@ -148,6 +148,10 @@ def upload_mcprodinfo_meta(base_url, user, run_number, lpm_prod_tag, keys, cert_
 def publish_MCProdInfo(mc_prod_info, ccdb_url = "https://alice-ccdb.cern.ch", username = "aliprod", force_overwrite=False, include_meta_into_aod=False):
    print("Publishing MCProdInfo")
 
+   if mc_prod_info.LPMProductionTag == None or len(mc_prod_info.LPMProductionTag) == 0:
+       print ("No LPM production tag found; Not publishing")
+       return
+
    # see if this already has meta-data uploaded, otherwise do nothing
    mc_prod_info_q = query_mcprodinfo(ccdb_url, username, mc_prod_info.RunNumber, mc_prod_info.LPMProductionTag)
    if mc_prod_info_q == None or force_overwrite == True:

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -119,18 +119,7 @@ export ALIEN_JDL_LPMANCHORYEAR=${ALIEN_JDL_LPMANCHORYEAR:-${ANCHORYEAR}}
 # decide whether to run TPC time series; on by default, switched off by setting to 0
 export ALIEN_JDL_ADDTIMESERIESINMC=${ALIEN_JDL_ADDTIMESERIESINMC:-1}
 
-# cache the production tag, will be set to a special anchor tag; reset later in fact
-ALIEN_JDL_LPMPRODUCTIONTAG_KEEP=$ALIEN_JDL_LPMPRODUCTIONTAG
-echo_info "Substituting ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMPRODUCTIONTAG with ALIEN_JDL_LPMANCHORPRODUCTION=$ALIEN_JDL_LPMANCHORPRODUCTION for simulating reco pass..."
-ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMANCHORPRODUCTION
-
-if [[ $ALIEN_JDL_ANCHOR_SIM_OPTIONS == *"--tpc-distortion-type 2"* ]]; then
-  export O2DPG_ENABLE_TPC_DISTORTIONS=ON
-  # set the SCALING SOURCE to CTP for MC unless explicitely given from outside
-  export ALIEN_JDL_TPCSCALINGSOURCE=${ALIEN_JDL_TPCSCALINGSOURCE:-"CTP"}
-fi
-
-# check variables that need to be set
+# check for presence of essential variables that need to be set
 [ -z "${ALIEN_JDL_LPMANCHORPASSNAME}" ] && { echo_error "Set ALIEN_JDL_LPMANCHORPASSNAME or ANCHORPASSNAME" ; exit 1 ; }
 [ -z "${ALIEN_JDL_LPMRUNNUMBER}" ] && { echo_error "Set ALIEN_JDL_LPMRUNNUMBER or RUNNUMBER" ; exit 1 ; }
 [ -z "${ALIEN_JDL_LPMPRODUCTIONTYPE}" ] && { echo_error "Set ALIEN_JDL_LPMPRODUCTIONTYPE or PRODUCTIONTYPE" ; exit 1 ; }
@@ -143,6 +132,19 @@ fi
 [ -z "${NTIMEFRAMES}" ] && { echo_error "Set NTIMEFRAMES" ; exit 1 ; }
 [ -z "${SPLITID}" ] && { echo_error "Set SPLITID" ; exit 1 ; }
 [ -z "${PRODSPLIT}" ] && { echo_error "Set PRODSPLIT" ; exit 1 ; }
+
+
+# cache the production tag, will be set to a special anchor tag; reset later in fact
+ALIEN_JDL_LPMPRODUCTIONTAG_KEEP=$ALIEN_JDL_LPMPRODUCTIONTAG
+echo_info "Substituting ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMPRODUCTIONTAG with ALIEN_JDL_LPMANCHORPRODUCTION=$ALIEN_JDL_LPMANCHORPRODUCTION for simulating reco pass..."
+ALIEN_JDL_LPMPRODUCTIONTAG=$ALIEN_JDL_LPMANCHORPRODUCTION
+
+if [[ $ALIEN_JDL_ANCHOR_SIM_OPTIONS == *"--tpc-distortion-type 2"* ]]; then
+  export O2DPG_ENABLE_TPC_DISTORTIONS=ON
+  # set the SCALING SOURCE to CTP for MC unless explicitely given from outside
+  export ALIEN_JDL_TPCSCALINGSOURCE=${ALIEN_JDL_TPCSCALINGSOURCE:-"CTP"}
+fi
+
 
 # The number of signal events can be given, but should be useful only in
 # certain expert modes. In the default case, the final event number is determined by the timeframe length.


### PR DESCRIPTION
* we need to check for variable presence before any assignment
* prevent publication of MCProd when LPM production tag was empty