### PR TITLE
Update of FIT digitizer parameters for 2025 data

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -117,7 +117,7 @@ def create_sim_config(args):
             add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
             # FV0 trigger settings
             add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "1080"})
-        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
+        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPEIR == "pO":
             # central and semicentral FT0 thresholds 
             add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
             # FV0 trigger settings
@@ -125,7 +125,7 @@ def create_sim_config(args):
         if COLTYPEIR == "pp":
             # 15 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
-        if COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
+        if COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPEIR == "pO":
             # 11 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "11"})
 

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -117,7 +117,7 @@ def create_sim_config(args):
             add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
             # FV0 trigger settings
             add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "1080"})
-        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe":
+        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
             # central and semicentral FT0 thresholds 
             add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
             # FV0 trigger settings

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -125,7 +125,7 @@ def create_sim_config(args):
         if COLTYPEIR == "pp":
             # 15 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
-        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
+        if COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
             # 11 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "11"})
 

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -110,34 +110,24 @@ def create_sim_config(args):
     if 562260 <= int(args.run) and int(args.run) <= 568721:
         # 14 ADC channels / MIP for FT0
         add(config, {"FT0DigParam.mMip_in_V": "7", "FT0DigParam.mMV_2_Nchannels": "2", "FT0DigParam.mMV_2_NchannelsInverse": "0.5"})
-        # 15 ADC channels / MIP for FV0
-        add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
         if COLTYPEIR == "PbPb":
             # 4 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
             # central and semicentral FT0 thresholds 
             add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
             # FV0 trigger settings
-            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
-        if COLTYPEIR == "OO":
-            # 4 ADC channels / MIP
-            add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
-            # central and semicentral FT0 thresholds 
-            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
-            # FV0 trigger settings
-            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
-        if COLTYPEIR == "NeNe":
-            # 4 ADC channels / MIP
-            add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
-            # central and semicentral FT0 thresholds 
-            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
-            # FV0 trigger settings
-            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
-        if COLTYPEIR == "pp":
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "1080"})
+        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe":
             # central and semicentral FT0 thresholds 
             add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
             # FV0 trigger settings
             add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
+        if COLTYPEIR == "pp":
+            # 15 ADC channels / MIP
+            add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
+        if COLTYPEIR == "pp" or COLTYPEIR == "OO" or COLTYPEIR == "NeNe" or COLTYPIER == "pO":
+            # 11 ADC channels / MIP
+            add(config, {"FV0DigParam.adcChannelsPerMip": "11"})
 
     return config
 

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -105,6 +105,39 @@ def create_sim_config(args):
         if COLTYPEIR == "PbPb":
             # 4 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+    # 2025
+    # first and last run of 2025
+    if 562260 <= int(args.run) and int(args.run) <= 568721:
+        # 14 ADC channels / MIP for FT0
+        add(config, {"FT0DigParam.mMip_in_V": "7", "FT0DigParam.mMV_2_Nchannels": "2", "FT0DigParam.mMV_2_NchannelsInverse": "0.5"})
+        # 15 ADC channels / MIP for FV0
+        add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
+        if COLTYPEIR == "PbPb":
+            # 4 ADC channels / MIP
+            add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
+        if COLTYPEIR == "OO":
+            # 4 ADC channels / MIP
+            add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
+        if COLTYPEIR == "NeNe":
+            # 4 ADC channels / MIP
+            add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
+        if COLTYPEIR == "pp":
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
 
     return config
 


### PR DESCRIPTION
This PR updates FT0 and FV0 digitizer settings for Run 3 data (runs 562260–568721) to better reflect 2025 conditions and recent digitizer improvements.

Key changes
FT0 calibration: set to ~14 ADC/MIP (mMip_in_V = 7, updated conversion factors)
System-dependent tuning:
- Pb–Pb: DCS-consistent FT0 thresholds and FV0 charge settings adapted to high multiplicity
- pp / OO / NeNe: DCS-consistent FT0 thresholds and FV0 charge levels for low-multiplicity systems
FV0 ADC/MIP:
- pp: 15
- light systems (OO, NeNe, pO): 11