### PR TITLE
Add configurations for rescattering in Pythia8 in pp 13.6 TeV and in Pythia8 Angantyr OO 5.36 TeV

### DIFF
--- a/MC/config/ALICE3/ini/pythia8_pp_rescattering_136tev.ini
+++ b/MC/config/ALICE3/ini/pythia8_pp_rescattering_136tev.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator/pythia8_pp_rescattering_136tev.cfg

--- a/MC/config/ALICE3/ini/tests/pythia8_pp_rescattering_136tev.C
+++ b/MC/config/ALICE3/ini/tests/pythia8_pp_rescattering_136tev.C
@@ -1,0 +1,24 @@
+int External() {
+  std::string path{"o2sim_Kine.root"};
+
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie()) {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree) {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  auto nEvents = tree->GetEntries();
+  if (nEvents == 0) {
+    std::cerr << "No event of interest\n";
+    return 1;
+  }
+  return 0;
+}

--- a/MC/config/ALICE3/pythia8/generator/pythia8_pp_rescattering_136tev.cfg
+++ b/MC/config/ALICE3/pythia8/generator/pythia8_pp_rescattering_136tev.cfg
@@ -1,0 +1,23 @@
+### Specify beams
+Beams:idA = 2212
+Beams:idB = 2212            
+Beams:eCM = 13600.              ### energy
+    
+Beams:frameType = 1
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+
+### processes
+SoftQCD:inelastic = on # all inelastic processes
+
+# default: do nothing, Monash 2013 will do its thing
+Tune:pp = 14
+
+### enable hadronic rescattering
+HadronLevel:Rescatter = on # default = off
+Fragmentation:setVertices = on # default = off
+PartonVertex:setVertex = on # default = off
+Rescattering:nearestNeighbours = off # default = on (but "require a larger retuning effort")
+Rescattering:inelastic = on # default = on
+
+Random:setSeed = on

--- a/MC/config/common/ini/pythia8_OO_rescattering_536.ini
+++ b/MC/config/common/ini/pythia8_OO_rescattering_536.ini
@@ -1,0 +1,9 @@
+[Diamond]
+width[2]=6.0
+
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/pythia8/generator_pythia8_ALICE3.C
+funcName=generator_pythia8_ALICE3()
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_OO_rescattering_536.cfg

--- a/MC/config/common/ini/tests/pythia8_OO_rescattering_536.C
+++ b/MC/config/common/ini/tests/pythia8_OO_rescattering_536.C
@@ -1,0 +1,24 @@
+int External() {
+  std::string path{"o2sim_Kine.root"};
+
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie()) {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree) {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  auto nEvents = tree->GetEntries();
+  if (nEvents == 0) {
+    std::cerr << "No event of interest\n";
+    return 1;
+  }
+  return 0;
+}

--- a/MC/config/common/pythia8/generator/pythia8_OO_rescattering_536.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_OO_rescattering_536.cfg
@@ -1,0 +1,22 @@
+### OO beams
+Beams:idA = 1000080160
+Beams:idB = 1000080160           
+Beams:eCM = 5360.0                ### energy
+    
+Beams:frameType = 1
+ParticleDecays:limitTau0 = on
+ParticleDecays:tau0Max = 10.      ### match alice: 1cm/c = 10.0mm/c
+
+### Save some CPU at init of jobs
+### To avoid refitting, add the following lines to your configuration file:
+HeavyIon:SigFitNGen = 0
+HeavyIon:SigFitDefPar = 2.15,18.42,0.33
+
+### enable hadronic rescattering
+HadronLevel:Rescatter = on # default = off
+Fragmentation:setVertices = on # default = off
+PartonVertex:setVertex = on # default = off
+Rescattering:nearestNeighbours = off # default = on (but "require a larger retuning effort")
+Rescattering:inelastic = on # default = on
+    
+Random:setSeed = on


### PR DESCRIPTION
Add the following option to copies of the existing configurations
HadronLevel:Rescatter = on # default = off
Fragmentation:setVertices = on # default = off
PartonVertex:setVertex = on # default = off
Rescattering:nearestNeighbours = off # default = on (but "require a larger retuning effort")
Rescattering:inelastic = on # default = on

@ddobrigk for your information