### PR TITLE
fix: sanitize shell/subprocess call in o2_dpg_workflow_runner.py

### DIFF
--- a/MC/bin/o2_dpg_workflow_runner.py
+++ b/MC/bin/o2_dpg_workflow_runner.py
@@ -110,8 +110,10 @@ metriclogger.info(meta)
 # TODO: integrate into standard logger
 def send_webhook(hook, t):
     if hook!=None:
-      command="curl -X POST -H 'Content-type: application/json' --data '{\"text\":\" " + str(t) + "\"}' " + str(hook) + " &> /dev/null"
-      os.system(command)
+      import json
+      data = json.dumps({"text": " " + str(t)})
+      subprocess.run(["curl", "-X", "POST", "-H", "Content-type: application/json", "--data", data, str(hook)],
+                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 # A fallback solution to getting all child procs
 # in case psutil has problems (PermissionError).


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `MC/bin/o2_dpg_workflow_runner.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `MC/bin/o2_dpg_workflow_runner.py:114` |
| **CWE** | CWE-78 |

**Description**: The workflow runner uses os.system() at multiple locations to execute commands constructed from workflow configuration data. os.system() invokes a shell, making it vulnerable to command injection if any part of the command string is derived from untrusted input such as workflow JSON files, task names, or file paths.

## Changes
- `MC/bin/o2_dpg_workflow_runner.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
