### PR TITLE
[PWGHF] removed primary deuteron from PYTHIA 

### DIFF
--- a/MC/config/PWGHF/pythia8/generator/pythia8_lambdab_probQQtoQ.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_lambdab_probQQtoQ.cfg
@@ -10,13 +10,6 @@ SoftQCD:inelastic on		# all inelastic processes
 ParticleDecays:limitTau0 on	
 ParticleDecays:tau0Max 10.
 
-# enable deuteron production by coalescence collisions
-HadronLevel:DeuteronProduction = on
-DeuteronProduction:channels = {2212 2112 > 22}
-DeuteronProduction:models = {0}
-DeuteronProduction:norm = 1
-DeuteronProduction:parms = {0.5 1} # coalescence momentum p0 in GeV/c
-
 ### switching on Pythia Mode2
 ColourReconnection:mode 1
 ColourReconnection:allowDoubleJunRem off


### PR DESCRIPTION
[PWGHF] Primary deuteron production in PYTHIA removed to avoid conflicts with secondary deuterons.