### PR TITLE
Config files for the charm baryon in ppref

### DIFF
--- a/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
+++ b/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
@@ -17,9 +17,9 @@ Init:showChangedParticleData = on
 ### Ξc+ -> p φ (10%)
 4232:addChannel = 1 0.10000 0 2212 333             ### Ξc+ -> p φ
 ### Ξc+ -> sigma+ π+ π- (10%)
-4232:addChannel = 1 0.10000 0 3222 -211 211        ### Ξc+ -> sigma+ π- π+ 1.37%
+4232:addChannel = 1 0.12500 0 3222 -211 211        ### Ξc+ -> sigma+ π- π+ 1.37%
 ### Ξc+ -> Ξ*0 π+ (10%)
-4232:addChannel = 1 0.10000 0 3324 211
+4232:addChannel = 1 0.12500 0 3324 211
 
 ### Ξc+ -> p K- π+
 4232:onIfMatch = 2212 321 211

--- a/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
+++ b/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
@@ -1,0 +1,82 @@
+# Decay configuration taken from MC/config/PWGHF/pythia8/generator/pythia8_charmhadronic_with_decays_Mode2_pp_ref.cfg
+Init:showChangedParticleData = on
+4332:tau0 = 0.0803     # OmegaC
+4132:tau0 = 0.0455     # Xic0
+
+# switch off all decay channels
+4232:onMode = off
+4332:onMode = off
+4132:onMode = off
+
+## Xic decays
+### Ξc+ -> p K- π+ (35%)
+4232:oneChannel = 1 0.17500 0 2212 -321 211        ### Ξc+ -> p K- π+ 6.18e-3
+4232:addChannel = 1 0.17500 0 2212 -313            ### Ξc+ -> p antiK*0(892)
+### Ξc+ -> Ξ- π+ π+ (35%) (set the same as Ξc+ -> p K- π+)
+4232:addChannel = 1 0.35000 0 3312 211 211        ### Ξc+ -> Ξ- π+ π+ 2.86%
+### Ξc+ -> p φ (10%)
+4232:addChannel = 1 0.10000 0 2212 333             ### Ξc+ -> p φ
+### Ξc+ -> sigma+ π+ π- (10%)
+4232:addChannel = 1 0.12500 0 3222 -211 211        ### Ξc+ -> sigma+ π- π+ 1.37%
+### Ξc+ -> Ξ*0 π+ (10%)
+4232:addChannel = 1 0.12500 0 3324 211 # is this decay channel existing?
+
+### Ξc+ -> p K- π+
+4232:onIfMatch = 2212 321 211
+### Ξc+ -> p antiK*0(892)
+4232:onIfMatch = 2212 313
+### Ξc+ -> p φ
+4232:onIfMatch = 2212 333
+### Ξc+ -> sigma+ π+ π- (10%)
+4232:onIfMatch = 3222 211 211
+### Ξc+ -> Ξ*0 π+, Ξ*0 -> Ξ- π+
+4232:onIfMatch = 3324 211
+### Ξc+ -> Ξ- π+ π+
+4232:onIfMatch = 3312 211 211
+
+## Xic0 decays
+### add Xic0 decays absent in PYTHIA8 decay table
+4132:oneChannel = 1 0.0143 0 3312 211               ### Xi_c()0 --> Xi- pi+ 0.01432524810113947
+
+### Xic0 -> Xi- pi+
+4132:onIfMatch = 3312 211
+# Matching Exclusive Decay Channels:
+# -------------------------------------------------------
+# Xi_c()0 --> Xi- pi+                      0.01432524810113947
+#   -> PDG Codes: 3312, 211
+# Xi_c()0 --> Xi- pi+ pi+ pi-              0.04775082700379833
+#   -> PDG Codes: 3312, 211, 211, -211
+
+## OmegaC decays
+### add custom OmegaC decays absent in PYTHIA8 decay table
+4332:oneChannel = 1 0.5 0 3334 211
+4332:addChannel = 1 0.5 0 3312 211
+
+### Omega_c -> Omega pi
+4332:onIfMatch = 3334 211
+# Matching Exclusive Decay Channels:
+# -------------------------------------------------------
+# Omega_c()0 --> Omega- pi+                None
+#   -> PDG Codes: 3334, 211
+# Omega_c()0 --> Omega- pi+ pi0            1.79939678284182
+#   -> PDG Codes: 3334, 211, 111
+# Omega_c()0 --> Omega- pi- 2 pi+          0.30954954954955
+#   -> PDG Codes: 3334, -211, [2], 211
+
+### Omega_c -> Xi pi
+4332:onIfMatch = 3312 211
+# Matching Exclusive Decay Channels:
+# -------------------------------------------------------
+# Omega_c()0 --> Xi- Kbar0 pi+             2.12
+#   -> PDG Codes: 3312, -311, 211
+# Omega_c()0 --> Xi- K- 2 pi+              0.625932203389831
+#   -> PDG Codes: 3312, -321, [2], 211
+
+## Allow the decay of resonances in the decay chain
+### for Xic0 -> pi Xi -> pi pi Lambda -> pi pi pi p 
+### and Omega_c -> pi Xi -> pi pi Lambda -> pi pi pi p
+3312:onMode = off
+3312:onIfAll = 3122 -211
+### for Omega_c -> pi Omega -> pi K Lambda -> pi K pi p
+3334:onMode = off
+3334:onIfAll = 3122 -321

--- a/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
+++ b/MC/config/PWGHF/pythia8/decayer/force_hadronic_charmbaryon.cfg
@@ -17,9 +17,9 @@ Init:showChangedParticleData = on
 ### Ξc+ -> p φ (10%)
 4232:addChannel = 1 0.10000 0 2212 333             ### Ξc+ -> p φ
 ### Ξc+ -> sigma+ π+ π- (10%)
-4232:addChannel = 1 0.12500 0 3222 -211 211        ### Ξc+ -> sigma+ π- π+ 1.37%
+4232:addChannel = 1 0.10000 0 3222 -211 211        ### Ξc+ -> sigma+ π- π+ 1.37%
 ### Ξc+ -> Ξ*0 π+ (10%)
-4232:addChannel = 1 0.12500 0 3324 211 # is this decay channel existing?
+4232:addChannel = 1 0.10000 0 3324 211
 
 ### Ξc+ -> p K- π+
 4232:onIfMatch = 2212 321 211

--- a/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
+++ b/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
@@ -65,4 +65,4 @@
 /mcPhysics/biasing/setParticles proton neutron pi+ pi-
 
 # external decayer
-/mcPhysics/setExtDecayerSelection omega_c0 anti_omega_c0 xi_c0 anti_xi_c0 xi_c+
+/mcPhysics/setExtDecayerSelection omega_c0 anti_omega_c0 xi_c0 anti_xi_c0 xi_c+ xi_c-

--- a/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
+++ b/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
@@ -1,0 +1,68 @@
+
+/control/verbose 2
+/mcVerbose/all 1
+/mcVerbose/geometryManager 1
+/mcVerbose/opGeometryManager 1
+/mcTracking/loopVerbose 1
+/mcVerbose/composedPhysicsList 2
+/mcVerbose/runAction 2   # For looping thresholds control
+#/tracking/verbose 1
+#//control/cout/ignoreThreadsExcept 0
+
+/mcPhysics/rangeCuts 0.001 mm
+/mcRegions/setRangePrecision 5
+/mcTracking/skipNeutrino true
+/mcDet/setIsMaxStepInLowDensityMaterials true
+/mcDet/setMaxStepInLowDensityMaterials 10 m
+/mcMagField/setConstDistance 1 mm
+/mcDet/setIsZeroMagField true
+/mcControl/useRootRandom true # couple G4 random seed to gRandom
+
+# optical
+
+/process/optical/verbose 0
+/process/optical/processActivation Scintillation 0
+/process/optical/processActivation OpWLS 0
+/process/optical/processActivation OpMieHG 0
+/process/optical/cerenkov/setTrackSecondariesFirst false
+/mcMagField/stepperType NystromRK4
+
+# PAI for TRD
+# Geant4 VMC >= v3.2
+/mcPhysics/emModel/setEmModel  PAI
+/mcPhysics/emModel/setRegions  TRD_Gas-mix
+/mcPhysics/emModel/setParticles  all
+/mcPrimaryGenerator/skipUnknownParticles true # don't crash when seeing unknown ion etc. (issue warning)
+
+#
+# Precise Msc for EMCAL
+#
+# Geant4 VMC >= v3.2
+/mcPhysics/emModel/setEmModel  SpecialUrbanMsc
+/mcPhysics/emModel/setRegions  EMC_Lead$ EMC_Scintillator$
+/mcPhysics/emModel/setParticles  e- e+
+
+# combined transportation + Msc mode is currently broken for ALICE (Geant 10.2.0)
+/process/em/transportationWithMsc Disabled
+
+#
+# Adding extra lines for fixing tracking bias
+#
+/mcMagField/setDeltaIntersection  1.0e-05 mm
+/mcMagField/setMinimumEpsilonStep 0.5e-05
+/mcMagField/setMaximumEpsilonStep 1.0e-05
+/mcMagField/printParameters
+
+# Change default parameters for killing looping particles
+#
+/mcPhysics/useHighLooperThresholds
+/mcRun/setLooperThresholdImportantEnergy 100. MeV
+
+# Define media with the INCLXX physics list; here basically in all ITS media
+#/mcVerbose/biasingConfigurationManager 3
+/mcPhysics/biasing/setModel inclxx
+/mcPhysics/biasing/setRegions ITS_AIR$ ITS_WATER$ ITS_COPPER$ ITS_KAPTON(POLYCH2)$ ITS_GLUE_IBFPC$ ITS_CERAMIC$ ITS_K13D2U2k$ ITS_K13D2U120$ ITS_F6151B05M$ ITS_M60J3K$ ITS_M55J6K$ ITS_FGS003$ ITS_CarbonFleece$ ITS_PEEKCF30$ ITS_GLUE$ ITS_ALUMINUM$ ITS_INOX304$ ALPIDE_METALSTACK$ ALPIDE_SI$
+/mcPhysics/biasing/setParticles proton neutron pi+ pi-
+
+# external decayer
+/mcPhysics/setExtDecayerSelection omega_c0 anti_omega_c0 xi_c0 anti_xi_c0 xi_c+

--- a/MC/config/common/pythia8/generator/pythia8_inel_536.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_536.cfg
@@ -1,0 +1,11 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 5360.0 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.	


### PR DESCRIPTION
This PR is for the configuration files used to produce the charm-baryon MC in pp ref.
- A decayer `.cfg` file
- A Geant4 `.in` file, which is the same as the standard one, except for the `setExtDecayerSelection`
- A Pythia8 generator `.cfg` file. Because I see the inelastic one is always used in the previous MC production with pre-generated event pools, instead of the HF one. So, I used the inelastic process and just changed the energy to 5360
Please let me know if you have any suggestions or comments! Thanks a lot!