### PR TITLE
[PWGHF] Add possibility to use EVTGEN in HF generator + config for B2Jpsi

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -38,6 +38,7 @@ public:
     mHadronPdgList = hadronPdgList;
     mPartPdgToReplaceList = partPdgToReplaceList;
     mFreqReplaceList = freqReplaceList;
+    mEvtGen = nullptr;
     mUseEvtGen = false;
     mEvtGenDecTable = "";
     // Ds1*(2700), Ds1*(2860), Ds3*(2860), Xic(3055)+, Xic(3080)+, Xic(3055)0, Xic(3080)0, LambdaC(2625), LambdaC(2595), LambdaC(2860), LambdaC(2880), LambdaC(2940), ThetaC(3100)
@@ -186,7 +187,7 @@ protected:
       {
         if (GeneratorPythia8::generateEvent())
         {
-          if (mEvtGen) {
+          if (mUseEvtGen) {
             mEvtGen->decay();
             checkConsistency();
           }
@@ -203,7 +204,7 @@ protected:
       {
         genOk = GeneratorPythia8::generateEvent();
         if (genOk) {
-          if (mEvtGen) {
+          if (mUseEvtGen) {
             mEvtGen->decay();
             checkConsistency();
           }

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -386,17 +386,11 @@ protected:
   void checkConsistency() {
     for (int iPart{1}; iPart<mPythia.event.size(); ++iPart) {
       // verify if all particles of decay chain are in the TDatabasePDG
+      // taken from https://github.com/AliceO2Group/O2DPG/blob/master/MC/config/PWGDQ/EvtGen/GeneratorEvtGen.C
       if (!TDatabasePDG::Instance()->GetParticle(abs(mPythia.event[iPart].id()))) {
-        std::cout << "Particle code non known in TDatabasePDG " << mPythia.event[iPart].id() << " - set pdg = 89" << std::endl;
+        // std::cout << "Particle code non known in TDatabasePDG " << mPythia.event[iPart].id() << " - set pdg = 89" << std::endl;
         mPythia.event[iPart].id(89);
       }
-
-      // istat = mEvtstdhep->getIStat(i);
-
-      // if (istat != 1 && istat != 2)
-      //   std::cout << "ImportParticles: Attention unknown status code!" << std::endl;
-      // if (istat == 2)
-      //   istat = 11; // status decayed
     }
   }
 

--- a/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
@@ -1,7 +1,12 @@
+R__LOAD_LIBRARY(EvtGen)
+R__ADD_INCLUDE_PATH($EVTGEN_ROOT/include)
+
 #include "FairGenerator.h"
 #include "Generators/GeneratorPythia8.h"
 #include "Generators/GeneratorPythia8Param.h"
+#include "EvtGen/EvtGen.hh"
 #include "Pythia8/Pythia.h"
+#include "Pythia8Plugins/EvtGen.h"
 #include "TRandom.h"
 #include "TDatabasePDG.h"
 #include <fairlogger/Logger.h>
@@ -33,6 +38,8 @@ public:
     mHadronPdgList = hadronPdgList;
     mPartPdgToReplaceList = partPdgToReplaceList;
     mFreqReplaceList = freqReplaceList;
+    mUseEvtGen = false;
+    mEvtGenDecTable = "";
     // Ds1*(2700), Ds1*(2860), Ds3*(2860), Xic(3055)+, Xic(3080)+, Xic(3055)0, Xic(3080)0, LambdaC(2625), LambdaC(2595), LambdaC(2860), LambdaC(2880), LambdaC(2940), ThetaC(3100)
     mCustomPartPdgs = {30433, 40433, 437, 4315, 4316, 4325, 4326, 4124, 14122, 24124, 24126, 4125, 9422111};
     mCustomPartMasses[30433] = 2.714f;
@@ -114,6 +121,10 @@ public:
       pdgToReplace.push_back(mPartPdgToReplaceList[iRepl].at(0));
     }
 
+    if (mUseEvtGen) {
+      mEvtGen = new Pythia8::EvtGenDecays(&mPythia, mEvtGenDecTable.data(), gSystem->ExpandPathName("$EVTGEN_ROOT/share/EvtGen/evt.pdl"));
+    }
+
     return o2::eventgen::GeneratorPythia8::Init();
   }
 
@@ -135,6 +146,14 @@ public:
   {
     return mUsedSeed;
   };
+  void setUseEvtGenDecayer(std::string evtGenDecTable = "") {
+    mUseEvtGen = true;
+    if (evtGenDecTable.empty()) {
+      mEvtGenDecTable = gSystem->ExpandPathName("$EVTGEN_ROOT/share/EvtGen/DECAY.DEC");
+    } else {
+      mEvtGenDecTable = gSystem->ExpandPathName(evtGenDecTable.data());
+    }
+  }
 
 protected:
   //__________________________________________________________________
@@ -167,6 +186,10 @@ protected:
       {
         if (GeneratorPythia8::generateEvent())
         {
+          if (mEvtGen) {
+            mEvtGen->decay();
+            checkConsistency();
+          }
           genOk = selectEvent();
         }
       }
@@ -179,6 +202,12 @@ protected:
       while (!genOk)
       {
         genOk = GeneratorPythia8::generateEvent();
+        if (genOk) {
+          if (mEvtGen) {
+            mEvtGen->decay();
+            checkConsistency();
+          }
+        }
       }
       notifySubGenerator(0);
     }
@@ -197,6 +226,8 @@ protected:
 
     for (auto iPart{0}; iPart < mPythia.event.size(); ++iPart)
     {
+
+
       // search for Q-Qbar mother with at least one Q in rapidity window
       if (!isGoodAtPartonLevel)
       {
@@ -352,11 +383,28 @@ protected:
     return true;
   }
 
+  void checkConsistency() {
+    for (int iPart{1}; iPart<mPythia.event.size(); ++iPart) {
+      // verify if all particles of decay chain are in the TDatabasePDG
+      if (!TDatabasePDG::Instance()->GetParticle(abs(mPythia.event[iPart].id()))) {
+        std::cout << "Particle code non known in TDatabasePDG " << mPythia.event[iPart].id() << " - set pdg = 89" << std::endl;
+        mPythia.event[iPart].id(89);
+      }
+
+      // istat = mEvtstdhep->getIStat(i);
+
+      // if (istat != 1 && istat != 2)
+      //   std::cout << "ImportParticles: Attention unknown status code!" << std::endl;
+      // if (istat == 2)
+      //   istat = 11; // status decayed
+    }
+  }
+
   private:
   // Interface to override import particles
   Pythia8::Event mOutputEvent;
 
-  // Properties of selection
+// Properties of selection
   int mQuarkPdg;
   float mQuarkRapidityMin;
   float mQuarkRapidityMax;
@@ -379,6 +427,12 @@ protected:
 
   // Control alternate trigger on different hadrons
   std::vector<int> mHadronPdgList = {};
+
+  // EVTGEN decayer from PYTHIA8 plugins
+  Pythia8::EvtGenDecays *mEvtGen;
+  bool mUseEvtGen;
+  std::string mEvtGenDecTable;
+
 };
 
 // Predefined generators:
@@ -444,5 +498,22 @@ FairGenerator *GeneratorPythia8GapHF(int inputTriggerRatio, float yQuarkMin = -1
   myGen->setQuarkRapidity(yQuarkMin, yQuarkMax);
   myGen->setHadronRapidity(yHadronMin, yHadronMax);
 
+  return myGen;
+}
+
+// Beauty-enriched with EvtGen decayer
+FairGenerator *GeneratorPythia8GapTriggeredBeautyWithEvtGen(int inputTriggerRatio, float yQuarkMin = -1.5, float yQuarkMax = 1.5, float yHadronMin = -1.5, float yHadronMax = 1.5, std::vector<int> hadronPdgList = {}, std::vector<std::array<int, 2>> partPdgToReplaceList = {}, std::vector<float> freqReplaceList = {}, std::string decayTable = "")
+{
+  auto myGen = new GeneratorPythia8GapTriggeredHF(inputTriggerRatio, std::vector<int>{5}, hadronPdgList, partPdgToReplaceList, freqReplaceList);
+  auto seed = (gRandom->TRandom::GetSeed() % 900000000);
+  myGen->setUsedSeed(seed);
+  myGen->readString("Random:setSeed on");
+  myGen->readString("Random:seed " + std::to_string(seed));
+  myGen->setQuarkRapidity(yQuarkMin, yQuarkMax);
+  if (hadronPdgList.size() != 0)
+  {
+    myGen->setHadronRapidity(yHadronMin, yHadronMax);
+  }
+  myGen->setUseEvtGenDecayer(decayTable);
   return myGen;
 }

--- a/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
+++ b/MC/config/PWGHF/ini/GeneratorHFTrigger_Bforced.ini
@@ -1,4 +1,4 @@
-#NEV_TEST> 20
+#NEV_TEST> 50
 [GeneratorExternal]
 fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
 funcName=GeneratorPythia8GapTriggeredBeauty(3, -5, 5)

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.ini
@@ -1,0 +1,9 @@
+#NEV_TEST> 20
+### The external generator derives from GeneratorPythia8.
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C
+funcName=GeneratorPythia8GapTriggeredBeautyWithEvtGen(5, -1.5, 1.5, -1.5, 1.5, {}, {}, {}, "${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/decayer/EVTGEN_DECAY_B2JPSI.DEC")
+
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/pythia8/generator/pythia8_Mode2_noforcedecays.cfg
+includePartonEvent=false

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
@@ -1,4 +1,4 @@
-#NEV_TEST> 10
+#NEV_TEST> 5
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_CharmBaryons.ini
@@ -1,4 +1,4 @@
-#NEV_TEST> 5
+#NEV_TEST> 10
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C

--- a/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_corrBkgSigmaC.ini
+++ b/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_and_bbbar_gap5_Mode2_corrBkgSigmaC.ini
@@ -1,4 +1,4 @@
-#NEV_TEST> 40
+#NEV_TEST> 100
 ### The external generator derives from GeneratorPythia8.
 [GeneratorExternal]
 fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/PWGHF/external/generator/generator_pythia8_gaptriggered_hf.C

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.C
@@ -1,0 +1,113 @@
+int External() {
+    std::string path{"~/test_evtgen/tf3/genevents_Kine.root"};//{"o2sim_Kine.root"};
+
+    int checkPdgQuark{5};
+    float ratioTrigger = 1./5; // one event triggered out of 5
+
+    std::vector<int> checkPdgHadron{443, 511, 521, 531, 5122};
+    std::map<int, std::vector<std::vector<int>>> checkHadronDecays{ // sorted pdg of daughters
+        {443, {{-11, 11}, {-13, 13}}}, // J/psi
+        {511, {{313, 443}}}, // B0
+        {521, {{321, 443}}}, // B+
+        {531, {{333, 443}}}, // Bs0
+        {5122, {{321, 443, 2212}}} // Lb0
+    };
+
+    TFile file(path.c_str(), "READ");
+    if (file.IsZombie()) {
+        std::cerr << "Cannot open ROOT file " << path << "\n";
+        return 1;
+    }
+
+    auto tree = (TTree *)file.Get("o2sim");
+    std::vector<o2::MCTrack> *tracks{};
+    tree->SetBranchAddress("MCTrack", &tracks);
+    o2::dataformats::MCEventHeader *eventHeader = nullptr;
+    tree->SetBranchAddress("MCEventHeader.", &eventHeader);
+
+    int nEventsMB{}, nEventsInj{};
+    int nSignals{}, nSignalGoodDecay{};
+    int nJPsiToEE{}, nJPsiToMuMu{};
+    auto nEvents = tree->GetEntries();
+
+    for (int i = 0; i < nEvents; i++) {
+        tree->GetEntry(i);
+
+        // check subgenerator information
+        if (eventHeader->hasInfo(o2::mcgenid::GeneratorProperty::SUBGENERATORID)) {
+            bool isValid = false;
+            int subGeneratorId = eventHeader->getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid);
+            if (subGeneratorId == 0) {
+                nEventsMB++;
+            } else if (subGeneratorId == checkPdgQuark) {
+                nEventsInj++;
+            }
+        }
+
+        for (auto &track : *tracks) {
+            auto pdg = track.GetPdgCode();
+            if (std::find(checkPdgHadron.begin(), checkPdgHadron.end(), std::abs(pdg)) != checkPdgHadron.end()) { // found signal
+                nSignals++; // count signal PDG
+
+                std::vector<int> pdgsDecay{};
+                std::vector<int> pdgsDecayAntiPart{};
+                for (int j{track.getFirstDaughterTrackId()}; j <= track.getLastDaughterTrackId(); ++j) {
+                    auto pdgDau = tracks->at(j).GetPdgCode();
+                    if (pdg == 443 && pdgDau == 22) {
+                        continue;
+                    }
+                    pdgsDecay.push_back(pdgDau);
+                    if (pdgDau != 333) { // phi is antiparticle of itself
+                        pdgsDecayAntiPart.push_back(-pdgDau);
+                    } else {
+                        pdgsDecayAntiPart.push_back(pdgDau);
+                    }
+                }
+
+                std::sort(pdgsDecay.begin(), pdgsDecay.end());
+                std::sort(pdgsDecayAntiPart.begin(), pdgsDecayAntiPart.end());
+
+                for (auto &decay : checkHadronDecays[std::abs(pdg)]) {
+                    if (pdgsDecay == decay || pdgsDecayAntiPart == decay) {
+                        nSignalGoodDecay++;
+                        if (pdg == 443) {
+                            if (decay == std::vector{-11, 11}) {
+                                nJPsiToEE++;
+                            } else if (decay == std::vector{-13, 13}) {
+                                nJPsiToMuMu++;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << "--------------------------------\n";
+    std::cout << "# Events: " << nEvents << "\n";
+    std::cout << "# MB events: " << nEventsMB << "\n";
+    std::cout << Form("# events injected with %d quark pair: ", checkPdgQuark) << nEventsInj << "\n";
+    std::cout <<"# signal hadrons: " << nSignals << "\n";
+    std::cout <<"# signal hadrons decaying in the correct channel: " << nSignalGoodDecay << "\n";
+    std::cout <<"# J/Psi decaying to e+e-: " << nJPsiToEE << "\n";
+    std::cout <<"# J/Psi decaying to mu+mu-: " << nJPsiToMuMu << "\n";
+
+    if (nEventsMB < nEvents * (1 - ratioTrigger) * 0.95 || nEventsMB > nEvents * (1 - ratioTrigger) * 1.05) { // we put some tolerance since the number of generated events is small
+        std::cerr << "Number of generated MB events different than expected\n";
+        return 1;
+    }
+    if (nEventsInj < nEvents * ratioTrigger * 0.95 || nEventsInj > nEvents * ratioTrigger * 1.05) {
+        std::cerr << "Number of generated events injected with " << checkPdgQuark << " different than expected\n";
+        return 1;
+    }
+
+    float fracForcedDecays = nSignals ? float(nSignalGoodDecay) / nSignals : 0.0f;
+    float uncFracForcedDecays = nSignals ? std::sqrt(fracForcedDecays * (1 - fracForcedDecays) / nSignals) : 1.0f;
+    if (1 - fracForcedDecays > 0.5 + uncFracForcedDecays) { // at least 50% in the main decay channels (we also have correlated backgrounds, mostly from other B decays)
+        std::cerr << "Fraction of signals decaying into the correct channel " << fracForcedDecays << " lower than expected\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.C
+++ b/MC/config/PWGHF/ini/tests/GeneratorHF_D2H_bbbar_B2JPsi_gap5_Mode2.C
@@ -1,5 +1,5 @@
 int External() {
-    std::string path{"~/test_evtgen/tf3/genevents_Kine.root"};//{"o2sim_Kine.root"};
+    std::string path{"o2sim_Kine.root"};
 
     int checkPdgQuark{5};
     float ratioTrigger = 1./5; // one event triggered out of 5

--- a/MC/config/PWGHF/pythia8/decayer/EVTGEN_DECAY_B2JPSI.DEC
+++ b/MC/config/PWGHF/pythia8/decayer/EVTGEN_DECAY_B2JPSI.DEC
@@ -150,152 +150,57 @@ Decay anti-B0
 #
 # B -> J/psi anti-K*0 BR increased by a factor of 10
 0.01330000 J/psi   anti-K*0                                 SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
-0.000017600 J/psi   pi0                                     SVS; #[Reconstructed PDG2011]
 0.000027000 J/psi   rho0                                    SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
 0.000030     J/psi  omega             SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus;
 0.000000000 J/psi   K-      pi+                             PHSP; #[Reconstructed PDG2011]
-0.0001     J/psi  anti-K0   pi0           PHSP;
-#rl0.0007     J/psi  anti-K0   pi+  pi-      PHSP;
-#rl0.00035     J/psi  anti-K0   pi0  pi0      PHSP;
-#rl0.00035     J/psi  K-  pi+  pi0      PHSP;
+0.00035     J/psi  K-  pi+  pi0      PHSP;
 0.001300000 J/psi   anti-K_10                               SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
 0.0001     J/psi  anti-K'_10             SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
 0.0005     J/psi  anti-K_2*0              PHSP;
-0.000094000 J/psi   phi     anti-K0                         PHSP; #[Reconstructed PDG2011]
 #
-0.000620000 psi(2S) anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
+# below multiplied by chi_c or psi(2S) BR to J/psi
+0.00036963 psi(2S) anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.00024238 psi(2S)  K-  pi+          PHSP;
+0.00006059 psi(2S)  K-  pi+  pi0     PHSP;
+0.00024238 psi(2S)  anti-K_10              PHSP;
 #
+0.00007637 chi_c1  anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.00013760 chi_c1  K-  pi+          PHSP;
+0.00006880 chi_c1  K-  pi+  pi0     PHSP;
 #
-0.000610000 psi(2S) anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
-
-0.0004     psi(2S)  K-  pi+          PHSP;
-0.0002     psi(2S)  anti-K0   pi0          PHSP;
-0.0002     psi(2S)  anti-K0   pi+  pi-     PHSP;
-0.0001     psi(2S)  anti-K0   pi0  pi0     PHSP;
-0.0001     psi(2S)  K-  pi+  pi0     PHSP;
-0.0004     psi(2S)  anti-K_10              PHSP;
-
-#
-0.000900000 eta_c   anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.000610000 anti-K*0 eta_c                                  SVS; #[Reconstructed PDG2011]
-0.0002    eta_c  K-  pi+          PHSP;
-0.0001    eta_c  anti-K0   pi0          PHSP;
-0.0002    eta_c  anti-K0   pi+  pi-     PHSP;
-0.0001    eta_c  anti-K0   pi0  pi0     PHSP;
-0.0001    eta_c  K-  pi+  pi0     PHSP;
-#
-0.000190000 chi_c0  anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.00030     anti-K*0 chi_c0              SVS;
-0.0002     chi_c0  K-  pi+          PHSP;
-0.0001     chi_c0  anti-K0   pi0          PHSP;
-0.0002     chi_c0  anti-K0   pi+  pi-     PHSP;
-0.0001     chi_c0  anti-K0   pi0  pi0     PHSP;
-0.0001     chi_c0  K-  pi+  pi0     PHSP;
-#
-0.000395000 chi_c1  anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.000222000 chi_c1  anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
-0.0004     chi_c1  K-  pi+          PHSP;
-0.0002     chi_c1  anti-K0   pi0          PHSP;
-0.0004     chi_c1  anti-K0   pi+  pi-     PHSP;
-0.0002     chi_c1  anti-K0   pi0  pi0     PHSP;
-0.0002     chi_c1  K-  pi+  pi0     PHSP;
-#
-0.00005     chi_c2 K_S0               STS;
-0.00005     chi_c2 K_L0               STS;
-#
-#
-0.00003     chi_c2  anti-K*0         PHSP;
-0.0002     chi_c2  K-  pi+          PHSP;
-0.0001     chi_c2  anti-K0   pi0          PHSP;
-0.0002     chi_c2  anti-K0   pi+  pi-     PHSP;
-0.0001    chi_c2  anti-K0   pi0  pi0     PHSP;
-0.0001     chi_c2  K-  pi+  pi0     PHSP;
+0.00000585   chi_c2  anti-K*0         PHSP;
+0.000039     chi_c2  K-  pi+          PHSP;
+0.0000195    chi_c2  K-  pi+  pi0     PHSP;
 #
 Enddecay
 #
-#
 Decay B0
 #       B -> cc= s
-0.000891000 J/psi   K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
-#
 # B -> J/psi K*0 BR increased by a factor of 10
 0.01330000 J/psi   K*0                                      SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-0.000017600 J/psi   pi0                                     SVS; #[Reconstructed PDG2011]
 0.000027000 J/psi   rho0                                    SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
 0.00003     J/psi  omega            SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus;
 0.000000000 J/psi   K+      pi-                             PHSP; #[Reconstructed PDG2011]
-0.0001     J/psi  K0  pi0           PHSP;
-#rl0.0007     J/psi  K0  pi-  pi+      PHSP;
-#rl0.00035     J/psi  K0  pi0  pi0      PHSP;
 #rl0.00035     J/psi  K+  pi-  pi0      PHSP;
 0.001300000 J/psi   K_10                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
 0.0001     J/psi  K'_10             SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
 0.0005     J/psi  K_2*0              PHSP;
-0.000094000 J/psi   phi     K0                              PHSP; #[Reconstructed PDG2011]
 #
-0.000620000 psi(2S) K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
+# below multiplied by chi_c or psi(2S) BR to J/psi
+0.00036963 psi(2S) K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.00024238 psi(2S)  K+  pi-          PHSP;
+0.00006059 psi(2S)  K+  pi-  pi0     PHSP;
+0.00024238 psi(2S)  K_10              PHSP;
 #
+0.00007637 chi_c1  K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.00013760 chi_c1  K+  pi-          PHSP;
+0.00006880 chi_c1  K+  pi-  pi0     PHSP;
 #
-0.000610000 psi(2S) K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-
-0.0004     psi(2S)  K+  pi-          PHSP;
-0.0002     psi(2S)  K0  pi0          PHSP;
-0.0002     psi(2S)  K0  pi-  pi+     PHSP;
-0.0001     psi(2S)  K0  pi0  pi0     PHSP;
-0.0001     psi(2S)  K+  pi-  pi0     PHSP;
-0.0004     psi(2S)  K_10              PHSP;
-#
-0.000900000 eta_c   K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.000610000 K*0     eta_c                                   SVS; #[Reconstructed PDG2011]
-0.0002    eta_c  K+  pi-          PHSP;
-0.0001    eta_c  K0  pi0          PHSP;
-0.0002    eta_c  K0  pi-  pi+     PHSP;
-0.0001    eta_c  K0  pi0  pi0     PHSP;
-0.0001    eta_c  K+  pi-  pi0     PHSP;
-#
-#
-#
-0.000190000 chi_c0  K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.0003     K*0 chi_c0              SVS;
-0.0002     chi_c0  K+  pi-          PHSP;
-0.0001     chi_c0  K0  pi0          PHSP;
-0.0002     chi_c0  K0  pi-  pi+     PHSP;
-0.0001     chi_c0  K0  pi0  pi0     PHSP;
-0.0001     chi_c0  K+  pi-  pi0     PHSP;
-#
-0.000395000 chi_c1  K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
-#
-#
-0.000222000 chi_c1  K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-0.0004     chi_c1  K+  pi-          PHSP;
-0.0002     chi_c1  K0  pi0          PHSP;
-0.0004     chi_c1  K0  pi-  pi+     PHSP;
-0.0002     chi_c1  K0  pi0  pi0     PHSP;
-0.0002     chi_c1  K+  pi-  pi0     PHSP;
-#
-0.00005     chi_c2 K_S0              STS;
-0.00005     chi_c2 K_L0              STS;
-#
-#
-0.00003     chi_c2  K*0             PHSP;
-0.0002     chi_c2  K+  pi-          PHSP;
-0.0001     chi_c2  K0  pi0          PHSP;
-0.0002     chi_c2  K0  pi-  pi+     PHSP;
-0.0001     chi_c2  K0  pi0  pi0     PHSP;
-0.0001     chi_c2  K+  pi-  pi0     PHSP;
+0.00000585 chi_c2  K*0             PHSP;
+0.000039   chi_c2  K+  pi-          PHSP;
+0.0000195  chi_c2  K+  pi-  pi0     PHSP;
 #
 Enddecay
-#
 #
 #
 Decay B-
@@ -315,47 +220,27 @@ Decay B-
 0.001800000 J/psi   K_1-                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
 0.000052000 J/psi   phi     K-                              PHSP; #[Reconstructed PDG2011]
 #
-0.000646000 psi(2S) K-                                      SVS; #[Reconstructed PDG2011]
-0.000620000 psi(2S) K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
-0.0004   psi(2S) anti-K0   pi-                   PHSP;
-0.0002   psi(2S) K-  pi0                   PHSP;
-0.001900000 psi(2S) K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.0001   psi(2S) K-  pi0  pi0              PHSP;
-0.0001   psi(2S) anti-K0   pi-  pi0              PHSP;
-0.0004     psi(2S)  K_1-              PHSP;
+# below multiplied by chi_c or psi(2S) BR to J/psi
+0.000391411 psi(2S) K-                                      SVS; #[Reconstructed PDG2011]
+0.000375658 psi(2S) K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.000121180 psi(2S) K-  pi0                   PHSP;
+0.001151210 psi(2S) K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000060590 psi(2S) K-  pi0  pi0              PHSP;
+0.000242360 psi(2S) K_1-                 PHSP;
 #
-0.000910000 eta_c   K-                                      PHSP; #[Reconstructed PDG2011]
-0.001200000 K*-     eta_c                                   SVS; #[Reconstructed PDG2011]
-0.0002    eta_c  anti-K0   pi-                 PHSP;
-0.0001    eta_c  K-  pi0                 PHSP;
-0.0002    eta_c  K-  pi+  pi-            PHSP;
-0.0001    eta_c  K-  pi0  pi0            PHSP;
-0.0001    eta_c  anti-K0   pi-  pi0            PHSP;
+0.00015824  chi_c1  K-                                      SVS; #[Reconstructed PDG2011]
+0.0001032   chi_c1  K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0000688   chi_c1  K-  pi0                 PHSP;
+0.0001376   chi_c1  K-  pi+  pi-            PHSP;
+0.0000688   chi_c1  K-  pi0  pi0            PHSP;
 #
-0.000133000 chi_c0  K-                                      PHSP; #[Reconstructed PDG2011]
-0.0004    K*-   chi_c0                    SVS;
-0.0002    chi_c0  anti-K0   pi-                 PHSP;
-0.0001    chi_c0  K-  pi0                 PHSP;
-0.0002    chi_c0  K-  pi+  pi-            PHSP;
-0.0001    chi_c0  K-  pi0  pi0            PHSP;
-0.0001    chi_c0  anti-K0   pi-  pi0            PHSP;
-#
-0.000460000 chi_c1  K-                                      SVS; #[Reconstructed PDG2011]
-0.000300000 chi_c1  K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
-0.0004    chi_c1  anti-K0   pi-                 PHSP;
-0.0002    chi_c1  K-  pi0                 PHSP;
-0.0004    chi_c1  K-  pi+  pi-            PHSP;
-0.0002    chi_c1  K-  pi0  pi0            PHSP;
-0.0002    chi_c1  anti-K0   pi-  pi0            PHSP;
-#
-0.00002    chi_c2  K-                      STS;
-0.00002    chi_c2  K*-                     PHSP;
-0.0002    chi_c2  anti-K0   pi-                 PHSP;
-0.0001    chi_c2  K-  pi0                 PHSP;
-0.0002    chi_c2  K-  pi+  pi-            PHSP;
-0.0001    chi_c2  K-  pi0  pi0            PHSP;
-0.0001    chi_c2  anti-K0   pi-  pi0            PHSP;
+0.0000039    chi_c2  K-                      STS;
+0.0000039    chi_c2  K*-                     PHSP;
+0.0000195    chi_c2  K-  pi0                 PHSP;
+0.000039    chi_c2  K-  pi+  pi-            PHSP;
+0.0000195    chi_c2  K-  pi0  pi0            PHSP;
 Enddecay
+
 #
 Decay B+
 #   B -> cc= s          sum = 1.92%
@@ -365,57 +250,33 @@ Decay B+
 0.001430000 J/psi   K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
 0.000049000 J/psi   pi+                                     SVS; #[Reconstructed PDG2011]
 0.000050000 J/psi   rho+                                    SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-0.0002   J/psi K0  pi+                    PHSP;
 0.0001   J/psi K+  pi0                    PHSP;
 #rl0.0007   J/psi K+  pi-  pi+               PHSP;
 #rl0.00035   J/psi K+  pi0  pi0               PHSP;
-#rl0.00035   J/psi K0  pi+  pi0               PHSP;
 0.0001   J/psi K'_1+                       SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
 0.0005   J/psi K_2*+                       PHSP;
 0.001800000 J/psi   K_1+                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
 0.000052000 J/psi   phi     K+                              PHSP; #[Reconstructed PDG2011]
 #
-0.000646000 psi(2S) K+                                      SVS; #[Reconstructed PDG2011]
-0.000620000 psi(2S) K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-0.0004   psi(2S) K0  pi+                   PHSP;
-0.0002   psi(2S) K+  pi0                   PHSP;
-0.001900000 psi(2S) K+      pi-     pi+                     PHSP; #[Reconstructed PDG2011]
-0.0001   psi(2S) K+  pi0  pi0              PHSP;
-0.0001   psi(2S) K0  pi+  pi0              PHSP;
-0.0004   psi(2S)  K_1+                     PHSP;
+# below multiplied by chi_c or psi(2S) BR to J/psi
+0.000391411 psi(2S) K+                                      SVS; #[Reconstructed PDG2011]
+0.000375658 psi(2S) K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.000121180 psi(2S) K+  pi0                   PHSP;
+0.001151210 psi(2S) K+      pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.000060590 psi(2S) K+  pi0  pi0              PHSP;
+0.000242360 psi(2S)  K_1+                     PHSP;
 #
-0.000910000 eta_c   K+                                      PHSP; #[Reconstructed PDG2011]
-0.001200000 K*+     eta_c                                   SVS; #[Reconstructed PDG2011]
-0.0002    eta_c  K0  pi+                 PHSP;
-0.0001    eta_c  K+  pi0                 PHSP;
-0.0002    eta_c  K+  pi-  pi+            PHSP;
-0.0001    eta_c  K+  pi0  pi0            PHSP;
-0.0001    eta_c  K0  pi+  pi0            PHSP;
+0.00015824  chi_c1  K+                                      SVS; #[Reconstructed PDG2011]
+0.0001032   chi_c1  K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0000688   chi_c1  K+  pi0                 PHSP;
+0.0001376   chi_c1  K+  pi-  pi+            PHSP;
+0.0000688   chi_c1  K+  pi0  pi0            PHSP;
 #
-0.000133000 chi_c0  K+                                      PHSP; #[Reconstructed PDG2011]
-0.0004    K*+   chi_c0                    SVS;
-0.0002    chi_c0  K0  pi+                 PHSP;
-0.0001    chi_c0  K+  pi0                 PHSP;
-0.0002    chi_c0  K+  pi-  pi+            PHSP;
-0.0001    chi_c0  K+  pi0  pi0            PHSP;
-0.0001    chi_c0  K0  pi+  pi0            PHSP;
-#
-0.000460000 chi_c1  K+                                      SVS; #[Reconstructed PDG2011]
-0.000300000 chi_c1  K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
-0.0004    chi_c1  K0  pi+                 PHSP;
-0.0002    chi_c1  K+  pi0                 PHSP;
-0.0004    chi_c1  K+  pi-  pi+            PHSP;
-0.0002    chi_c1  K+  pi0  pi0            PHSP;
-0.0002    chi_c1  K0  pi+  pi0            PHSP;
-#
-0.00002    chi_c2  K+                      STS;
-0.00002    chi_c2  K*+                     PHSP;
-0.0002    chi_c2  K0  pi+                 PHSP;
-0.0001    chi_c2  K+  pi0                 PHSP;
-0.0002    chi_c2  K+  pi-  pi+            PHSP;
-0.0001    chi_c2  K+  pi0  pi0            PHSP;
-0.0001    chi_c2  K0  pi+  pi0            PHSP;
-
+0.0000039   chi_c2  K+                      STS;
+0.0000039   chi_c2  K*+                     PHSP;
+0.0000195   chi_c2  K+  pi0                 PHSP;
+0.000039    chi_c2  K+  pi-  pi+            PHSP;
+0.0000195   chi_c2  K+  pi0  pi0            PHSP;
 Enddecay
 
 #-----------------------------------------------------------------
@@ -478,112 +339,53 @@ Decay anti-B_s0
 #                                        B --> (c c=)  (s s=)
 #					2.65%
 #					should be: psi = 0.80%  CLNS 94/1315 but isn't quite right.
-# B_s0 -> J/psi phi increased by a factor fo 10
+# B_s0 -> J/psi phi increased by a factor fo 10 and includes phi->KK
 0.00064   J/psi   eta'               SVS;
 0.00032   J/psi   eta                SVS;
-0.01300000 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
-0.00008   J/psi   K0                 SVS;
+0.006305 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
 0.00070   J/psi   K-       K+        PHSP;
-0.00070   J/psi   anti-K0  K0        PHSP;
 0.00070   J/psi   anti-K0  K+   pi-  PHSP;
-0.00070   J/psi   anti-K0  K0   pi0  PHSP;
 0.00070   J/psi   K-       K+   pi0  PHSP;
 # LHCb PR 04/02/04 Add (cc) phi n pi(+/0)
 0.00039   J/psi   phi      pi+  pi-  PHSP;
 0.00039   J/psi   phi      pi0  pi0  PHSP;
 # LHCb PR add (cc) phi eta(') + npi see CDF QQ
 0.0002    J/psi   eta      pi+  pi-  PHSP;
-0.0002    J/psi   eta      pi0  pi0  PHSP;
 0.0004    J/psi   eta'     pi+  pi-  PHSP;
-0.0004    J/psi   eta'     pi0  pi0  PHSP;
 0.0002    J/psi   pi+      pi-       PHSP;
-0.0002    J/psi   pi0      pi0       PHSP;
 #					psi' = 0.34%  CLNS 94/1315
 #
-0.000465  psi(2S) eta'               SVS;
-0.000235  psi(2S) eta                SVS;
-0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
-0.0003    psi(2S) K-       K+        PHSP;
-0.0003    psi(2S) anti-K0  K0        PHSP;
-0.0003    psi(2S) anti-K0  K+    pi- PHSP;
-0.0003    psi(2S) anti-K0  K0    pi0 PHSP;
-0.0003    psi(2S) K-       K+    pi0 PHSP;
-0.00034   psi(2S) phi      pi+  pi-  PHSP;
-0.00034   psi(2S) phi      pi0  pi0  PHSP;
-0.0002    psi(2S) eta      pi+  pi-  PHSP;
-0.0002    psi(2S) eta      pi0  pi0  PHSP;
-0.0004    psi(2S) eta'     pi+  pi-  PHSP;
-0.0004    psi(2S) eta'     pi0  pi0  PHSP;
-0.0002    psi(2S) pi+      pi-       PHSP;
-0.0002    psi(2S) pi0      pi0       PHSP;
+0.000281767  psi(2S) eta'               SVS;
+0.000142398  psi(2S) eta                SVS;
+0.000201697  psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.000181785  psi(2S) K-       K+        PHSP;
+0.000181785  psi(2S) anti-K0  K+    pi- PHSP;
+0.000181785  psi(2S) K-       K+    pi0 PHSP;
+0.000206023  psi(2S) phi      pi+  pi-  PHSP;
+0.000206023  psi(2S) phi      pi0  pi0  PHSP;
+0.000121190  psi(2S) eta      pi+  pi-  PHSP;
+0.000242381  psi(2S) eta'     pi+  pi-  PHSP;
+0.000121190  psi(2S) pi+      pi-       PHSP;
 #
-#					chic0 = 0.05% (20% of chic2)
-#					Bodwin et.al. Phys Rev D46 1992
-0.00010   chi_c0  eta'               PHSP;
-0.00005   chi_c0  eta                PHSP;
-0.00020   phi     chi_c0             SVS;
-0.00003   chi_c0  K-       K+        PHSP;
-0.00003   chi_c0  anti-K0  K0        PHSP;
-0.00003   chi_c0  anti-K0  K+   pi-  PHSP;
-0.00003   chi_c0  anti-K0  K0   pi0  PHSP;
-0.00003   chi_c0  K-       K+   pi0  PHSP;
-#
-#
-#					chic1 = 0.37%  CLNS 94/1315
-0.0007    chi_c1  eta'		     SVS;
-0.0003    chi_c1  eta                SVS;
-0.0014    chi_c1  phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
-0.00026   chi_c1  K-       K+        PHSP;
-0.00026   chi_c1  anti-K0  K0        PHSP;
-0.00026   chi_c1  anti-K0  K+   pi-  PHSP;
-0.00026   chi_c1  anti-K0  K0   pi0  PHSP;
-0.00026   chi_c1  K-       K+   pi0  PHSP;
-0.00040   chi_c1  phi      pi+  pi-  PHSP;
-0.00040   chi_c1  phi      pi0  pi0  PHSP;
-0.0001    chi_c1  eta      pi+  pi-  PHSP;
-0.0001    chi_c1  eta      pi0  pi0  PHSP;
-0.0002    chi_c1  eta'     pi+  pi-  PHSP;
-0.0002    chi_c1  eta'     pi0  pi0  PHSP;
+#					chi_c1 = 0.37%  CLNS 94/1315
+0.0002408    chi_c1  eta'		     SVS;
+0.0001032    chi_c1  eta                SVS;
+0.0004816    chi_c1  phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
+0.00008944   chi_c1  K-       K+        PHSP;
+0.00008944   chi_c1  anti-K0  K+   pi-  PHSP;
+0.00008944   chi_c1  K-       K+   pi0  PHSP;
+0.0001376   chi_c1  phi      pi+  pi-  PHSP;
+0.0000344    chi_c1  eta      pi+  pi-  PHSP;
+0.0000688    chi_c1  eta'     pi+  pi-  PHSP;
 #
 #
 #					chic2 = 0.25%  CLNS 94/1315
-0.000465    chi_c2      eta'                  STS;
-0.000235    chi_c2      eta                   STS;
-#0.0010      chi_c2      phi                   STV; whb: model doesn't exist!
-0.00016     chi_c2      K-         K+	      PHSP;
-0.00016     chi_c2      anti-K0    K0	      PHSP;
-0.00016     chi_c2      anti-K0    K+   pi-   PHSP;
-0.00016     chi_c2      anti-K0    K0   pi0   PHSP;
-0.00016     chi_c2      K-         K+   pi0   PHSP;
-#
-#
-#                                       etac(1s) = 0.41%  Guess: CBX 97-65
-#
-0.0008      eta_c       eta'                  PHSP;
-0.0004      eta_c       eta                   PHSP;
-0.0015      phi         eta_c                 SVS;
-0.00028     eta_c       K-         K+         PHSP;
-0.00028     eta_c       anti-K0    K0         PHSP;
-0.00028     eta_c       anti-K0    K+   pi-   PHSP;
-0.00028     eta_c       anti-K0    K0   pi0   PHSP;
-0.00028     eta_c       K-         K+   pi0   PHSP;
-0.00040   eta_c   phi      pi+  pi-  PHSP;
-0.00040   eta_c   phi      pi0  pi0  PHSP;
-0.0001    eta_c   eta      pi+  pi-  PHSP;
-0.0001    eta_c   eta      pi0  pi0  PHSP;
-0.0002    eta_c   eta'     pi+  pi-  PHSP;
-0.0002    eta_c   eta'     pi0  pi0  PHSP;
-#
-#
-#                                        etac(2s) = 0.18%  Guess: CBX 97-65
-0.0004      eta_c(2S)   eta'                  PHSP;
-0.0002      eta_c(2S)   eta                   PHSP;
-0.0006      phi         eta_c(2S)             SVS;
-0.00012     eta_c(2S)   K-         K+         PHSP;
-0.00012     eta_c(2S)   anti-K0    K0         PHSP;
-0.00012     eta_c(2S)   anti-K0    K+   pi-   PHSP;
-0.00012     eta_c(2S)   anti-K0    K0   pi0   PHSP;
-0.00012     eta_c(2S)   K-         K+   pi0   PHSP;
+0.00009067    chi_c2      eta'                  STS;
+0.00004583    chi_c2      eta                   STS;
+#0.000195      chi_c2      phi                   STV; whb: model doesn't exist!
+0.0000312     chi_c2      K-         K+	      PHSP;
+0.0000312     chi_c2      anti-K0    K+   pi-   PHSP;
+0.0000312     chi_c2      K-         K+   pi0   PHSP;
 #
 Enddecay
 #
@@ -606,15 +408,12 @@ Decay B_s0
 #                                        B --> (c c=)  (s s=)
 #					2.65%
 #					should be: psi = 0.80%  CLNS 94/1315 but isn't quite right.
-# B_s0 -> J/psi phi increased by a factor of 10
+# B_s0 -> J/psi phi increased by a factor of 10 and including phi->KK
 0.00064     J/psi       eta'		                   SVS;
 0.00032     J/psi       eta	                           SVS;
-0.01300000 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
-0.00008     J/psi       K0		                   SVS;
+0.006305 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
 0.00070     J/psi       K-          K+                     PHSP;
-0.00070     J/psi       anti-K0     K0                     PHSP;
 0.00070     J/psi       K0          K-         pi+         PHSP;
-0.00070     J/psi       anti-K0     K0         pi0         PHSP;
 0.00070     J/psi       K-          K+         pi0         PHSP;
 # LHCb PR 04/02/04 Add (cc) phi n pi(+/0)
 0.00039   J/psi   phi      pi+  pi-  PHSP;
@@ -625,80 +424,38 @@ Decay B_s0
 0.0004    J/psi   eta'     pi+  pi-  PHSP;
 0.0004    J/psi   eta'     pi0  pi0  PHSP;
 0.0002    J/psi   pi+      pi-       PHSP;
-0.0002    J/psi   pi0      pi0       PHSP;
 #					psi' = 0.34%  CLNS 94/1315
-0.000465    psi(2S)     eta'	                           SVS;
-0.000235    psi(2S)     eta                                SVS;
-0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
-0.0003      psi(2S)     K-          K+                     PHSP;
-0.0003      psi(2S)     anti-K0     K0                     PHSP;
-0.0003      psi(2S)     K0          K-         pi+         PHSP;
-0.0003      psi(2S)     anti-K0     K0         pi0         PHSP;
-0.0003      psi(2S)     K-          K+         pi0         PHSP;
-0.00034   psi(2S) phi      pi+  pi-  PHSP;
-0.00034   psi(2S) phi      pi0  pi0  PHSP;
-0.0002    psi(2S) eta      pi+  pi-  PHSP;
-0.0002    psi(2S) eta      pi0  pi0  PHSP;
-0.0004    psi(2S) eta'     pi+  pi-  PHSP;
-0.0004    psi(2S) eta'     pi0  pi0  PHSP;
-0.0002    psi(2S) pi+      pi-       PHSP;
-0.0002    psi(2S) pi0      pi0       PHSP;
-#
-#					chic0 = 0.05% (20% of chic2)
-#					Bodwin et.al. Phys Rev D46 1992
-0.00010     chi_c0      eta'                               PHSP;
-0.00005     chi_c0      eta                                PHSP;
-0.00020     phi         chi_c0                             SVS;
-0.00003     chi_c0      K-          K+                     PHSP;
-0.00003     chi_c0      anti-K0     K0                     PHSP;
-0.00003     chi_c0      K0          K-         pi+         PHSP;
-0.00003     chi_c0      anti-K0     K0         pi0         PHSP;
-0.00003     chi_c0      K-          K+         pi0         PHSP;
-#
+# below multiplied by chi_c or psi(2S) BR to J/psi and phi BR to KK
+0.000281767    psi(2S)     eta'	                           SVS;
+0.000142398    psi(2S)     eta                                SVS;
+0.000201697    psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.000181785    psi(2S)     K-          K+                     PHSP;
+0.000181785    psi(2S)     K0          K-         pi+         PHSP;
+0.000181785    psi(2S)     K-          K+         pi0         PHSP;
+0.000206023   psi(2S) phi      pi+  pi-  PHSP;
+0.000206023   psi(2S) phi      pi0  pi0  PHSP;
+0.000121190    psi(2S) eta      pi+  pi-  PHSP;
+0.000242381    psi(2S) eta'     pi+  pi-  PHSP;
+0.000121190    psi(2S) pi+      pi-       PHSP;
 #
 #					chic1 = 0.37%  CLNS 94/1315
-0.0007       chi_c1      eta'	                           SVS;
-0.0003      chi_c1      eta                                SVS;
-0.0014      chi_c1      phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
-0.00026     chi_c1      K-          K+	                   PHSP;
-0.00026     chi_c1      anti-K0     K0	                   PHSP;
-0.00026     chi_c1      K0          K-         pi+         PHSP;
-0.00026     chi_c1      anti-K0     K0         pi0         PHSP;
-0.00026     chi_c1      K-          K+         pi0         PHSP;
-0.00040   chi_c1  phi      pi+  pi-  PHSP;
-0.00040   chi_c1  phi      pi0  pi0  PHSP;
-0.0001    chi_c1  eta      pi+  pi-  PHSP;
-0.0001    chi_c1  eta      pi0  pi0  PHSP;
-0.0002    chi_c1  eta'     pi+  pi-  PHSP;
-0.0002    chi_c1  eta'     pi0  pi0  PHSP;
-#
+0.0002408       chi_c1      eta'	                           SVS;
+0.0001032      chi_c1      eta                                SVS;
+0.0004816      chi_c1      phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
+0.00008944     chi_c1      K-          K+	                   PHSP;
+0.00008944   chi_c1  anti-K0      K+  pi-  PHSP;
+0.00008944     chi_c1      K-          K+         pi0         PHSP;
+0.0001376   chi_c1  phi      pi+  pi-  PHSP;
+0.0000344    chi_c1  eta      pi+  pi-  PHSP;
+0.0000688    chi_c1  eta'     pi+  pi-  PHSP;
 #
 #					chic2 = 0.25%  CLNS 94/1315
-0.000465    chi_c2      eta'                               STS;
-0.000235    chi_c2      eta                                STS;
-#0.0010      chi_c2      phi                                STV; whb: doesn't exist
-0.00016     chi_c2      K-          K+	                   PHSP;
-0.00016     chi_c2      anti-K0     K0	                   PHSP;
-0.00016     chi_c2      K0          K-         pi+         PHSP;
-0.00016     chi_c2      anti-K0     K0         pi0         PHSP;
-0.00016     chi_c2      K-          K+         pi0         PHSP;
-#
-#
-#                                       etac(1s) = 0.41%  Guess: CBX 97-65
-0.0008      eta_c       eta'                               PHSP;
-0.0004      eta_c       eta                                PHSP;
-0.0015      phi         eta_c                              SVS;
-0.00028     eta_c       K-          K+                     PHSP;
-0.00028     eta_c       K0          anti-K0                PHSP;
-0.00028     eta_c       K0          K-         pi+         PHSP;
-0.00028     eta_c       K0          anti-K0    pi0         PHSP;
-0.00028     eta_c       K-          K+         pi0         PHSP;
-0.00040   eta_c   phi      pi+  pi-  PHSP;
-0.00040   eta_c   phi      pi0  pi0  PHSP;
-0.0001    eta_c   eta      pi+  pi-  PHSP;
-0.0001    eta_c   eta      pi0  pi0  PHSP;
-0.0002    eta_c   eta'     pi+  pi-  PHSP;
-0.0002    eta_c   eta'     pi0  pi0  PHSP;
+0.00009067    chi_c2      eta'                               STS;
+0.00004583    chi_c2      eta                                STS;
+#0.000195     chi_c2      phi                                STV; whb: doesn't exist
+0.0000312     chi_c2      K-          K+	                   PHSP;
+0.0000312     chi_c2      K0          K-         pi+         PHSP;
+0.0000312     chi_c2      K-          K+         pi0         PHSP;
 #
 Enddecay
 
@@ -2310,26 +2067,6 @@ Enddecay
 #
 Decay phi
 0.489000000 K+      K-                                      VSS; #[Reconstructed PDG2011]
-0.342000000 K_L0    K_S0                                    VSS; #[Reconstructed PDG2011]
-0.0425   rho+ pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
-0.0425   rho0 pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
-0.0425   rho- pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
-0.0250   pi+  pi- pi0                    PHSP;
-0.013090000 eta     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
-0.000687600 pi0     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
-0.000295400 e+      e-                                      PHOTOS      VLL; #[Reconstructed PDG2011]
-0.000287000 mu+     mu-                                     PHOTOS      VLL; #[Reconstructed PDG2011]
-0.000113000 pi0     pi0     gamma                           PHSP; #[Reconstructed PDG2011]
-0.000115000 eta     e+      e-                              PHSP; #[Reconstructed PDG2011]
-0.000322000 f_0     gamma                                   PHSP; #[Reconstructed PDG2011]
-0.000074000 pi+     pi-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000047000 omega   pi0                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000041000 pi+     pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000004000 pi+     pi-     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000011200 pi0     e+      e-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000072700 pi0     eta     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000062500 eta'    gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000014000 mu+     mu-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
 Enddecay
 #
 Decay a_1+
@@ -2763,101 +2500,14 @@ Decay J/psi
 Enddecay
 #
 Decay psi(2S)
-0.007720000 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
-0.007700000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
-0.003000000 tau+    tau-                                    PHOTOS  VLL; #[Reconstructed PDG2011]
 0.336000000 J/psi   pi+     pi-                             VVPIPI; #[Reconstructed PDG2011]
 0.177300000 J/psi   pi0     pi0                             VVPIPI; #[Reconstructed PDG2011]
 0.032800000 J/psi   eta                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
 0.001300000 J/psi   pi0                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.096200000 gamma   chi_c0                                  PHSP; #[Reconstructed PDG2011]
-0.092000000 gamma   chi_c1                                  PHSP; #[Reconstructed PDG2011]
-0.087400000 gamma   chi_c2                                  PHSP; #[Reconstructed PDG2011]
-0.003400000 gamma   eta_c                                   PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000121000 gamma   eta'                                    PHSP; #[Reconstructed PDG2011]
-0.000210000 gamma   f_2                                     PHSP; #[Reconstructed PDG2011]
-0.003500000 pi+     pi-     pi+     pi-     pi+     pi-     pi0     PHSP; #[Reconstructed PDG2011]
-0.000350000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
-0.002900000 pi+     pi-     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
-0.000200000 b_1+    pi-                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000200000 b_1-    pi+                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000240000 b_10    pi0                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000168000 pi+     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
-0.0000545  K*0 anti-K0                    PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.0000545  anti-K*0 K0                    PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000022  rho0 eta                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000021000 omega   pi0                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000028000 phi     eta                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.000008  rho+ pi-                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000008  rho- pi+                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000008  rho0 pi0                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000001  phi pi0                        PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000001  omega eta                      PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.0000085 K*+ K-                         PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.0000085 K*- K+                         PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
-0.000185000 omega   K+      K-                              PHSP; #[Reconstructed PDG2011]
-0.000340000 K+      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.000600000 p+      anti-p- pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.000133000 p+      anti-p- pi0                             PHSP; #[Reconstructed PDG2011]
-0.000276000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
-0.000500000 K_1+    K-                                      PHSP; #[Reconstructed PDG2011]
-0.000500000 K_1-    K+                                      PHSP; #[Reconstructed PDG2011]
-0.000220000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
-0.000280000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
-0.000128000 Delta++ anti-Delta--                            PHSP; #[Reconstructed PDG2011]
-0.000220000 Sigma0  anti-Sigma0                             PHSP; #[Reconstructed PDG2011]
-0.00026   Sigma*+  anti-Sigma*-          PHSP;
-0.000180000 Xi-     anti-Xi+                                PHSP; #[Reconstructed PDG2011]
-0.000080000 pi+     pi-                                     PHSP; #[Reconstructed PDG2011]
-0.000063000 K+      K-                                      PHSP; #[Reconstructed PDG2011]
-0.000070000 phi     K-      K+                              PHSP; #[Reconstructed PDG2011]
-0.000117000 phi     pi-     pi+                             PHSP; #[Reconstructed PDG2011]
-0.000170000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
-0.0008 h_c pi0 PHSP;
-0.0       K0   anti-K0       PHSP;
-0.0       K_S0      K_S0     PHSP;
-0.0       K_L0      K_L0     PHSP;
-0.000054000 K_S0    K_L0                                    PHSP; #[Reconstructed PDG2011]
-#
-# March 2009 New Modes
-0.004800000 pi+     pi-     pi+     pi-     pi0     pi0     PHSP; #[Reconstructed PDG2011]
-0.001200000 pi+     pi-     pi+     pi-     eta             PHSP; #[Reconstructed PDG2011]
-0.001300000 K+      K-      pi+     pi-     eta             PHSP; #[Reconstructed PDG2011]
-0.001000000 K+      K-      pi+     pi-     pi+     pi-     pi0     PHSP; #[Reconstructed PDG2011]
-0.001900000 K+      K-      pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
-0.001260000 K+      K-      pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
-#
-0.013568632 rndmflav anti-rndmflav PYTHIA 42;
-0.103318590 g g g PYTHIA 92;
-0.007344778 gamma g g PYTHIA 92;
-0.000100000 Lambda0 anti-p- K+                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000180000 Lambda0 anti-p- K+      pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000280000 Lambda0 anti-Lambda0 pi+     pi-                PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000260000 Sigma+  anti-Sigma-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000280000 Xi0     anti-Xi0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000060000 eta     p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000069000 omega   p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000320000 p+      anti-n0 pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000950000 eta     pi+     pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000450000 eta'    pi+     pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000000000 omega   pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000220000 omega   f_2                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000220000 rho0    K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000190000 K*0     anti-K_2*0                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000050000 rho0    p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000020000 pi+     pi-     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000730000 p+      anti-p- pi+     pi-     pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000060000 K+      K-      K+      K-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000110000 K+      K-      K+      K-      pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000031000 phi     eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000032000 omega   eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000027000 p+      anti-p- K+      K-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000044000 phi     f'_2                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000870000 gamma   eta     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000400000 gamma   pi+     pi-     pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000190000 gamma   K+      K-      pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000029000 gamma   p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000028000 gamma   pi+     pi-     p+      anti-p-         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+# below we also account for chi_c -> JPsi BR
+0.00111592  gamma   chi_c0                                  PHSP; #[Reconstructed PDG2011]
+0.03164800  gamma   chi_c1                                  PHSP; #[Reconstructed PDG2011]
+0.01704300  gamma   chi_c2                                  PHSP; #[Reconstructed PDG2011]
 Enddecay
 
 Decay psi(4040)
@@ -2950,157 +2600,14 @@ Enddecay
 #
 Decay chi_c0
 0.011600000 gamma   J/psi                                   PHSP; #[Reconstructed PDG2011]
-0.000228000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
-0.000222000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
-0.00243    pi0 pi0                        PHSP;
-0.00487    pi+ pi-                        PHSP;
-0.013800000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.002810000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.012000000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
-0.008900000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
-0.0100    rho+ pi- pi0                   PHSP;
-0.0100    rho- pi+ pi0                   PHSP;
-0.00057    K+   K-                        PHSP;
-0.000920000 phi     phi                                     PHSP; #[Reconstructed PDG2011]
-0.001700000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
-0.0036    anti-K*0  K+  pi-              PHSP;
-0.0036    K*0  K-  pi+                   PHSP;
-0.0043    K*+  anti-K0   pi-             PHSP;
-0.0043    K*-  K0  pi+                   PHSP;
-0.018000000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.002100000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
-0.002680000 eta     eta                                     PHSP; #[Reconstructed PDG2011]
-0.000330000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
-0.00086    f_0 f_0                        PHSP;
-0.0       K0   anti-K0       PHSP;
-0.003160000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
-0.00282    K_L0      K_L0     PHSP;
-0.0       K_S0      K_L0     PHSP;
-#
-# March 2009 New Modes
-0.002030000 eta'    eta'                                    PHSP; #[Reconstructed PDG2011]
-0.002200000 omega   omega                                   PHSP; #[Reconstructed PDG2011]
-0.00325   K_1+ K-   PHSP;
-0.00325   K_1- K+   PHSP;
-0.000990000 K+      K-      phi                             PHSP; #[Reconstructed PDG2011]
-0.001140000 p+      anti-n0 pi-                             PHSP; #[Reconstructed PDG2011]
-0.000525   K+ anti-p- Lambda0   PHSP;
-0.000525   K- p+ Lambda0   PHSP;
-0.005800000 K_S0    K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.00590   K_L0 K_L0 pi+ pi-   PHSP;
-0.00000   K0 anti-K0 pi+ pi-   PHSP;
-0.001400000 K+      K-      K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
-0.00150   K+ K- K_L0 K_L0   PHSP;
-0.00000   K+ K- K0 anti-K0   PHSP;
-#
-0.799360000 rndmflav anti-rndmflav PYTHIA 42;
-0.034000000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.005700000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.003100000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000570000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000370000 p+      anti-p- eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.001050000 pi0     pi0     p+      anti-p-                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000420000 Sigma0  anti-Sigma0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000310000 Sigma+  anti-Sigma-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000320000 Xi0     anti-Xi0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000490000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
 Enddecay
 #
 Decay chi_c1
 0.344000000 J/psi   gamma                                   VVP 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
-0.007600000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.000073000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
-0.005800000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
-0.004500000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.003900000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
-0.0020    rho+ pi- pi0                   PHSP;
-0.0020    rho- pi+ pi0                   PHSP;
-0.0016    anti-K*0  K+  pi-              PHSP;
-0.0016    K*0  K-  pi+                   PHSP;
-0.001500000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
-0.0009    K*+  anti-K0   pi-             PHSP;
-0.0009    K*-  K0  pi+                   PHSP;
-0.000500000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
-0.000720000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
-0.0003    K+ K- K_S0 K_S0                PHSP;
-0.000118000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
-0.00385    K+ anti-K0  pi-                PHSP;
-0.00385    K- K0 pi+                      PHSP;
-0.000560000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.00000    K0   anti-K0                   PHSP;
-0.00001    K_S0      K_S0                 PHSP;
-0.00001    K_L0      K_L0                 PHSP;
-0.00000    K_S0      K_L0                 PHSP;
-#
-# March 2009 New Modes
-0.002200000 pi+     pi-     eta                             PHSP; #[Reconstructed PDG2011]
-0.002400000 pi+     pi-     eta'                            PHSP; #[Reconstructed PDG2011]
-0.001910000 K+      K-      pi0                             PHSP; #[Reconstructed PDG2011]
-#
-0.587724 rndmflav anti-rndmflav PYTHIA 42;
-0.008700000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.001180000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.001200000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000330000 K+      K-      eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.002800000 f_2     eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000430000 K+      K-      phi                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000120000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000320000 K+      anti-p- Lambda0                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000084000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000229000 gamma   rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000078000 gamma   omega                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
 Enddecay
-
-
 #
 Decay chi_c2
 0.195000000 gamma   J/psi                                   PHSP; #[Reconstructed PDG2011]
-0.000256000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
-0.000072000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
-0.00072   pi0 pi0                       TSS;
-0.00145    pi+ pi-                       TSS;
-0.011100000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
-0.001780000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.008600000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
-0.009200000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
-0.004000000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
-0.0046   rho+ pi- pi0                   PHSP;
-0.0046   rho- pi+ pi0                   PHSP;
-0.001090000 K+      K-                                      TSS; #[Reconstructed PDG2011]
-0.002400000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
-0.0003    K+  K- K_S0 K_S0               PHSP;
-0.001480000 phi     phi                                     PHSP; #[Reconstructed PDG2011]
-0.00115    anti-K*0  K+  pi-              PHSP;
-0.00115    K*0  K-  pi+                   PHSP;
-0.002500000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
-0.0016    K*+  anti-K0   pi-             PHSP;
-0.0016    K*-  K0  pi+                   PHSP;
-0.001320000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
-0.000186000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
-0.00000   K0   anti-K0       PHSP;
-0.000580000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
-0.00065   K_L0      K_L0                  PHSP;
-0.00000   K_S0      K_L0     PHSP;
-#
-# March 2009 New Modes
-0.001900000 omega   omega                                   PHSP; #[Reconstructed PDG2011]
-0.0007   anti-K0 K+ pi-   PHSP;
-0.0007   K0 K- pi+   PHSP;
-0.001550000 K+      K-      phi                             PHSP; #[Reconstructed PDG2011]
-0.001100000 p+      anti-n0 pi-                             PHSP; #[Reconstructed PDG2011]
-#
-0.709461000 rndmflav anti-rndmflav PYTHIA 42;
-0.020000000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.002200000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.001400000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000520000 pi+     pi-     eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000540000 pi+     pi-     eta'                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000540000 eta     eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000330000 K+      K-      pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000470000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000200000 p+      anti-p- eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000850000 pi0     pi0     p+      anti-p-                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
-0.000155000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
 Enddecay
 #
 Decay psi(3770)
@@ -4195,34 +3702,30 @@ Decay h_c
 Enddecay
 
 # 12/08/03 RJT  Update b-baryon decays...
-Decay Lambda_b0
-# add arbitrary Lb0 -> J/psi p K- (TO CHECK)
-  0.01000    J/psi    p+    K-                             PHSP;
-  0.00047    Lambda0         J/psi                        PHSP;
-  0.00038    Lambda0         psi(2S)                      PHSP;
-  0.00100    Lambda0         eta_c                        PHSP;
+# chi_c or psi(2S) BR to J/psi are included below
 
-# # PR LHCb 27 Apr 2004, addition of Pythia decays
-# 0.398544837 anti-u d c ud_0 PYTHIA 23;
-# 0.082218903 anti-u c d ud_0 PYTHIA 43;
-# 0.072280354 anti-c s c ud_0 PYTHIA 43;
-# 0.010842053 anti-u d u ud_0 PYTHIA 22;
-# 0.010842053 anti-c s u ud_0 PYTHIA 22;
+Decay Lambda_b0
+# add from PDG 2026
+  0.00032     J/psi    p+    K-                           PHSP;
+  0.000026   J/psi    p+    pi-                           PHSP;
+  0.000000454  psi(2S)    p+    pi-                         PHSP;
+  0.00000454   psi(2S)    p+    K-                          PHSP;
+  0.00000258   chi_c1     p+    K-                          PHSP;
+  0.000000175  chi_c1     p+    pi-                         PHSP;
+  0.00000156   chi_c2     p+    K-                          PHSP;
+  0.0000000937  chi_c2     p+    pi-                         PHSP;
 Enddecay
 
 Decay anti-Lambda_b0
-# add arbitrary Lb0 -> J/psi p K- (TO CHECK)
-  0.01000    J/psi    anti-p-    K+                        PHSP;
-  0.00047    anti-Lambda0    J/psi                        PHSP;
-  0.00038    anti-Lambda0    psi(2S)                      PHSP;
-  0.001000   anti-Lambda0    eta_c       PHSP;
-  0.00080    anti-n0    anti-D0                           PHSP;
-
-# 0.398544837 u anti-d anti-c anti-ud_0 PYTHIA 23;
-# 0.082218903 u anti-c anti-d anti-ud_0 PYTHIA 43;
-# 0.072280354 c anti-s anti-c anti-ud_0 PYTHIA 43;
-# 0.010842053 u anti-d anti-u anti-ud_0 PYTHIA 22;
-# 0.010842053 c anti-s anti-u anti-ud_0 PYTHIA 22;
+# add from PDG 2026;
+  0.00032     J/psi     anti-p-    K+                          PHSP;
+  0.000026   J/psi      anti-p-    pi+                         PHSP;
+  0.000000454  psi(2S)    anti-p-    pi+                         PHSP;
+  0.00000454   psi(2S)    anti-p-    K+                          PHSP;
+  0.00000258   chi_c1     anti-p-    K+                          PHSP;
+  0.000000175  chi_c1     anti-p-    pi+                         PHSP;
+  0.00000156   chi_c2     anti-p-    K+                          PHSP;
+  0.0000000937  chi_c2     anti-p-    pi+                         PHSP;
 Enddecay
 
 Decay Xi_b-

--- a/MC/config/PWGHF/pythia8/decayer/EVTGEN_DECAY_B2JPSI.DEC
+++ b/MC/config/PWGHF/pythia8/decayer/EVTGEN_DECAY_B2JPSI.DEC
@@ -1,0 +1,5047 @@
+
+########################################################################
+# Copyright 1998-2020 CERN for the benefit of the EvtGen authors       #
+#                                                                      #
+# This file is part of EvtGen.                                         #
+#                                                                      #
+# EvtGen is free software: you can redistribute it and/or modify       #
+# it under the terms of the GNU General Public License as published by #
+# the Free Software Foundation, either version 3 of the License, or    #
+# (at your option) any later version.                                  #
+#                                                                      #
+# EvtGen is distributed in the hope that it will be useful,            #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        #
+# GNU General Public License for more details.                         #
+#                                                                      #
+# You should have received a copy of the GNU General Public License    #
+# along with EvtGen.  If not, see <https://www.gnu.org/licenses/>.     #
+########################################################################
+
+# Updated to PDG 2010 by Tomas Pilar - T.Pilar@warwick.ac.uk
+# Updated Mixing Parameters Mark Whitehead May 2009
+#
+Define qoverp_incohMix_B_s0 1.0
+Define dm_incohMix_B_s0 17.8e12
+Define qoverp_incohMix_B0 1.0
+Define dm_incohMix_B0 0.507e12
+# Old definition of dm still in some decay models
+Define dm 0.507e12
+#Define dgamma 0
+#Define qoverp 1
+#Define phaseqoverp 0
+#Define values for B0s mixing
+#Define dms 20.e12
+# DeltaGammas corresponds to DG/G = 10%
+#Define dgammas 6.852e10
+# Activate incoherent Mixing
+### TODO: find a way to give mixing parameters through decay file to EvtGen
+#####yesIncoherentB0Mixing dm  dgamma
+#####yesIncoherentBsMixing dms dgammas
+# define the values of the CKM angles  (alpha=70, beta=40)
+Define alpha 1.365
+Define beta  0.39
+Define gamma 1.387
+Define twoBetaPlusGamma  2.167
+Define betaPlusHalfGamma 1.0835
+Define minusGamma -1.387
+Define minusTwoBeta -0.78
+
+# New definitions for psiKstar modes (Lange, July 26, 2000)
+Define PKHplus  0.159
+Define PKHzero  0.775
+Define PKHminus 0.612
+Define PKphHplus  1.563
+Define PKphHzero  0.0
+Define PKphHminus 2.712
+
+Define Aplus  0.490
+Define Azero  1.10
+Define Aminus 0.4
+#
+Define phAplus  2.5
+Define phAzero  0.0
+Define phAminus -0.17
+
+#
+# These particle aliases are used in for CP violating decays
+# in which the decay distributions depends on how the K* decayed.
+#
+#
+Alias K*L       K*0
+Alias K*S       K*0
+Alias K*BL       anti-K*0
+Alias K*BS       anti-K*0
+Alias K*0T      K*0
+Alias anti-K*0T anti-K*0
+Alias K*BR  anti-K*0
+Alias K*0R  K*0
+Alias anti-K_0*0N anti-K_0*0
+Alias K_0*0N K_0*0
+#
+ChargeConj K*L    K*BL
+ChargeConj K*S    K*BS
+ChargeConj K*0T    anti-K*0T
+ChargeConj K_0*0N  anti-K_0*0N
+ChargeConj K*0R    K*BR
+#JetSet parameter modifications
+#(Very important that there are no blank spaces in the parameter string!)
+#Turn of B0-B0B mixing in JetSet:
+#JetSetPar MSTJ(26)=0
+# control of L=1 mesons (in order: J1S0 J0S1 J1S1 J2S1) - commented out by NB/WP
+#JetSetPar PARJ(14)=0.05
+#JetSetPar PARJ(15)=0.05
+#JetSetPar PARJ(16)=0.05
+#JetSetPar PARJ(17)=0.05
+#cut-off parameter used to stop fragmentation process (should not be changed)
+#####JetSetPar PARJ(33)=0.3 SET NOW IN GAUSS
+
+# PR LHCb 10/01/2006
+# Turn on PHOTOS for all decays
+yesPhotos
+#
+#
+#Decay vpho
+#1.000                     PYCONT;
+#Enddecay
+#
+# use new VSS_BMIX mixing decay model (DK,28-Oct-1999)
+Decay Upsilon(4S)
+0.515122645 B+      B-                                      VSS; #[Reconstructed PDG2011]
+0.483122645 B0      anti-B0                                 VSS_BMIX dm; #[Reconstructed PDG2011]
+0.000015583 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000015766 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000015766 tau+    tau-                                    PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000084099 Upsilon(2S) pi+     pi-                         VVPIPI; #[Reconstructed PDG2011]
+0.000044342 Upsilon(2S) pi0     pi0                         VVPIPI; #[Reconstructed PDG2011]
+0.000080123 Upsilon pi+     pi-                             VVPIPI; #[Reconstructed PDG2011]
+0.000044342 Upsilon pi0     pi0                             VVPIPI; #[Reconstructed PDG2011]
+0.000194392 Upsilon eta                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+# BF ~ (2J+1)E^3_gamma; see PRL 94, 032001
+# V-> gamma S    Partial wave (L,S)=(0,0)
+0.000092625 gamma   chi_b0(3P)                              HELAMP 1. 0. 1. 0.; #[Reconstructed PDG2011]
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.000138938 gamma   chi_b1(3P)                              HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.000129084 gamma   chi_b2(3P)                              HELAMP 2.4494897 0. 1.7320508 0. 1. 0. 1. 0. 1.7320508 0. 2.4494897 0.; #[Reconstructed PDG2011]
+# V-> gamma S    Partial wave (L,S)=(0,0)
+0.000002956 gamma   chi_b0(2P)                              HELAMP 1. 0. 1. 0.; #[Reconstructed PDG2011]
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.000007883 gamma   chi_b1(2P)                              HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.000011825 gamma   chi_b2(2P)                              HELAMP 2.4494897 0. 1.7320508 0. 1. 0. 1. 0. 1.7320508 0. 2.4494897 0.; #[Reconstructed PDG2011]
+0.000837571 g g g PYTHIA 92;
+0.000039415 gamma g g PYTHIA 92;
+Enddecay
+#
+#
+#
+Decay anti-B0
+#   Charmonium states - updated from Lange's recommendations (august 23,2000)
+# Based on new BABAR results I'm making the following changes (Lange, March 13, 2001
+#       J/psi K0   was 10, now 9 x 10^-4
+#       J/psi pi0   was 2.5, now 2.0 x 10^-4
+#       J/psi Kstar was 15, now 13
+#       Fix chic1 KS CP eigenstate
+#       adding J/psi rho and omega - for lack of better thing will use the Kstar helicity amplitudes.
+#       Psi2sKs  30 ->31
+#       chic1 Kstar: 12 ->6
+0.000891000 J/psi   anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+# B -> J/psi anti-K*0 BR increased by a factor of 10
+0.01330000 J/psi   anti-K*0                                 SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.000017600 J/psi   pi0                                     SVS; #[Reconstructed PDG2011]
+0.000027000 J/psi   rho0                                    SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.000030     J/psi  omega             SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus;
+0.000000000 J/psi   K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.0001     J/psi  anti-K0   pi0           PHSP;
+#rl0.0007     J/psi  anti-K0   pi+  pi-      PHSP;
+#rl0.00035     J/psi  anti-K0   pi0  pi0      PHSP;
+#rl0.00035     J/psi  K-  pi+  pi0      PHSP;
+0.001300000 J/psi   anti-K_10                               SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
+0.0001     J/psi  anti-K'_10             SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
+0.0005     J/psi  anti-K_2*0              PHSP;
+0.000094000 J/psi   phi     anti-K0                         PHSP; #[Reconstructed PDG2011]
+#
+0.000620000 psi(2S) anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K-  pi+          PHSP;
+0.0002     psi(2S)  anti-K0   pi0          PHSP;
+0.0002     psi(2S)  anti-K0   pi+  pi-     PHSP;
+0.0001     psi(2S)  anti-K0   pi0  pi0     PHSP;
+0.0001     psi(2S)  K-  pi+  pi0     PHSP;
+0.0004     psi(2S)  anti-K_10              PHSP;
+
+#
+0.000900000 eta_c   anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000610000 anti-K*0 eta_c                                  SVS; #[Reconstructed PDG2011]
+0.0002    eta_c  K-  pi+          PHSP;
+0.0001    eta_c  anti-K0   pi0          PHSP;
+0.0002    eta_c  anti-K0   pi+  pi-     PHSP;
+0.0001    eta_c  anti-K0   pi0  pi0     PHSP;
+0.0001    eta_c  K-  pi+  pi0     PHSP;
+#
+0.000190000 chi_c0  anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.00030     anti-K*0 chi_c0              SVS;
+0.0002     chi_c0  K-  pi+          PHSP;
+0.0001     chi_c0  anti-K0   pi0          PHSP;
+0.0002     chi_c0  anti-K0   pi+  pi-     PHSP;
+0.0001     chi_c0  anti-K0   pi0  pi0     PHSP;
+0.0001     chi_c0  K-  pi+  pi0     PHSP;
+#
+0.000395000 chi_c1  anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000222000 chi_c1  anti-K*0                                SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0004     chi_c1  K-  pi+          PHSP;
+0.0002     chi_c1  anti-K0   pi0          PHSP;
+0.0004     chi_c1  anti-K0   pi+  pi-     PHSP;
+0.0002     chi_c1  anti-K0   pi0  pi0     PHSP;
+0.0002     chi_c1  K-  pi+  pi0     PHSP;
+#
+0.00005     chi_c2 K_S0               STS;
+0.00005     chi_c2 K_L0               STS;
+#
+#
+0.00003     chi_c2  anti-K*0         PHSP;
+0.0002     chi_c2  K-  pi+          PHSP;
+0.0001     chi_c2  anti-K0   pi0          PHSP;
+0.0002     chi_c2  anti-K0   pi+  pi-     PHSP;
+0.0001    chi_c2  anti-K0   pi0  pi0     PHSP;
+0.0001     chi_c2  K-  pi+  pi0     PHSP;
+#
+Enddecay
+#
+#
+Decay B0
+#       B -> cc= s
+0.000891000 J/psi   K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+# B -> J/psi K*0 BR increased by a factor of 10
+0.01330000 J/psi   K*0                                      SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.000017600 J/psi   pi0                                     SVS; #[Reconstructed PDG2011]
+0.000027000 J/psi   rho0                                    SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.00003     J/psi  omega            SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus;
+0.000000000 J/psi   K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.0001     J/psi  K0  pi0           PHSP;
+#rl0.0007     J/psi  K0  pi-  pi+      PHSP;
+#rl0.00035     J/psi  K0  pi0  pi0      PHSP;
+#rl0.00035     J/psi  K+  pi-  pi0      PHSP;
+0.001300000 J/psi   K_10                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
+0.0001     J/psi  K'_10             SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
+0.0005     J/psi  K_2*0              PHSP;
+0.000094000 J/psi   phi     K0                              PHSP; #[Reconstructed PDG2011]
+#
+0.000620000 psi(2S) K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000610000 psi(2S) K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+
+0.0004     psi(2S)  K+  pi-          PHSP;
+0.0002     psi(2S)  K0  pi0          PHSP;
+0.0002     psi(2S)  K0  pi-  pi+     PHSP;
+0.0001     psi(2S)  K0  pi0  pi0     PHSP;
+0.0001     psi(2S)  K+  pi-  pi0     PHSP;
+0.0004     psi(2S)  K_10              PHSP;
+#
+0.000900000 eta_c   K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000610000 K*0     eta_c                                   SVS; #[Reconstructed PDG2011]
+0.0002    eta_c  K+  pi-          PHSP;
+0.0001    eta_c  K0  pi0          PHSP;
+0.0002    eta_c  K0  pi-  pi+     PHSP;
+0.0001    eta_c  K0  pi0  pi0     PHSP;
+0.0001    eta_c  K+  pi-  pi0     PHSP;
+#
+#
+#
+0.000190000 chi_c0  K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.0003     K*0 chi_c0              SVS;
+0.0002     chi_c0  K+  pi-          PHSP;
+0.0001     chi_c0  K0  pi0          PHSP;
+0.0002     chi_c0  K0  pi-  pi+     PHSP;
+0.0001     chi_c0  K0  pi0  pi0     PHSP;
+0.0001     chi_c0  K+  pi-  pi0     PHSP;
+#
+0.000395000 chi_c1  K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
+#
+#
+0.000222000 chi_c1  K*0                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0004     chi_c1  K+  pi-          PHSP;
+0.0002     chi_c1  K0  pi0          PHSP;
+0.0004     chi_c1  K0  pi-  pi+     PHSP;
+0.0002     chi_c1  K0  pi0  pi0     PHSP;
+0.0002     chi_c1  K+  pi-  pi0     PHSP;
+#
+0.00005     chi_c2 K_S0              STS;
+0.00005     chi_c2 K_L0              STS;
+#
+#
+0.00003     chi_c2  K*0             PHSP;
+0.0002     chi_c2  K+  pi-          PHSP;
+0.0001     chi_c2  K0  pi0          PHSP;
+0.0002     chi_c2  K0  pi-  pi+     PHSP;
+0.0001     chi_c2  K0  pi0  pi0     PHSP;
+0.0001     chi_c2  K+  pi-  pi0     PHSP;
+#
+Enddecay
+#
+#
+#
+Decay B-
+#   B -> cc= s          sum = 1.92%
+# B -> J/psi K- increased by a factor of 10
+0.01014000 J/psi   K-                                       SVS; #[Reconstructed PDG2011]
+0.001430000 J/psi   K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.000049000 J/psi   pi-                                     SVS; #[Reconstructed PDG2011]
+0.000050000 J/psi   rho-                                    SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0002   J/psi anti-K0   pi-                    PHSP;
+0.0001   J/psi K-  pi0                    PHSP;
+#rl0.0007   J/psi K-  pi+  pi-               PHSP;
+#rl0.00035   J/psi K-  pi0  pi0               PHSP;
+#rl0.00035   J/psi anti-K0   pi-  pi0               PHSP;
+0.0001   J/psi K'_1-                       SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
+0.0005   J/psi K_2*-                       PHSP;
+0.001800000 J/psi   K_1-                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
+0.000052000 J/psi   phi     K-                              PHSP; #[Reconstructed PDG2011]
+#
+0.000646000 psi(2S) K-                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0004   psi(2S) anti-K0   pi-                   PHSP;
+0.0002   psi(2S) K-  pi0                   PHSP;
+0.001900000 psi(2S) K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K-  pi0  pi0              PHSP;
+0.0001   psi(2S) anti-K0   pi-  pi0              PHSP;
+0.0004     psi(2S)  K_1-              PHSP;
+#
+0.000910000 eta_c   K-                                      PHSP; #[Reconstructed PDG2011]
+0.001200000 K*-     eta_c                                   SVS; #[Reconstructed PDG2011]
+0.0002    eta_c  anti-K0   pi-                 PHSP;
+0.0001    eta_c  K-  pi0                 PHSP;
+0.0002    eta_c  K-  pi+  pi-            PHSP;
+0.0001    eta_c  K-  pi0  pi0            PHSP;
+0.0001    eta_c  anti-K0   pi-  pi0            PHSP;
+#
+0.000133000 chi_c0  K-                                      PHSP; #[Reconstructed PDG2011]
+0.0004    K*-   chi_c0                    SVS;
+0.0002    chi_c0  anti-K0   pi-                 PHSP;
+0.0001    chi_c0  K-  pi0                 PHSP;
+0.0002    chi_c0  K-  pi+  pi-            PHSP;
+0.0001    chi_c0  K-  pi0  pi0            PHSP;
+0.0001    chi_c0  anti-K0   pi-  pi0            PHSP;
+#
+0.000460000 chi_c1  K-                                      SVS; #[Reconstructed PDG2011]
+0.000300000 chi_c1  K*-                                     SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus; #[Reconstructed PDG2011]
+0.0004    chi_c1  anti-K0   pi-                 PHSP;
+0.0002    chi_c1  K-  pi0                 PHSP;
+0.0004    chi_c1  K-  pi+  pi-            PHSP;
+0.0002    chi_c1  K-  pi0  pi0            PHSP;
+0.0002    chi_c1  anti-K0   pi-  pi0            PHSP;
+#
+0.00002    chi_c2  K-                      STS;
+0.00002    chi_c2  K*-                     PHSP;
+0.0002    chi_c2  anti-K0   pi-                 PHSP;
+0.0001    chi_c2  K-  pi0                 PHSP;
+0.0002    chi_c2  K-  pi+  pi-            PHSP;
+0.0001    chi_c2  K-  pi0  pi0            PHSP;
+0.0001    chi_c2  anti-K0   pi-  pi0            PHSP;
+Enddecay
+#
+Decay B+
+#   B -> cc= s          sum = 1.92%
+#
+# B -> J/psi K+ BR increased by a factor of 10
+0.01014000 J/psi   K+                                       SVS; #[Reconstructed PDG2011]
+0.001430000 J/psi   K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.000049000 J/psi   pi+                                     SVS; #[Reconstructed PDG2011]
+0.000050000 J/psi   rho+                                    SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0002   J/psi K0  pi+                    PHSP;
+0.0001   J/psi K+  pi0                    PHSP;
+#rl0.0007   J/psi K+  pi-  pi+               PHSP;
+#rl0.00035   J/psi K+  pi0  pi0               PHSP;
+#rl0.00035   J/psi K0  pi+  pi0               PHSP;
+0.0001   J/psi K'_1+                       SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0;
+0.0005   J/psi K_2*+                       PHSP;
+0.001800000 J/psi   K_1+                                    SVV_HELAMP 0.5 0.0 1.0 0.0 0.5 0.0; #[Reconstructed PDG2011]
+0.000052000 J/psi   phi     K+                              PHSP; #[Reconstructed PDG2011]
+#
+0.000646000 psi(2S) K+                                      SVS; #[Reconstructed PDG2011]
+0.000620000 psi(2S) K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0004   psi(2S) K0  pi+                   PHSP;
+0.0002   psi(2S) K+  pi0                   PHSP;
+0.001900000 psi(2S) K+      pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.0001   psi(2S) K+  pi0  pi0              PHSP;
+0.0001   psi(2S) K0  pi+  pi0              PHSP;
+0.0004   psi(2S)  K_1+                     PHSP;
+#
+0.000910000 eta_c   K+                                      PHSP; #[Reconstructed PDG2011]
+0.001200000 K*+     eta_c                                   SVS; #[Reconstructed PDG2011]
+0.0002    eta_c  K0  pi+                 PHSP;
+0.0001    eta_c  K+  pi0                 PHSP;
+0.0002    eta_c  K+  pi-  pi+            PHSP;
+0.0001    eta_c  K+  pi0  pi0            PHSP;
+0.0001    eta_c  K0  pi+  pi0            PHSP;
+#
+0.000133000 chi_c0  K+                                      PHSP; #[Reconstructed PDG2011]
+0.0004    K*+   chi_c0                    SVS;
+0.0002    chi_c0  K0  pi+                 PHSP;
+0.0001    chi_c0  K+  pi0                 PHSP;
+0.0002    chi_c0  K+  pi-  pi+            PHSP;
+0.0001    chi_c0  K+  pi0  pi0            PHSP;
+0.0001    chi_c0  K0  pi+  pi0            PHSP;
+#
+0.000460000 chi_c1  K+                                      SVS; #[Reconstructed PDG2011]
+0.000300000 chi_c1  K*+                                     SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus; #[Reconstructed PDG2011]
+0.0004    chi_c1  K0  pi+                 PHSP;
+0.0002    chi_c1  K+  pi0                 PHSP;
+0.0004    chi_c1  K+  pi-  pi+            PHSP;
+0.0002    chi_c1  K+  pi0  pi0            PHSP;
+0.0002    chi_c1  K0  pi+  pi0            PHSP;
+#
+0.00002    chi_c2  K+                      STS;
+0.00002    chi_c2  K*+                     PHSP;
+0.0002    chi_c2  K0  pi+                 PHSP;
+0.0001    chi_c2  K+  pi0                 PHSP;
+0.0002    chi_c2  K+  pi-  pi+            PHSP;
+0.0001    chi_c2  K+  pi0  pi0            PHSP;
+0.0001    chi_c2  K0  pi+  pi0            PHSP;
+
+Enddecay
+
+#-----------------------------------------------------------------
+# B references:
+#
+# [B1]: http://www.slac.stanford.edu/BFROOT/www/Physics/Tools/generators/dec-update/2002/Breco-recommendations.html
+#
+#-----------------------------------------------------------------
+
+
+#
+#
+#   B* mesons
+#
+Decay B*+
+1.0000    B+  gamma                       VSP_PWAVE;
+Enddecay
+Decay B*-
+1.0000    B-  gamma                       VSP_PWAVE;
+Enddecay
+Decay B*0
+1.0000    B0  gamma                       VSP_PWAVE;
+Enddecay
+Decay anti-B*0
+1.0000    anti-B0 gamma                       VSP_PWAVE;
+Enddecay
+Decay B_s*0
+1.0000    B_s0  gamma                      VSP_PWAVE;
+Enddecay
+Decay anti-B_s*0
+1.0000    anti-B_s0 gamma                       VSP_PWAVE;
+Enddecay
+#
+# B_s decays.
+#
+#
+# To count up the BR for this decay:
+# awk ' /^0./{ sum = sum + $1 ;print sum } ' junk.dec
+#
+# anti-B_s decays.
+# -------------------------------------------------------
+# whb&fkw 3/28/01 Taken from fkw's QQ tables.
+#                 most dubious part are the B to baryons.
+# fkw 4/28/00 made the Bs parallel to the Bd as best as I could
+# -------------------------------------------------------
+#
+# Lange - Nov14 - NOT adjusted for D_s->phipi change
+#
+Decay anti-B_s0
+#
+# fkw 4/28/00 Strategy for charmonium modes:
+# Take Bd BR's, replace spectator,
+# assume etaprime = 2/3 ss
+# and eta = 1/3 ss
+#
+# Note: Just for kicks I gave the c\bar c decays a small piece that is
+#       self tagging. See if you can find it. This is already in
+#       the B0 decays in cleo's version of decay.dec .
+#
+#                                        B --> (c c=)  (s s=)
+#					2.65%
+#					should be: psi = 0.80%  CLNS 94/1315 but isn't quite right.
+# B_s0 -> J/psi phi increased by a factor fo 10
+0.00064   J/psi   eta'               SVS;
+0.00032   J/psi   eta                SVS;
+0.01300000 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.00008   J/psi   K0                 SVS;
+0.00070   J/psi   K-       K+        PHSP;
+0.00070   J/psi   anti-K0  K0        PHSP;
+0.00070   J/psi   anti-K0  K+   pi-  PHSP;
+0.00070   J/psi   anti-K0  K0   pi0  PHSP;
+0.00070   J/psi   K-       K+   pi0  PHSP;
+# LHCb PR 04/02/04 Add (cc) phi n pi(+/0)
+0.00039   J/psi   phi      pi+  pi-  PHSP;
+0.00039   J/psi   phi      pi0  pi0  PHSP;
+# LHCb PR add (cc) phi eta(') + npi see CDF QQ
+0.0002    J/psi   eta      pi+  pi-  PHSP;
+0.0002    J/psi   eta      pi0  pi0  PHSP;
+0.0004    J/psi   eta'     pi+  pi-  PHSP;
+0.0004    J/psi   eta'     pi0  pi0  PHSP;
+0.0002    J/psi   pi+      pi-       PHSP;
+0.0002    J/psi   pi0      pi0       PHSP;
+#					psi' = 0.34%  CLNS 94/1315
+#
+0.000465  psi(2S) eta'               SVS;
+0.000235  psi(2S) eta                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003    psi(2S) K-       K+        PHSP;
+0.0003    psi(2S) anti-K0  K0        PHSP;
+0.0003    psi(2S) anti-K0  K+    pi- PHSP;
+0.0003    psi(2S) anti-K0  K0    pi0 PHSP;
+0.0003    psi(2S) K-       K+    pi0 PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+#					chic0 = 0.05% (20% of chic2)
+#					Bodwin et.al. Phys Rev D46 1992
+0.00010   chi_c0  eta'               PHSP;
+0.00005   chi_c0  eta                PHSP;
+0.00020   phi     chi_c0             SVS;
+0.00003   chi_c0  K-       K+        PHSP;
+0.00003   chi_c0  anti-K0  K0        PHSP;
+0.00003   chi_c0  anti-K0  K+   pi-  PHSP;
+0.00003   chi_c0  anti-K0  K0   pi0  PHSP;
+0.00003   chi_c0  K-       K+   pi0  PHSP;
+#
+#
+#					chic1 = 0.37%  CLNS 94/1315
+0.0007    chi_c1  eta'		     SVS;
+0.0003    chi_c1  eta                SVS;
+0.0014    chi_c1  phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
+0.00026   chi_c1  K-       K+        PHSP;
+0.00026   chi_c1  anti-K0  K0        PHSP;
+0.00026   chi_c1  anti-K0  K+   pi-  PHSP;
+0.00026   chi_c1  anti-K0  K0   pi0  PHSP;
+0.00026   chi_c1  K-       K+   pi0  PHSP;
+0.00040   chi_c1  phi      pi+  pi-  PHSP;
+0.00040   chi_c1  phi      pi0  pi0  PHSP;
+0.0001    chi_c1  eta      pi+  pi-  PHSP;
+0.0001    chi_c1  eta      pi0  pi0  PHSP;
+0.0002    chi_c1  eta'     pi+  pi-  PHSP;
+0.0002    chi_c1  eta'     pi0  pi0  PHSP;
+#
+#
+#					chic2 = 0.25%  CLNS 94/1315
+0.000465    chi_c2      eta'                  STS;
+0.000235    chi_c2      eta                   STS;
+#0.0010      chi_c2      phi                   STV; whb: model doesn't exist!
+0.00016     chi_c2      K-         K+	      PHSP;
+0.00016     chi_c2      anti-K0    K0	      PHSP;
+0.00016     chi_c2      anti-K0    K+   pi-   PHSP;
+0.00016     chi_c2      anti-K0    K0   pi0   PHSP;
+0.00016     chi_c2      K-         K+   pi0   PHSP;
+#
+#
+#                                       etac(1s) = 0.41%  Guess: CBX 97-65
+#
+0.0008      eta_c       eta'                  PHSP;
+0.0004      eta_c       eta                   PHSP;
+0.0015      phi         eta_c                 SVS;
+0.00028     eta_c       K-         K+         PHSP;
+0.00028     eta_c       anti-K0    K0         PHSP;
+0.00028     eta_c       anti-K0    K+   pi-   PHSP;
+0.00028     eta_c       anti-K0    K0   pi0   PHSP;
+0.00028     eta_c       K-         K+   pi0   PHSP;
+0.00040   eta_c   phi      pi+  pi-  PHSP;
+0.00040   eta_c   phi      pi0  pi0  PHSP;
+0.0001    eta_c   eta      pi+  pi-  PHSP;
+0.0001    eta_c   eta      pi0  pi0  PHSP;
+0.0002    eta_c   eta'     pi+  pi-  PHSP;
+0.0002    eta_c   eta'     pi0  pi0  PHSP;
+#
+#
+#                                        etac(2s) = 0.18%  Guess: CBX 97-65
+0.0004      eta_c(2S)   eta'                  PHSP;
+0.0002      eta_c(2S)   eta                   PHSP;
+0.0006      phi         eta_c(2S)             SVS;
+0.00012     eta_c(2S)   K-         K+         PHSP;
+0.00012     eta_c(2S)   anti-K0    K0         PHSP;
+0.00012     eta_c(2S)   anti-K0    K+   pi-   PHSP;
+0.00012     eta_c(2S)   anti-K0    K0   pi0   PHSP;
+0.00012     eta_c(2S)   K-         K+   pi0   PHSP;
+#
+Enddecay
+#
+# B_s decays.
+# -------------------------------------------------------
+# whb&fkw 3/28/01 Taken from fkw's QQ tables.
+#                 most dubious part are the B to baryons.
+# fkw 4/28/00 made the Bs parallel to the Bd as best as I could
+# -------------------------------------------------------
+Decay B_s0
+# fkw 4/28/00 Strategy for charmonium modes:
+# Take Bd BR's, replace spectator,
+# assume etaprime = 2/3 ss
+# and eta = 1/3 ss
+#
+# Note: Just for kicks I gave the c\bar c decays a small piece that is
+#       self tagging. See if you can find it. This is already in
+#       the B0 decays in cleo's version of decay.dec .
+#
+#                                        B --> (c c=)  (s s=)
+#					2.65%
+#					should be: psi = 0.80%  CLNS 94/1315 but isn't quite right.
+# B_s0 -> J/psi phi increased by a factor of 10
+0.00064     J/psi       eta'		                   SVS;
+0.00032     J/psi       eta	                           SVS;
+0.01300000 J/psi   phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.00008     J/psi       K0		                   SVS;
+0.00070     J/psi       K-          K+                     PHSP;
+0.00070     J/psi       anti-K0     K0                     PHSP;
+0.00070     J/psi       K0          K-         pi+         PHSP;
+0.00070     J/psi       anti-K0     K0         pi0         PHSP;
+0.00070     J/psi       K-          K+         pi0         PHSP;
+# LHCb PR 04/02/04 Add (cc) phi n pi(+/0)
+0.00039   J/psi   phi      pi+  pi-  PHSP;
+0.00039   J/psi   phi      pi0  pi0  PHSP;
+# LHCb PR Add (cc) phi eta(') + npi like in CDF QQ
+0.0002    J/psi   eta      pi+  pi-  PHSP;
+0.0002    J/psi   eta      pi0  pi0  PHSP;
+0.0004    J/psi   eta'     pi+  pi-  PHSP;
+0.0004    J/psi   eta'     pi0  pi0  PHSP;
+0.0002    J/psi   pi+      pi-       PHSP;
+0.0002    J/psi   pi0      pi0       PHSP;
+#					psi' = 0.34%  CLNS 94/1315
+0.000465    psi(2S)     eta'	                           SVS;
+0.000235    psi(2S)     eta                                SVS;
+0.000680000 psi(2S) phi                                     SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.0003      psi(2S)     K-          K+                     PHSP;
+0.0003      psi(2S)     anti-K0     K0                     PHSP;
+0.0003      psi(2S)     K0          K-         pi+         PHSP;
+0.0003      psi(2S)     anti-K0     K0         pi0         PHSP;
+0.0003      psi(2S)     K-          K+         pi0         PHSP;
+0.00034   psi(2S) phi      pi+  pi-  PHSP;
+0.00034   psi(2S) phi      pi0  pi0  PHSP;
+0.0002    psi(2S) eta      pi+  pi-  PHSP;
+0.0002    psi(2S) eta      pi0  pi0  PHSP;
+0.0004    psi(2S) eta'     pi+  pi-  PHSP;
+0.0004    psi(2S) eta'     pi0  pi0  PHSP;
+0.0002    psi(2S) pi+      pi-       PHSP;
+0.0002    psi(2S) pi0      pi0       PHSP;
+#
+#					chic0 = 0.05% (20% of chic2)
+#					Bodwin et.al. Phys Rev D46 1992
+0.00010     chi_c0      eta'                               PHSP;
+0.00005     chi_c0      eta                                PHSP;
+0.00020     phi         chi_c0                             SVS;
+0.00003     chi_c0      K-          K+                     PHSP;
+0.00003     chi_c0      anti-K0     K0                     PHSP;
+0.00003     chi_c0      K0          K-         pi+         PHSP;
+0.00003     chi_c0      anti-K0     K0         pi0         PHSP;
+0.00003     chi_c0      K-          K+         pi0         PHSP;
+#
+#
+#					chic1 = 0.37%  CLNS 94/1315
+0.0007       chi_c1      eta'	                           SVS;
+0.0003      chi_c1      eta                                SVS;
+0.0014      chi_c1      phi                SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0;
+0.00026     chi_c1      K-          K+	                   PHSP;
+0.00026     chi_c1      anti-K0     K0	                   PHSP;
+0.00026     chi_c1      K0          K-         pi+         PHSP;
+0.00026     chi_c1      anti-K0     K0         pi0         PHSP;
+0.00026     chi_c1      K-          K+         pi0         PHSP;
+0.00040   chi_c1  phi      pi+  pi-  PHSP;
+0.00040   chi_c1  phi      pi0  pi0  PHSP;
+0.0001    chi_c1  eta      pi+  pi-  PHSP;
+0.0001    chi_c1  eta      pi0  pi0  PHSP;
+0.0002    chi_c1  eta'     pi+  pi-  PHSP;
+0.0002    chi_c1  eta'     pi0  pi0  PHSP;
+#
+#
+#					chic2 = 0.25%  CLNS 94/1315
+0.000465    chi_c2      eta'                               STS;
+0.000235    chi_c2      eta                                STS;
+#0.0010      chi_c2      phi                                STV; whb: doesn't exist
+0.00016     chi_c2      K-          K+	                   PHSP;
+0.00016     chi_c2      anti-K0     K0	                   PHSP;
+0.00016     chi_c2      K0          K-         pi+         PHSP;
+0.00016     chi_c2      anti-K0     K0         pi0         PHSP;
+0.00016     chi_c2      K-          K+         pi0         PHSP;
+#
+#
+#                                       etac(1s) = 0.41%  Guess: CBX 97-65
+0.0008      eta_c       eta'                               PHSP;
+0.0004      eta_c       eta                                PHSP;
+0.0015      phi         eta_c                              SVS;
+0.00028     eta_c       K-          K+                     PHSP;
+0.00028     eta_c       K0          anti-K0                PHSP;
+0.00028     eta_c       K0          K-         pi+         PHSP;
+0.00028     eta_c       K0          anti-K0    pi0         PHSP;
+0.00028     eta_c       K-          K+         pi0         PHSP;
+0.00040   eta_c   phi      pi+  pi-  PHSP;
+0.00040   eta_c   phi      pi0  pi0  PHSP;
+0.0001    eta_c   eta      pi+  pi-  PHSP;
+0.0001    eta_c   eta      pi0  pi0  PHSP;
+0.0002    eta_c   eta'     pi+  pi-  PHSP;
+0.0002    eta_c   eta'     pi0  pi0  PHSP;
+#
+Enddecay
+
+# whb: QQ B_c included- Near end of File
+#Decay B_c-
+#CHANNEL  0 0.0700 TAU-  NUTB
+#CHANNEL  1 0.1100 NUEB  E-    *CC*
+#CHANNEL  1 0.1100 NUMB  MU-   *CC*
+#CHANNEL  1 0.0300 NUTB  TAU-  *CC*
+#CHANNEL  0 0.3400 *DU*  *CC*
+#CHANNEL  0 0.0700 *SC*  *CC*
+#CHANNEL  0 0.2700 *SC*
+#0.0700      tau-        anti-nu_tau                        PHSP;
+#0.1100      anti-nu_e   e-          *CC*              Simpleleptonic;
+#0.1100      anti-nu_mu  mu-         *CC*               Simple leptonic;
+#0.0300      anti-nu_tau tau-        *CC*               Simple leptonic;
+#0.3400      *DU*        *CC*                               PHSP;
+#0.0700      *SC*        *CC*                               PHSP;
+#0.2700      *SC*                                           PHSP;
+#Enddecay
+#
+#Decay  B_c+
+#CHANNEL  0 0.0700 TAU+  NUT
+#CHANNEL  1 0.1100 NUE   E+    *CC*
+#CHANNEL  1 0.1100 NUM   MU+   *CC*
+#CHANNEL  1 0.0300 NUT   TAU+  *CC*
+#CHANNEL  0 0.3400 *UD*  *CC*
+#CHANNEL  0 0.0700 *CS*  *CC*
+#CHANNEL  0 0.2700 *CS*
+#0.0700      tau+        nu_tau                             PHSP;
+#0.1100      nu_e        E+          *CC*                  Simple leptonic;
+#0.1100      nu_mu       mu+         *CC*                  Simple leptonic;
+#0.0300      nu_tau      tau+        *CC*                  Simple leptonic;
+#0.3400      *UD*        *CC*                               PHSP;
+#0.0700      *CS*        *CC*                               PHSP;
+#0.2700      *CS*                                           PHSP;
+#Enddecay
+
+#
+# Updated to PDG 2008
+#
+Decay tau-
+0.154002925 e-      anti-nu_e nu_tau                        PHOTOS TAULNUNU; #[Reconstructed PDG2011]
+0.170000000 mu-     anti-nu_mu nu_tau                       PHOTOS  TAULNUNU; #[Reconstructed PDG2011]
+0.109100000 pi-     nu_tau                                  TAUSCALARNU; #[Reconstructed PDG2011]
+0.006960000 K-      nu_tau                                  TAUSCALARNU; #[Reconstructed PDG2011]
+0.255100000 pi-     pi0     nu_tau                          TAUHADNU -0.108 0.775 0.149 1.364 0.400; #[Reconstructed PDG2011]
+0.001124109 nu_tau gamma pi- pi0 PYTHIA 21;
+0.079301562 pi0     pi0     pi-     nu_tau                  TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4; #[Reconstructed PDG2011]
+0.000385656 nu_tau K- pi0 pi0 PYTHIA 21;
+0.008508640 nu_tau pi- pi0 pi0 pi0 PYTHIA 21;
+0.000864699 nu_tau  pi-     pi0     pi0     pi0     pi0     PHSP; #[Reconstructed PDG2011]
+#0.2515         rho- nu_tau                     TAUVECTORNU;
+#0.1790         a_1-  nu_tau                     TAUVECTORNU;
+# Modes with K0s
+#
+0.000319939 nu_tau pi- anti-K0 PYTHIA 21;
+0.001590000 nu_tau K- K0 PYTHIA 21;
+0.001700000 nu_tau K0 pi- anti-K0 PYTHIA 21;
+0.001590000 nu_tau K- pi0 K0 PYTHIA 21;
+0.004000000 nu_tau pi- anti-K0 pi0 PYTHIA 21;
+# 3 Charged Particles
+#
+0.093200000 pi-     pi-     pi+     nu_tau                  TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4; #[Reconstructed PDG2011]
+0.046100000 nu_tau pi- pi+ pi- pi0 PYTHIA 21;
+0.000501526 nu_tau  pi-     pi-     pi+     pi0     pi0     PHSP; #[Reconstructed PDG2011]
+0.000155646 nu_tau  pi-     pi-     pi+     pi0     pi0     pi0     PHSP; #[Reconstructed PDG2011]
+0.003420000 nu_tau K- pi+ pi- PYTHIA 21;
+0.001360000 nu_tau K- pi+ pi- pi0 PYTHIA 21;
+0.001400000 nu_tau K- pi- K+ PYTHIA 21;
+0.000015800 nu_tau K- K+ K- PYTHIA 21;
+# 5 Charged Particles
+#
+0.000700406 nu_tau  pi-     pi-     pi-     pi+     pi+     PHSP; #[Reconstructed PDG2011]
+0.000129705 nu_tau  pi-     pi-     pi-     pi+     pi+     pi0     PHSP; #[Reconstructed PDG2011]
+# Misc other modes
+#
+0.012000000 K*-     nu_tau                                  TAUVECTORNU; #[Reconstructed PDG2011]
+0.001390000 nu_tau eta pi- pi0 PYTHIA 21;
+0.003199387 nu_tau pi- omega pi0 PYTHIA 21;
+0.000410000 nu_tau K- omega PYTHIA 21;
+0.002200000 anti-K*0 pi-     nu_tau                         PHSP; #[Reconstructed PDG2011]
+0.002100000 K*0     K-      nu_tau                          PHSP; #[Reconstructed PDG2011]
+0.000034000 phi     pi-     nu_tau                          PHSP; #[Reconstructed PDG2011]
+0.000037000 phi     K-      nu_tau                          PHSP; #[Reconstructed PDG2011]
+0.003600000 mu-     anti-nu_mu nu_tau  gamma                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.017500000 e-      anti-nu_e nu_tau  gamma                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004290000 K-      pi0     nu_tau                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.002200000 anti-K0 rho-    nu_tau                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000260000 pi-     anti-K0 pi0     pi0     nu_tau          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000310000 pi-     K0      anti-K0 pi0     nu_tau          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000061000 K-      K+      pi-     pi0     nu_tau          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000028000 e-      e-      e+      anti-nu_e nu_tau        PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004700000 K_1-    nu_tau                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001700000 K'_1-   nu_tau                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001500000 K'*-    nu_tau                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000150000 eta     pi-     pi0     pi0     nu_tau          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000161000 eta     K-      nu_tau                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000138000 eta     K*-     nu_tau                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000048000 eta     K-      pi0     nu_tau                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000093000 eta     anti-K0 pi-     nu_tau                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000360000 f_1     pi-     nu_tau                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+CDecay tau+
+#
+#   Vector Mesons Updated PDG 2008
+#
+Decay D*+
+0.6770    D0  pi+                        VSS;
+0.3070    D+  pi0                        VSS;
+0.0160    D+  gamma                       VSP_PWAVE;
+Enddecay
+Decay D*-
+0.6770    anti-D0 pi-                        VSS;
+0.3070    D-  pi0                        VSS;
+0.0160    D-  gamma                       VSP_PWAVE;
+Enddecay
+Decay D*0
+0.619000000 D0      pi0                                     VSS; #[Reconstructed PDG2011]
+0.381000000 D0      gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+Enddecay
+Decay anti-D*0
+0.6190    anti-D0  pi0                       VSS;
+0.3810    anti-D0  gamma                      VSP_PWAVE;
+Enddecay
+#
+Decay D_s*+
+0.942000000 D_s+    gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.058000000 D_s+    pi0                                     VSS; #[Reconstructed PDG2011]
+Enddecay
+Decay D_s*-
+0.942000000 D_s-    gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.058000000 D_s-    pi0                                     VSS; #[Reconstructed PDG2011]
+Enddecay
+#
+#
+#   D+ Meson
+#
+Decay D+
+0.055200000 anti-K*0 e+      nu_e                           PHOTOS   ISGW2; # PDG2014
+0.088300000 anti-K0 e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.002773020 anti-K_10 e+      nu_e                          PHOTOS   ISGW2; # Keep same as in 2010 version
+0.002927076 anti-K_2*0 e+      nu_e                         PHOTOS   ISGW2; # Keep same as in 2010 version
+0.004050000 pi0     e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.001140000 eta     e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.000220000 eta'    e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.002180000 rho0    e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.001820000 omega   e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.003321725 K-      pi+     e+      nu_e                    PHOTOS   PHSP;  # PDG2014 (subtracted K*)+tiny bit to have sum=1
+0.001200122 anti-K0 pi0     e+      nu_e                    PHOTOS   PHSP;  # Keep same as in 2010 version+tiny bit to have sum=1
+#
+0.052800000 anti-K*0 mu+     nu_mu                          PHOTOS  ISGW2; # PDG2014 
+0.092000000 anti-K0 mu+     nu_mu                           PHOTOS  ISGW2; # PDG2014
+0.002773020 anti-K_10 mu+     nu_mu                         PHOTOS  ISGW2; # Keep same as in 2010 version
+0.002927076 anti-K_2*0 mu+     nu_mu                        PHOTOS  ISGW2; # Keep same as in 2010 version
+0.004050000 pi0     mu+     nu_mu                           PHOTOS  ISGW2; # Same as electron
+0.001140000 eta     mu+     nu_mu                           PHOTOS  ISGW2; # Same as electron
+0.002200000 eta'    mu+     nu_mu                           PHOTOS  ISGW2; # Same as electron
+0.002400000 rho0    mu+     nu_mu                           PHOTOS  ISGW2; # PDG2014
+0.001820000 omega   mu+     nu_mu                           PHOTOS  ISGW2; # Same as electron
+0.002921725 K-      pi+     mu+     nu_mu                   PHOTOS   PHSP; # PDG2014 (subtracted K*)+tiny bit to have sum=1
+0.001200122 anti-K0 pi0     mu+     nu_mu                   PHOTOS   PHSP; # Keep same as in 2010 version+tiny bit to have sum=1
+#
+#
+0.000382000 mu+     nu_mu                                   PHOTOS   SLN; #[Reconstructed PDG2011]
+0.000770283 tau+    nu_tau                                  SLN; #[Reconstructed PDG2011]
+#
+0.014900000 K_S0    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.014600000 K_L0    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi+                                     PHSP; #[Reconstructed PDG2011]
+#
+0.025950843 a_1+    K_S0                                    SVS; #[Reconstructed PDG2011]
+0.025950843 a_1+    K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 a_1+    anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+0.027090862 anti-K'_10 pi+                                  SVS; #[Reconstructed PDG2011]
+#0.0115   anti-K_0*0N  pi+                PHSP;
+0.013387523 anti-K*0 rho+                                   SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+#
+# the Dalitz mode below includes K*bar(892)0 pi+,
+# K*bar(1430)0 pi+, and K*bar(1680)0 pi+ resonances.
+0.094000000 K-      pi+     pi+                             D_DALITZ; #[Reconstructed PDG2011]
+# the Dalitz mode below includes K0bar rho+,
+# and K*bar(892)0 pi+ resonances
+0.069900000 K_S0    pi+     pi0                             D_DALITZ; # PDG2014
+0.069900000 K_L0    pi+     pi0                             D_DALITZ; # Assume to be same as K_S0 pi+ pi0
+0.000000000 anti-K0 pi+     pi0                             D_DALITZ; #[Reconstructed PDG2011]
+#0.0100   anti-K0   eta  pi+                    PHSP;
+#
+0.001247859 K_S0    rho0    pi+                             PHSP; #[Reconstructed PDG2011]
+0.001247859 K_L0    rho0    pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 rho0    pi+                             PHSP; #[Reconstructed PDG2011]
+#
+0.003851416 anti-K0 omega   pi+                             PHSP; #[Reconstructed PDG2011]
+0.007032686 K-      rho+    pi+                             PHSP; #[Reconstructed PDG2011]
+0.009274210 K*-     pi+     pi+                             PHSP; #[Reconstructed PDG2011]
+0.047187552 anti-K*0 pi0     pi+                            PHSP; #[Reconstructed PDG2011]
+#0.0100   anti-K*0 eta  pi+                    PHSP;
+0.001101505 anti-K*0 rho0    pi+                            PHSP; #[Reconstructed PDG2011]
+0.003851416 anti-K*0 omega   pi+                            PHSP; #[Reconstructed PDG2011]
+#0.0100   K*- rho+  pi+                   PHSP;
+#
+0.008473116 K-      pi+     pi+     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+#0.002472609 K_S0    pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#0.002472609 K_L0    pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.031200000 K_S0    pi+     pi+     pi-                     PHSP; # PDG2014 (why it was much smaller?)
+0.031200000 K_L0    pi+     pi+     pi-                     PHSP; # PDG2014
+0.000000000 anti-K0 pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+#0.0188   anti-K0   pi+  pi0   pi0              PHSP;
+0.005700000 K-      pi+     pi+     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.003851416 K-      pi+     pi+     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+0.006701464 anti-K0 pi+     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.002695991 anti-K0 pi+     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+#
+0.004600000 K_S0    K_S0    K+                              PHSP; #[Reconstructed PDG2011]
+0.003111944 K_L0    K_L0    K+                              PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 anti-K0 K+                              PHSP; #[Reconstructed PDG2011]
+#
+0.004660214 phi     pi+                                     SVS; #[Reconstructed PDG2011]
+0.023000000 phi     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.002860000 K_S0    K+                                      PHSP; #[Reconstructed PDG2011]
+0.002195307 K_L0    K+                                      PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+                                      PHSP; #[Reconstructed PDG2011]
+#
+0.002179902 anti-K*0 K+                                     SVS; #[Reconstructed PDG2011]
+#
+0.016000000 K*+     K_S0                                    SVS; #[Reconstructed PDG2011]
+0.011145999 K*+     K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 K*+     anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+#0.0180   anti-K*0 K*+                         SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.002826940 K+      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K+      anti-K0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K*+     K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K+      K*-     pi+                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K*+     anti-K0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K+      anti-K*0 pi0                            PHSP; #[Reconstructed PDG2011]
+0.000770283 anti-K*0 K0      pi+                            PHSP; #[Reconstructed PDG2011]
+0.000770283 anti-K0 K*0     pi+                             PHSP; #[Reconstructed PDG2011]
+#
+0.001260000 pi0     pi+                                     PHSP; #[Reconstructed PDG2011]
+0.000830000 rho0    pi+                                     SVS; #[Reconstructed PDG2011]
+0.002440000 pi+     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.004700000 pi+     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011600000 pi+     pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003851416 pi+     pi0     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003430000 eta     pi+                                     PHSP; #[Reconstructed PDG2011]
+0.004400000 eta'    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.001380000 eta     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.002310850 eta     pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001540566 eta     pi+     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#lange jul22,2002
+0.001660000 pi+     pi+     pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.009300000 anti-K*0 a_1+                                   PHSP; #[Reconstructed PDG2011]
+0.010545178 K+      K-      pi+     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001740000 K+      K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001270967 K+      K_L0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K+      anti-K0 pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.002380000 K_S0    K-      pi+     pi+                     PHSP; #[Reconstructed PDG2011]
+0.001756246 K_L0    K-      pi+     pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-      pi+     pi+                     PHSP; #[Reconstructed PDG2011]
+#
+0.000230000 K+      K-      pi+     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+#
+0.000240000 K+      K-      K_S0    pi+                     PHSP; #[Reconstructed PDG2011]
+0.000161759 K+      K-      K_L0    pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K+      K-      anti-K0 pi+                     PHSP; #[Reconstructed PDG2011]
+# Doubly Cabibbo suppressed modes
+0.000237000 K+      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000332000 K+      pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.000089000 K+      K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.001720000 K-      rho0    pi+     pi+                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001600000 eta'    pi+     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000210000 K+      rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+#
+Decay D-
+0.055200000 K*0     e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.088300000 K0      e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.002773020 K_10    e-      anti-nu_e                       PHOTOS    ISGW2; # Keep same as in 2010 version
+0.002927076 K_2*0   e-      anti-nu_e                       PHOTOS    ISGW2; # Keep same as in 2010 version
+0.004050000 pi0     e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.001140000 eta     e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.000220000 eta'    e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.002180000 rho0    e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.001820000 omega   e-      anti-nu_e                       PHOTOS    ISGW2; # PDG2014
+0.003321725 K+      pi-     e-      anti-nu_e               PHOTOS   PHSP;   # PDG2014 (subtracted K*)+tiny bit to have sum=1
+0.001200122 K0      pi0     e-      anti-nu_e               PHOTOS   PHSP;   # Keep same as in 2010 version+tiny bit to have sum=1
+#
+0.052800000 K*0     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.092000000 K0      mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002773020 K_10    mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002927076 K_2*0   mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.004050000 pi0     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.001140000 eta     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002200000 eta'    mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002400000 rho0    mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.001820000 omega   mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002921725 K+      pi-     mu-     anti-nu_mu              PHOTOS   PHSP; #[Reconstructed PDG2011]
+0.001200122 K0      pi0     mu-     anti-nu_mu              PHOTOS   PHSP; #[Reconstructed PDG2011]
+#
+0.000382000 mu-     anti-nu_mu                              PHOTOS   SLN; #[Reconstructed PDG2011]
+0.000770283 tau-    anti-nu_tau                             SLN; #[Reconstructed PDG2011]
+#
+0.014900000 K_S0    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.014600000 K_L0    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi-                                     PHSP; #[Reconstructed PDG2011]
+#
+0.025950843 a_1-    K_S0                                    SVS; #[Reconstructed PDG2011]
+0.025950843 a_1-    K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 a_1-    K0                                      SVS; #[Reconstructed PDG2011]
+#
+0.027090862 K'_10   pi-                                     SVS; #[Reconstructed PDG2011]
+#0.0115   K_0*0N  pi-                        PHSP;
+0.013387523 K*0     rho-                                    SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+#
+# the Dalitz mode below includes K*(892)0 pi-, K*(1430)0 pi-, and K*(1680)0 pi- resonances.
+0.094000000 K+      pi-     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+# the Dalitz mode below includes K0 rho-, and K*(892)0 pi- resonances.
+0.069900000 K_S0    pi-     pi0                             D_DALITZ; # PDG2014
+0.069900000 K_L0    pi-     pi0                             D_DALITZ; # Assume to be same as K_S0 pi- pi0
+0.000000000 K0      pi-     pi0                             D_DALITZ; #[Reconstructed PDG2011]
+#
+#0.0100   K0  eta  pi-                    PHSP;
+0.001247859 K_S0    rho0    pi-                             PHSP; #[Reconstructed PDG2011]
+0.001247859 K_L0    rho0    pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      rho0    pi-                             PHSP; #[Reconstructed PDG2011]
+#
+0.003851416 K0      omega   pi-                             PHSP; #[Reconstructed PDG2011]
+0.007032686 K+      rho-    pi-                             PHSP; #[Reconstructed PDG2011]
+0.009274210 K*+     pi-     pi-                             PHSP; #[Reconstructed PDG2011]
+0.047187552 K*0     pi0     pi-                             PHSP; #[Reconstructed PDG2011]
+#0.0100   K*0 eta  pi-                    PHSP;
+0.001101505 K*0     rho0    pi-                             PHSP; #[Reconstructed PDG2011]
+0.003851416 K*0     omega   pi-                             PHSP; #[Reconstructed PDG2011]
+#0.0100   K*+ rho-  pi-                   PHSP;
+#
+0.008473116 K+      pi-     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.031200000 K_S0    pi-     pi-     pi+                     PHSP; # PDG2014 (why it was much smaller?)
+0.031200000 K_L0    pi-     pi-     pi+                     PHSP; # PDG2014
+0.000000000 K0      pi-     pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+#
+#0.0188   K0  pi-  pi0   pi0              PHSP;
+0.005700000 K+      pi-     pi-     pi-     pi+             PHSP; #[Reconstructed PDG2011]
+0.003851416 K+      pi-     pi-     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+0.006701464 K0      pi-     pi-     pi+     pi0             PHSP; #[Reconstructed PDG2011]
+0.002695991 K0      pi-     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+#
+0.004600000 K_S0    K_S0    K-                              PHSP; #[Reconstructed PDG2011]
+0.003111944 K_L0    K_L0    K-                              PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K0      K-                              PHSP; #[Reconstructed PDG2011]
+#
+0.004660214 phi     pi-                                     SVS; #[Reconstructed PDG2011]
+0.023000000 phi     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.002860000 K_S0    K-                                      PHSP; #[Reconstructed PDG2011]
+0.002195307 K_L0    K-                                      PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-                                      PHSP; #[Reconstructed PDG2011]
+#
+0.002179902 K*0     K-                                      SVS; #[Reconstructed PDG2011]
+#
+0.016000000 K*-     K_S0                                    SVS; #[Reconstructed PDG2011]
+0.011145999 K*-     K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 K*-     K0                                      SVS; #[Reconstructed PDG2011]
+#
+#0.0180   K*0 K*-                         SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.002826940 K-      K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K-      K0      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K*-     K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K-      K*+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K*-     K0      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K-      K*0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K*0     anti-K0 pi-                             PHSP; #[Reconstructed PDG2011]
+0.000770283 K0      anti-K*0 pi-                            PHSP; #[Reconstructed PDG2011]
+#
+0.001260000 pi0     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000830000 rho0    pi-                                     SVS; #[Reconstructed PDG2011]
+0.002440000 pi-     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.004700000 pi-     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011600000 pi-     pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003851416 pi-     pi0     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003430000 eta     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.004400000 eta'    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.001380000 eta     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.002310850 eta     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001540566 eta     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#lange jul22,2002
+0.001660000 pi+     pi-     pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.009300000 K*0     a_1-                                    PHSP; #[Reconstructed PDG2011]
+0.010545178 K+      K-      pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001740000 K-      K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001270967 K-      K_L0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K-      K0      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.002380000 K_S0    K+      pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001756246 K_L0    K+      pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+      pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.000230000 K+      K-      pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+#
+0.000240000 K+      K-      K_S0    pi-                     PHSP; #[Reconstructed PDG2011]
+0.000161759 K+      K-      K_L0    pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K+      K-      K0      pi-                     PHSP; #[Reconstructed PDG2011]
+# Doubly Cabibbo suppressed modes
+0.000237000 K-      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000332000 K-      pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.000089000 K-      K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.001720000 K+      rho0    pi-     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001600000 eta'    pi-     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000210000 K-      rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay K*BR
+1.0000   anti-K0  pi0                          VSS;
+Enddecay
+#
+#
+Decay D0
+# updated according to suggestions by P. Roudeau,
+# using PDG2004 measurements and imposing the equality
+# of sl partial widths for D+ and D0.
+# Include additional decay anti-K0 pi- e+ nu_e , K- pi0 e+ nu_e.
+#
+0.021600000 K*-     e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.035500000 K-      e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.000760000 K_1-    e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.001100000 K_2*-   e+      nu_e                            PHOTOS   ISGW2; # Small decrease as this is unmeasured
+0.002890000 pi-     e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.001770000 rho-    e+      nu_e                            PHOTOS   ISGW2; # PDG2014
+0.001080000 anti-K0 pi-     e+      nu_e                    PHOTOS   PHSP;  # PDG2014 subtracting K* (decreased due large uncertaity ) 
+0.000400000 K-      pi0     e+      nu_e                    PHOTOS   PHSP;  # PDG2014 subtracting K* (decreased due large uncertaity ) 
+#
+0.021000000 K*-     mu+     nu_mu                           PHOTOS  ISGW2; # 1.1 * PDG2014
+0.034700000 K-      mu+     nu_mu                           PHOTOS  ISGW2; # 1.05 * PDG2014
+0.000076000 K_1-    mu+     nu_mu                           PHOTOS  ISGW2; # PDG2014 for electron
+0.001100000 K_2*-   mu+     nu_mu                           PHOTOS  ISGW2; # copy from electron
+0.002370000 pi-     mu+     nu_mu                           PHOTOS  ISGW2; # PDG2014
+0.002015940 rho-    mu+     nu_mu                           PHOTOS  ISGW2; # PDG2014 for electron
+0.001080000 anti-K0 pi-     mu+     nu_mu                   PHOTOS   PHSP; # copy electron
+0.000400000 K-      pi0     mu+     nu_mu                   PHOTOS   PHSP; # copy electron
+#
+0.038900000 K-      pi+                                     PHSP; #[Reconstructed PDG2011]
+#
+0.012200000 K_S0    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.010000000 K_L0    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi0                                     PHSP; #[Reconstructed PDG2011]
+#
+0.004290000 K_S0    eta                                     PHSP; #[Reconstructed PDG2011]
+0.003802795 K_L0    eta                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 eta                                     PHSP; #[Reconstructed PDG2011]
+#
+0.009300000 K_S0    eta'                                    PHSP; #[Reconstructed PDG2011]
+0.008980094 K_L0    eta'                                    PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 eta'                                    PHSP; #[Reconstructed PDG2011]
+#
+0.011100000 omega   K_S0                                    SVS; #[Reconstructed PDG2011]
+0.010904400 omega   K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 omega   anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+0.001603588 anti-K*0 eta                                    SVS; #[Reconstructed PDG2011]
+0.000916336 anti-K*0 eta'                                   SVS; #[Reconstructed PDG2011]
+0.078000000 a_1+    K-                                      SVS; #[Reconstructed PDG2011]
+0.067625607 K*-     rho+                                    SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.015800000 anti-K*0 rho0                                   SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.011000000 anti-K*0 omega                                  SVV_HELAMP  1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+# the Dalitz mode below includes K*bar(892)0 pi0,
+# K*(892)- pi+, and K- rho(770)+ resonances
+0.139000000 K-      pi+     pi0                             D_DALITZ; #[Reconstructed PDG2011]
+0.006634274 K*BR    pi0                                     SVS; #[Reconstructed PDG2011]
+0.016000000 K_1-    pi+                                     SVS; #[Reconstructed PDG2011]
+0.006505987 anti-K_10 pi0                                   SVS; #[Reconstructed PDG2011]
+#
+# the Dalitz mode below includes K*(892)- pi+ and Kbar0 rho(770)0 resonances
+# LHCb PR 09 Apr 2004 split into KS/KL
+0.029400000 K_S0    pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+0.027856619 K_L0    pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+#
+0.008300000 K_S0    pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.004425904 K_L0    pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.024000000 anti-K*0 pi+     pi-                            PHSP; #[Reconstructed PDG2011]
+0.010629499 anti-K*0 pi0     pi0                            PHSP; #[Reconstructed PDG2011]
+0.009163361 K*-     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.006231086 K-      rho+    pi0                             PHSP; #[Reconstructed PDG2011]
+0.005305586 K-      pi+     rho0                            PHSP; #[Reconstructed PDG2011]
+0.019000000 K-      pi+     omega                           PHSP; #[Reconstructed PDG2011]
+0.009163361 K-      pi+     eta                             PHSP; #[Reconstructed PDG2011]
+0.007500000 K-      pi+     eta'                            PHSP; #[Reconstructed PDG2011]
+0.013300000 K-      pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.054000000 K_S0    pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.010079698 K_L0    pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+# K- pi+ pi0 pi0 is (15 +/- 5)% in the PDG, but we decrease it to
+# have everything add to 1 and get enough neutral kaons:
+#0.02575  K-  pi+  pi0   pi0              PHSP;
+#
+#0.0143   anti-K0   pi0  pi0   pi0              PHSP;
+0.040316317   anti-K0   pi0  pi0   pi0              PHSP; # Add in to fill sum to 1. [MK June 2015]
+0.000000000 K-      pi+     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.003482077 K-      pi+     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+#
+0.002800000 K_S0    pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.002684865 K_L0    pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+#
+#0.0638   anti-K0   pi+  pi-   pi0   pi0        PHSP;
+#0.0192   anti-K0   pi+  pi-   pi0   pi0   pi0  PHSP;
+#
+0.002034266 phi     K_S0                                    SVS; #[Reconstructed PDG2011]
+0.002034266 phi     K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 phi     anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+0.004650000 K_S0    K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.002785662 K_L0    K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+      K-                              PHSP; #[Reconstructed PDG2011]
+#
+0.000950000 K_S0    K_S0    K_S0                            PHSP; #[Reconstructed PDG2011]
+0.003940000 K+      K-                                      PHSP; #[Reconstructed PDG2011]
+0.000190000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
+0.000366534 K_L0    K_L0                                    PHSP; #[Reconstructed PDG2011]
+0.000366534 K*0     anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+0.000091634 anti-K*0 K_S0                                   SVS; #[Reconstructed PDG2011]
+0.000091634 anti-K*0 K_L0                                   SVS; #[Reconstructed PDG2011]
+0.000000000 anti-K*0 K0                                     SVS; #[Reconstructed PDG2011]
+#
+0.000485658 K*-     K+                                      SVS; #[Reconstructed PDG2011]
+0.001365341 K*+     K-                                      SVS; #[Reconstructed PDG2011]
+0.001282871 anti-K*0 K*0                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.000714742 phi     pi0                                     SVS; #[Reconstructed PDG2011]
+0.001007970 phi     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.002430000 K+      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.002749008 K+      K-      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001280000 K_S0    K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001255381 K_L0    K_L0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.001374504 anti-K0 K0      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001397000 pi+     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000800000 pi0     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000640000 eta     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000810000 eta'    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.001670000 eta     eta                                     PHSP; #[Reconstructed PDG2011]
+0.009800000 rho+    pi-                                     SVS; #[Reconstructed PDG2011]
+0.004970000 rho-    pi+                                     SVS; #[Reconstructed PDG2011]
+0.003730000 rho0    pi0                                     SVS; #[Reconstructed PDG2011]
+0.001209564 pi+     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000091634 pi0     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.005620000 pi+     pi+     pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.009360000 pi+     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.001510000 pi+     pi-     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.005498017 pi+     pi-     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+0.000420000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+#
+# Doubly Cabibbo suppressed decays:
+0.000137450 pi-     K+                                      PHSP; #[Reconstructed PDG2011]
+0.000128287 pi-     K*+                                     PHSP; #[Reconstructed PDG2011]
+0.000274901 pi-     K+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000247411 K+      pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+# PR LHCb - 19 Apr. 2004 Add D0 -> mu+ mu-
+0.000000000 mu+     mu-                                     PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.000140000 phi     eta                                     PHSP; #[Reconstructed PDG2011]
+0.019000000 anti-K*0 pi+     pi-     pi0                    PHSP; #[Reconstructed PDG2011]
+0.000220000 K-      pi+     pi-     pi+     pi-     pi+     PHSP; #[Reconstructed PDG2011]
+0.000641435 K+      K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.003100000 K+      K-      pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.000221000 K+      K-      K-      pi+                     PHSP; #[Reconstructed PDG2011]
+#
+0.005600000 K_S0    eta     pi0                             PHSP; #[Reconstructed PDG2011]
+0.003665345 K_L0    eta     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 eta     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.002600000 K_S0    K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.002382474 K_L0    K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+      pi-                             PHSP; #[Reconstructed PDG2011]
+#
+0.003500000 K_S0    K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.003344627 K_L0    K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+#
+0.000310000 K_S0    K_S0    K+      pi-                     PHSP; #[Reconstructed PDG2011]
+0.000293228 K_L0    K_L0    K+      pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      K+      pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.000310000 K_S0    K_S0    K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000293228 K_L0    K_L0    K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K-      pi+     pi-     e+      nu_e            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001820000 rho0    rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001090000 eta     pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001600000 omega   pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000450000 eta'    pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001260000 eta     eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000027000 phi     gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000328000 anti-K*0 gamma                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+#
+Decay K*0R
+1.0000   K0 pi0                          VSS;
+Enddecay
+#
+#
+Decay anti-D0
+0.021600000 K*+     e-      anti-nu_e                       PHOTOS   ISGW2; # PDG2014
+0.035500000 K+      e-      anti-nu_e                       PHOTOS   ISGW2; # PDG2014
+0.000760000 K_1+    e-      anti-nu_e                       PHOTOS   ISGW2; # PDG2014
+0.001100000 K_2*+   e-      anti-nu_e                       PHOTOS   ISGW2; # Small decrease as this is unmeasured
+0.002890000 pi+     e-      anti-nu_e                       PHOTOS   ISGW2; # PDG2014
+0.001770000 rho+    e-      anti-nu_e                       PHOTOS   ISGW2; # PDG2014
+0.001080000 K0      pi+     e-      anti-nu_e               PHOTOS   PHSP;  # PDG2014 subtracting K* (decreased due large uncertaity ) 
+0.000400000 K+      pi0     e-      anti-nu_e               PHOTOS   PHSP;  # PDG2014 subtracting K* (decreased due large uncertaity ) 
+#
+0.021000000 K*+     mu-     anti-nu_mu                      PHOTOS  ISGW2; # 1.1 * PDG2014
+0.034700000 K+      mu-     anti-nu_mu                      PHOTOS  ISGW2; # 1.05 * PDG2014
+0.000076000 K_1+    mu-     anti-nu_mu                      PHOTOS  ISGW2; # PDG2014 for electron
+0.001100000 K_2*+   mu-     anti-nu_mu                      PHOTOS  ISGW2; # copy from electron
+0.002370000 pi+     mu-     anti-nu_mu                      PHOTOS  ISGW2; # PDG2014
+0.002015940 rho+    mu-     anti-nu_mu                      PHOTOS  ISGW2; # PDG2014 for electron
+0.001080000 K0      pi+     mu-     anti-nu_mu              PHOTOS   PHSP; # copy electron
+0.000400000 K+      pi0     mu-     anti-nu_mu              PHOTOS   PHSP; # copy electron
+#
+0.038900000 K+      pi-                                     PHSP; #[Reconstructed PDG2011]
+#
+0.012200000 K_S0    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.010000000 K_L0    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi0                                     PHSP; #[Reconstructed PDG2011]
+#
+0.004290000 K_S0    eta                                     PHSP; #[Reconstructed PDG2011]
+0.003818748 K_L0    eta                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      eta                                     PHSP; #[Reconstructed PDG2011]
+#
+0.009300000 K_S0    eta'                                    PHSP; #[Reconstructed PDG2011]
+0.009017767 K_L0    eta'                                    PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      eta'                                    PHSP; #[Reconstructed PDG2011]
+#
+0.011100000 omega   K_S0                                    SVS; #[Reconstructed PDG2011]
+0.010950146 omega   K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 omega   K0                                      SVS; #[Reconstructed PDG2011]
+#
+0.001610316 K*0     eta                                     SVS; #[Reconstructed PDG2011]
+0.000920180 K*0     eta'                                    SVS; #[Reconstructed PDG2011]
+0.078000000 a_1-    K+                                      SVS; #[Reconstructed PDG2011]
+0.067909308 K*+     rho-                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.015800000 K*0     rho0                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.011000000 K*0     omega                                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+# the Dalitz mode below includes K*(892)0 pi0, K*(892)+ pi-, and K+ rho(770)- resonances
+0.139000000 K+      pi-     pi0                             D_DALITZ; #[Reconstructed PDG2011]
+0.006662106 K*0R    pi0                                     SVS; #[Reconstructed PDG2011]
+0.016000000 K_1+    pi-                                     SVS; #[Reconstructed PDG2011]
+0.006533280 K_10    pi0                                     SVS; #[Reconstructed PDG2011]
+# the Dalitz mode below includes K*(892)+ pi- and K0 rho(770)0 resonances
+# LHCb PR 09 Apr 2004, split into KS/KL
+0.000000000 K0      pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+0.029400000 K_S0    pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+0.027973482 K_L0    pi+     pi-                             D_DALITZ; #[Reconstructed PDG2011]
+#
+0.008300000 K_S0    pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.004444471 K_L0    pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.024000000 K*0     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.010674092 K*0     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.009201803 K*+     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.006257226 K+      rho-    pi0                             PHSP; #[Reconstructed PDG2011]
+0.005327844 K+      pi-     rho0                            PHSP; #[Reconstructed PDG2011]
+0.019000000 K+      pi-     omega                           PHSP; #[Reconstructed PDG2011]
+0.009201803 K+      pi-     eta                             PHSP; #[Reconstructed PDG2011]
+0.007500000 K+      pi-     eta'                            PHSP; #[Reconstructed PDG2011]
+0.013300000 K+      pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.054000000 K_S0    pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.010121984 K_L0    pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+# K+ pi- pi0 pi0 is (15 +/- 5)% in the PDG, but we decrease it to
+# have everything add to 1 and get enough neutral kaons:
+#0.02575  K+  pi-  pi0   pi0              PHSP;
+#
+#0.0143   K0  pi0  pi0   pi0              PHSP;
+0.040346268 K0  pi0  pi0   pi0              PHSP;
+0.000000000 K+      pi-     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.003496685 K+      pi-     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+#
+0.002800000 K_S0    pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.002696128 K_L0    pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi+     pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+#
+#0.0638   K0   pi-  pi+   pi0   pi0        PHSP;
+#0.0192   K0   pi-  pi+   pi0   pi0   pi0  PHSP;
+#
+0.002042800 phi     K_S0                                    SVS; #[Reconstructed PDG2011]
+0.002042800 phi     K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 phi     K0                                      SVS; #[Reconstructed PDG2011]
+#
+0.004650000 K_S0    K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.002797348 K_L0    K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K+      K-                              PHSP; #[Reconstructed PDG2011]
+#
+0.000950000 K_S0    K_S0    K_S0                            PHSP; #[Reconstructed PDG2011]
+0.003940000 K+      K-                                      PHSP; #[Reconstructed PDG2011]
+0.000190000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
+0.000368072 K_L0    K_L0                                    PHSP; #[Reconstructed PDG2011]
+0.000368072 anti-K*0 K0                                     SVS; #[Reconstructed PDG2011]
+#
+0.000092018 K*0     K_S0                                    SVS; #[Reconstructed PDG2011]
+0.000092018 K*0     K_L0                                    SVS; #[Reconstructed PDG2011]
+0.000000000 K*0     anti-K0                                 SVS; #[Reconstructed PDG2011]
+#
+0.000487696 K*+     K-                                      SVS; #[Reconstructed PDG2011]
+0.001371069 K*-     K+                                      SVS; #[Reconstructed PDG2011]
+0.001288252 K*0     anti-K*0                                SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.000717741 phi     pi0                                     SVS; #[Reconstructed PDG2011]
+0.001012198 phi     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.002430000 K+      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.002760541 K+      K-      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001280000 K_S0    K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001260647 K_L0    K_L0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.001380270 anti-K0 K0      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.001397000 pi+     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000800000 pi0     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000640000 eta     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000810000 eta'    pi0                                     PHSP; #[Reconstructed PDG2011]
+0.001670000 eta     eta                                     PHSP; #[Reconstructed PDG2011]
+0.009128189 rho+    pi-                                     SVS; #[Reconstructed PDG2011]
+0.004637709 rho-    pi+                                     SVS; #[Reconstructed PDG2011]
+0.003730000 rho0    pi0                                     SVS; #[Reconstructed PDG2011]
+0.001214638 pi+     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000092018 pi0     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.005620000 pi+     pi+     pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.009360000 pi+     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.001510000 pi+     pi-     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.005521082 pi+     pi-     pi0     pi0     pi0             PHSP; #[Reconstructed PDG2011]
+0.000420000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+#
+# Doubly Cabibbo suppressed decays:
+0.000138027 pi+     K-                                      PHSP; #[Reconstructed PDG2011]
+0.000128825 pi+     K*-                                     PHSP; #[Reconstructed PDG2011]
+0.000276054 pi+     K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000248449 K-      pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+# PR LHCb - 19 Apr. 2004 Add anti-D0 -> mu+ mu-
+0.000000000 mu-     mu+                                     PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.000140000 phi     eta                                     PHSP; #[Reconstructed PDG2011]
+0.019000000 K*0     pi+     pi-     pi0                     PHSP; #[Reconstructed PDG2011]
+0.000220000 K+      pi-     pi-     pi+     pi-     pi+     PHSP; #[Reconstructed PDG2011]
+0.000644126 K+      K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.003100000 K+      K-      pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.000221000 K+      K+      K-      pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.005600000 K_S0    eta     pi0                             PHSP; #[Reconstructed PDG2011]
+0.003680721 K_L0    eta     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      eta     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.002600000 K_S0    K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.002392469 K_L0    K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+#
+0.003500000 K_S0    K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.003358658 K_L0    K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+      pi-                             PHSP; #[Reconstructed PDG2011]
+#
+0.000310000 K_S0    K_S0    K+      pi-                     PHSP; #[Reconstructed PDG2011]
+0.000294458 K_L0    K_L0    K+      pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      K+      pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.000310000 K_S0    K_S0    K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000294458 K_L0    K_L0    K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      K-      pi+                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K+      pi-     pi+     e-      anti-nu_e       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001820000 rho0    rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001090000 eta     pi-     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001600000 omega   pi-     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000450000 eta'    pi-     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001260000 eta     eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000027000 phi     gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000328000 K*0     gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+# Updated to PDG 2008
+Decay D_s+
+0.024900000 phi     e+      nu_e                            PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.026700000 eta     e+      nu_e                            PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.009900000 eta'    e+      nu_e                            PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002058115 anti-K0 e+      nu_e                            PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.000762265 anti-K*0 e+      nu_e                           PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.018309605 phi     mu+     nu_mu                           PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.022845082 eta     mu+     nu_mu                           PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.008186726 eta'    mu+     nu_mu                           PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002058115 anti-K0 mu+     nu_mu                           PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.000762265 anti-K*0 mu+     nu_mu                          PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.005800000 mu+     nu_mu                                   PHOTOS  SLN; #[Reconstructed PDG2011]
+0.031100000 tau+    nu_tau                                  SLN; #[Reconstructed PDG2011]
+### Lange Nov14, 2004 - average cleo + babar (prelim) using stat error only..
+0.045000000 phi     pi+                                     SVS; #[Reconstructed PDG2011]
+0.015600000 eta     pi+                                     PHSP; #[Reconstructed PDG2011]
+0.038000000 eta'    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.002300000 omega   pi+                                     SVS; #[Reconstructed PDG2011]
+0.000304906 rho+    pi0                                     SVS; #[Reconstructed PDG2011]
+0.000076226 pi+     pi0                                     PHSP; #[Reconstructed PDG2011]
+#?
+0.000196200 rho0    pi+                                     SVS;  # PDG 2014 
+0.007852048 f_0     pi+                                     PHSP; # PDG 2014
+0.001753646 f_2     pi+                                     PHSP; # PDG 2014
+0.004754077 f'_0    pi+                                     PHSP; # PDG 2014
+0.005768112 f_0(1500) pi+                                   PHSP; # PDG 2014
+#0.000735750 rho(2S)0 pi+                                    PHSP; # PDG 2014
+0.000000000 pi+     pi-     pi+                             PHSP; # PDG 2014 (filled by exclusives)
+0.084000000 phi     rho+                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.089000000 rho+    eta                                     SVS; #[Reconstructed PDG2011]
+0.124213286 rho+    eta'                                    SVS; # Decrease compared to PDG 2014 to preserve unitarity after 
+#                                                                # fixing Ds --> 3pi, we also have too much of inclusive eta', 
+#                                                                #so pick this decay
+0.006500000 pi+     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.007622650 phi     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011433975 eta     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011433975 eta'    pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.012100000 phi     pi+     pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.003811325 phi     pi+     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003811325 eta     pi+     pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.003811325 eta     pi+     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.014900000 K_S0    K+                                      PHSP; #[Reconstructed PDG2011]
+0.011472088 K_L0    K+                                      PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+                                      PHSP; #[Reconstructed PDG2011]
+#
+0.030490600 anti-K*0 K+                                     SVS; #[Reconstructed PDG2011]
+0.054000000 K*+     anti-K0                                 SVS; #[Reconstructed PDG2011]
+0.072000000 anti-K*0 K*+                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.002286795 anti-K0 K+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000914718 anti-K*0 K+      pi0                            PHSP; #[Reconstructed PDG2011]
+0.000914718 K*+     anti-K0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.003049060 anti-K*0 K*+     pi0                            PHSP; #[Reconstructed PDG2011]
+0.003811325 K+      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+#
+0.009600000 K_S0    K+      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.007470197 K_L0    K+      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K+      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.000762265 anti-K0 K+      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K+      K-      pi+     pi-     pi+             PHSP; #[Reconstructed PDG2011]
+0.000152453 phi     K+                                      SVS; #[Reconstructed PDG2011]
+0.001390000 eta     K+                                      PHSP; #[Reconstructed PDG2011]
+0.001600000 eta'    K+                                      PHSP; #[Reconstructed PDG2011]
+0.000152453 eta     K+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000152453 eta     K+      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000152453 eta'    K+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000152453 eta'    K+      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000490000 K+      K-      K+                              PHSP; #[Reconstructed PDG2011]
+#
+0.001200000 K_S0    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.000968077 K_L0    pi+                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi+                                     PHSP; #[Reconstructed PDG2011]
+#
+0.001143397 rho+    K0                                      SVS; #[Reconstructed PDG2011]
+0.002700000 rho0    K+                                      SVS; #[Reconstructed PDG2011]
+0.010000000 K0      pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.001905662 a_1+    K0                                      SVS; #[Reconstructed PDG2011]
+0.006021893 K*0     pi+                                     SVS; #[Reconstructed PDG2011]
+0.003811325 K*0     rho+                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.003811325 K*0     pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.000820000 K+      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.004200000 K+      pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.008000000 pi+     pi+     pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+0.049000000 pi+     pi+     pi+     pi-     pi-     pi0     PHSP; #[Reconstructed PDG2011]
+0.001300000 p+      anti-n0                                 PHSP; #[Reconstructed PDG2011]
+#
+0.000840000 K_S0    K_S0    pi+     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.000686038 K_L0    K_L0    pi+     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi+     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+#
+0.002900000 K_S0    pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.002424003 K_L0    pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi+     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+# Doubly Cabibbo suppressed
+0.000129000 K+      K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.003700000 K0      e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001800000 K*0     e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 K+      K-      pi+     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.028000000 omega   pi+     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.016000000 omega   pi+     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+# Updated to PDG 2008
+Decay D_s-
+0.024900000 phi     e-      anti-nu_e                       PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.026700000 eta     e-      anti-nu_e                       PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.009900000 eta'    e-      anti-nu_e                       PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002058115 K0      e-      anti-nu_e                       PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.000762265 K*0     e-      anti-nu_e                       PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.018309605 phi     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.022845082 eta     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.008186726 eta'    mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.002058115 K0      mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.000762265 K*0     mu-     anti-nu_mu                      PHOTOS  ISGW2; #[Reconstructed PDG2011]
+0.005800000 mu-     anti-nu_mu                              PHOTOS    SLN; #[Reconstructed PDG2011]
+0.031100000 tau-    anti-nu_tau                             SLN; #[Reconstructed PDG2011]
+0.045000000 phi     pi-                                     SVS; #[Reconstructed PDG2011]
+0.015600000 eta     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.038000000 eta'    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.002300000 omega   pi-                                     SVS; #[Reconstructed PDG2011]
+0.000304906 rho-    pi0                                     SVS; #[Reconstructed PDG2011]
+0.000076226 pi-     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000196200 rho0    pi-                                     SVS;  # PDG 2014 
+0.007852048 f_0     pi-                                     PHSP; # PDG 2014
+0.001753646 f_2     pi-                                     PHSP; # PDG 2014
+0.004754077 f'_0    pi-                                     PHSP; # PDG 2014
+0.005768112 f_0(1500) pi-                                   PHSP; # PDG 2014
+#0.000735750 rho(2S)0 pi-                                    PHSP; # PDG 2014
+0.000000000 pi-     pi+     pi-                             PHSP; # PDG 2014 (filled by exclusives)
+0.084000000 phi     rho-                                    SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.089000000 rho-    eta                                     SVS; #[Reconstructed PDG2011]
+0.124213286 rho-    eta'                                    SVS; # Decrease compared to PDG 2014 to preserve unitarity after 
+0.006500000 pi-     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.007622650 phi     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011433975 eta     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.011433975 eta'    pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.012100000 phi     pi-     pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.003811325 phi     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003811325 eta     pi-     pi-     pi+                     PHSP; #[Reconstructed PDG2011]
+0.003811325 eta     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+#
+0.014900000 K_S0    K-                                      PHSP; #[Reconstructed PDG2011]
+0.011472088 K_L0    K-                                      PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-                                      PHSP; #[Reconstructed PDG2011]
+#
+0.030490600 K*0     K-                                      SVS; #[Reconstructed PDG2011]
+0.054000000 K*-     K0                                      SVS; #[Reconstructed PDG2011]
+0.072000000 K*0     K*-                                     SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.002286795 K0      K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000914718 K*0     K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000914718 K*-     K0      pi0                             PHSP; #[Reconstructed PDG2011]
+0.003049060 K*0     K*-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.003811325 K+      K-      pi-                             PHSP; #[Reconstructed PDG2011]
+#
+0.009600000 K_S0    K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.007470197 K_L0    K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+#
+0.000762265 K0      K-      pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K-      K+      pi-     pi+     pi-             PHSP; #[Reconstructed PDG2011]
+0.000152453 phi     K-                                      SVS; #[Reconstructed PDG2011]
+0.001390000 eta     K-                                      PHSP; #[Reconstructed PDG2011]
+0.001600000 eta'    K-                                      PHSP; #[Reconstructed PDG2011]
+0.000152453 eta     K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000152453 eta     K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000152453 eta'    K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000152453 eta'    K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000490000 K-      K-      K+                              PHSP; #[Reconstructed PDG2011]
+#
+0.001200000 K_S0    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000968077 K_L0    pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 pi-                                     PHSP; #[Reconstructed PDG2011]
+#
+0.001143397 rho-    anti-K0                                 SVS; #[Reconstructed PDG2011]
+0.002700000 rho0    K-                                      SVS; #[Reconstructed PDG2011]
+0.010000000 anti-K0 pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.001905662 a_1-    anti-K0                                 SVS; #[Reconstructed PDG2011]
+0.006021893 anti-K*0 pi-                                    SVS; #[Reconstructed PDG2011]
+0.003811325 anti-K*0 rho-                                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.003811325 anti-K*0 pi-     pi0                            PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.000820000 K-      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.004200000 K-      pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.008000000 pi+     pi+     pi-     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+0.049000000 pi+     pi+     pi-     pi-     pi-     pi0     PHSP; #[Reconstructed PDG2011]
+0.001300000 anti-p- n0                                      PHSP; #[Reconstructed PDG2011]
+#
+0.000840000 K_S0    K_S0    pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+0.000686038 K_L0    K_L0    pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-K0 K0      pi+     pi-     pi-             PHSP; #[Reconstructed PDG2011]
+#
+0.002900000 K_S0    pi+     pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.002424003 K_L0    pi+     pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000000000 K0      pi+     pi-     pi-                     PHSP; #[Reconstructed PDG2011]
+# Doubly Cabibbo suppressed
+0.000129000 K-      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.003700000 anti-K0 e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001800000 anti-K*0 e-      anti-nu_e                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 K-      K+      pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.028000000 omega   pi-     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.016000000 omega   pi-     pi-     pi+                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+#   D**
+#
+Decay D_0*+
+0.3333   D+  pi0                         PHSP;
+0.6667   D0  pi+                         PHSP;
+Enddecay
+Decay D_0*-
+0.3333   D-  pi0                         PHSP;
+0.6667   anti-D0 pi-                         PHSP;
+Enddecay
+Decay D_0*0
+0.3333   D0  pi0                         PHSP;
+0.6667   D+  pi-                         PHSP;
+Enddecay
+Decay anti-D_0*0
+0.3333   anti-D0 pi0                         PHSP;
+0.6667   D-  pi+                         PHSP;
+Enddecay
+#
+
+SetLineshapePW D_1+ D*+ pi0 2
+SetLineshapePW D_1+ D*0 pi+ 2
+SetLineshapePW D_1- D*- pi0 2
+SetLineshapePW D_1- anti-D*0 pi- 2
+SetLineshapePW D_10 D*0 pi0 2
+SetLineshapePW D_10 D*+ pi- 2
+SetLineshapePW anti-D_10 anti-D*0 pi0 2
+SetLineshapePW anti-D_10 D*- pi+ 2
+
+Decay D_1+
+0.3333    D*+ pi0                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.6667    D*0 pi+                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay D_1-
+0.3333    D*- pi0                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.6667    anti-D*0 pi-                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay D_10
+0.3333    D*0 pi0                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.6667    D*+ pi-                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay anti-D_10
+0.3333    anti-D*0 pi0                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.6667    D*- pi+                        VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+#
+Decay D'_1+
+0.3333    D*+ pi0                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.6667    D*0 pi+                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay D'_1-
+0.3333    D*- pi0                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.6667    anti-D*0 pi-                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay D'_10
+0.6667    D*+ pi-                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.3333    D*0 pi0                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay anti-D'_10
+0.3333    anti-D*0 pi0                   VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.6667    D*- pi+                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+
+SetLineshapePW D_2*+ D*+ pi0 2
+SetLineshapePW D_2*+ D*0 pi+ 2
+SetLineshapePW D_2*- D*- pi0 2
+SetLineshapePW D_2*- anti-D*0 pi- 2
+SetLineshapePW D_2*0 D*0 pi0 2
+SetLineshapePW D_2*0 D*+ pi- 2
+SetLineshapePW anti-D_2*0 anti-D*0 pi0 2
+SetLineshapePW anti-D_2*0 D*- pi+ 2
+
+Decay D_2*+
+0.1030    D*+ pi0                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2090    D*0 pi+                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2290    D+  pi0                        TSS;
+0.4590    D0  pi+                        TSS;
+Enddecay
+Decay D_2*-
+0.1030    D*- pi0                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2090    anti-D*0 pi-                   TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2290    D-  pi0                        TSS;
+0.4590    anti-D0 pi-                    TSS;
+Enddecay
+Decay D_2*0
+0.2090    D*+ pi-                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.1030    D*0 pi0                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2290    D0  pi0                        TSS;
+0.4590    D+  pi-                        TSS;
+Enddecay
+Decay anti-D_2*0
+0.1030    anti-D*0 pi0                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2090    D*- pi+                        TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.2290    anti-D0 pi0                        TSS;
+0.4590    D-  pi+                        TSS;
+Enddecay
+#
+#  D_s **
+#
+Decay D_s0*+
+# 0.5000   D+ K0                            PHSP;
+# 0.5000   D0 K+                           PHSP;
+1.000      D_s+ pi0                        PHSP;
+Enddecay
+Decay D_s0*-
+# 0.5000   D- anti-K0                          PHSP;
+# 0.5000   anti-D0 K-                          PHSP;
+1.000      D_s- pi0                        PHSP;
+Enddecay
+Decay D'_s1+
+0.5000   D*+ K0                            VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.5000   D*0 K+                            VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.0000   gamma D_s*+                       PHSP;
+0.0000   gamma D_s+                        PHSP;
+Enddecay
+Decay D'_s1-
+0.5000   D*- anti-K0                       VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.5000   anti-D*0 K-                       VVS_PWAVE  0.0 0.0 0.0 0.0 1.0 0.0;
+0.0000   gamma D_s*-                       PHSP;
+0.0000   gamma D_s-                        PHSP;
+Enddecay
+Decay D_s1+
+0.80000  D_s*+ pi0                       PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.20000  D_s+ gamma                       VSP_PWAVE;
+Enddecay
+Decay D_s1-
+0.80000  D_s*- pi0                       PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.20000  D_s- gamma                       VSP_PWAVE;
+Enddecay
+Decay D_s2*+
+0.0500    D*+ K0                         TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.0500    D*0 K+                         TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.4300    D+  K0                         TSS;
+0.4700    D0  K+                         TSS;
+Enddecay
+Decay D_s2*-
+0.0500    D*- anti-K0                    TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.0500    anti-D*0 K-                    TVS_PWAVE  0.0 0.0 1.0 0.0 0.0 0.0;
+0.4300    D-  anti-K0                    TSS;
+0.4700    anti-D0 K-                     TSS;
+Enddecay
+#
+#
+#  Charm Mesons: Radially Excited States
+#
+Decay D(2S)0
+0.6667    D*+ pi-                        SVS;
+0.3333    D*0 pi0                        SVS;
+Enddecay
+Decay anti-D(2S)0
+0.3333    anti-D*0 pi0                        SVS;
+0.6667    D*- pi+                        SVS;
+Enddecay
+Decay D(2S)+
+0.3333    D*+ pi0                        SVS;
+0.6667    D*0 pi+                        SVS;
+Enddecay
+Decay D(2S)-
+0.3333    D*- pi0                        SVS;
+0.6667    anti-D*0 pi-                        SVS;
+Enddecay
+Decay D*(2S)0
+0.3333    D*+ pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1667    D*0 pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1667    D0  pi0                        VSS;
+0.3333    D+  pi-                        VSS;
+Enddecay
+Decay anti-D*(2S)0
+0.1667    anti-D*0 pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3333    D*- pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1667    anti-D0  pi0                       VSS;
+0.3333    D-  pi+                        VSS;
+Enddecay
+Decay D*(2S)+
+0.1667    D*+ pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3333    D*0 pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1667    D+  pi0                        VSS;
+0.3333    D0  pi+                        VSS;
+Enddecay
+Decay D*(2S)-
+0.1667    D*- pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3333    anti-D*0 pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1667    D-  pi0                        VSS;
+0.3333    anti-D0  pi-                       VSS;
+Enddecay
+#
+#
+#  Strange Mesons updated to PDG 2008
+#
+#
+Decay K_S0
+0.691086452 pi+     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.305986452 pi0     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000000201 pi+     pi-     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001722185 pi+     pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000042831 pi+     pi-     e+      e-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000025 pi0     gamma   gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000002399 gamma   gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000344328 pi+     e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000344328 pi-     e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000235400 pi+     mu-     anti-nu_mu                      PHSP;  #[New mode added] #TP manually added 9/1/2011 according to pdg
+0.000235400 pi-     mu+     nu_mu                           PHSP;  #[New mode added] #TP manually added 9/1/2011 according to pdg
+Enddecay
+#
+#  K_L0 is decayed in GEANT
+#
+Decay K0
+0.500     K_L0                              PHSP;
+0.500     K_S0                              PHSP;
+Enddecay
+Decay anti-K0
+0.500     K_L0                              PHSP;
+0.500     K_S0                              PHSP;
+Enddecay
+#
+Decay K*0
+0.6657      K+  pi-                        VSS;
+0.3323      K0  pi0                        VSS;
+0.0020      K0  gamma                       VSP_PWAVE;
+Enddecay
+#
+Decay anti-K*0
+0.6657      K-  pi+                        VSS;
+0.3323      anti-K0   pi0                        VSS;
+0.0020      anti-K0   gamma                       VSP_PWAVE;
+Enddecay
+#
+Decay K*+
+0.6657      K0  pi+                        VSS;
+0.3323      K+  pi0                        VSS;
+0.0020      K+  gamma                       VSP_PWAVE;
+Enddecay
+#
+Decay K*-
+0.6657      anti-K0   pi-                        VSS;
+0.3323      K-  pi0                        VSS;
+0.0020      K-  gamma                       VSP_PWAVE;
+Enddecay
+#
+# The decays below are for particle aliases and used when
+# generating CP violating decays that depends on the decay
+# of the neutral K*
+#
+Decay K*L
+1.0000      pi0 K_L0                       VSS;
+Enddecay
+Decay K*S
+1.0000      pi0 K_S0                       VSS;
+Enddecay
+Decay K*BL
+1.0000      pi0 K_L0                       VSS;
+Enddecay
+Decay K*BS
+1.0000      pi0 K_S0                       VSS;
+Enddecay
+Decay K*0T
+1.0000      pi- K+                        VSS;
+Enddecay
+Decay anti-K*0T
+1.0000      pi+ K-                        VSS;
+Enddecay
+#
+#
+Decay K_0*+
+0.6667      K0  pi+                       PHSP;
+0.3333      K+  pi0                       PHSP;
+Enddecay
+#
+Decay K_0*-
+0.6667      anti-K0   pi-                 PHSP;
+0.3333      K-  pi0                       PHSP;
+Enddecay
+#
+Decay K_0*0
+0.6667      K+  pi-                       PHSP;
+0.3333      K0  pi0                       PHSP;
+Enddecay
+#
+Decay K_0*0N
+1.0000      K0  pi0                       PHSP;
+Enddecay
+#
+Decay anti-K_0*0
+0.6667      K-  pi+                       PHSP;
+0.3333      anti-K0   pi0                 PHSP;
+Enddecay
+#
+Decay anti-K_0*0N
+1.0000      anti-K0   pi0                 PHSP;
+Enddecay
+#
+Decay K_10
+0.2800   rho-  K+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1400   rho0  K0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1067   K*+   pi-                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0533   K*0   pi0                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+#To large masses can cause infinit loops
+0.1100   omega  K0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1444   K0    pi+ pi-                   PHSP;
+0.1244   K+    pi- pi0                   PHSP;
+0.0412   K0    pi0 pi0                   PHSP;
+Enddecay
+#
+Decay anti-K_10
+0.2800   rho+  K-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1400   rho0  anti-K0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1067   K*-   pi+                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0533   anti-K*0   pi0                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+#To large masses can cause infinit loops
+0.1100   omega  anti-K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1444   anti-K0    pi+ pi-                   PHSP;
+0.1244   K-    pi+ pi0                   PHSP;
+0.0412   anti-K0    pi0 pi0                   PHSP;
+Enddecay
+#
+Decay K_1+
+0.2800   rho+  K0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1400   rho0  K+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1067   K*0   pi+                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0533   K*+   pi0                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+#To large masses can cause infinit loops
+0.1100   omega  K+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1444   K+    pi+ pi-                   PHSP;
+0.1244   K0    pi+ pi0                   PHSP;
+0.0412   K+    pi0 pi0                   PHSP;
+Enddecay
+#
+Decay K_1-
+0.2800   rho-  anti-K0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1400   rho0  K-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1067   anti-K*0   pi-                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0533   K*-   pi0                       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+#To large masses can cause infinit loops
+0.1100   omega  K-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1444   K-    pi+ pi-                   PHSP;
+0.1244   anti-K0    pi- pi0                   PHSP;
+0.0412   K-    pi0 pi0                   PHSP;
+Enddecay
+#
+Decay K'_1+
+0.6300   K*0  pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3100   K*+  pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0200   rho+ K0                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   rho0 K+                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   omega K+                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0133   K+  pi+  pi-                    PHSP;
+0.0067   K+  pi0  pi0                    PHSP;
+Enddecay
+#
+Decay K'_1-
+0.6300   anti-K*0  pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3100   K*-  pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0200   rho- anti-K0                          VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   rho0 K-                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   omega K-                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0133   K-  pi+  pi-                    PHSP;
+0.0067   K-  pi0  pi0                    PHSP;
+Enddecay
+#
+Decay K'_10
+0.6300   K*+  pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3100   K*0  pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0200   rho- K+                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   rho0 K0                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   omega K0                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0133   K0  pi+  pi-                    PHSP;
+0.0067   K0  pi0  pi0                    PHSP;
+Enddecay
+#
+Decay anti-K'_10
+0.6300   K*- pi+                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.3100   anti-K*0 pi0                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0200   rho+ K-                         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   rho0 anti-K0                          VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0100   omega anti-K0                          VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0133   anti-K0   pi+  pi-                    PHSP;
+0.0067   anti-K0   pi0  pi0                    PHSP;
+Enddecay
+#
+Decay K_2*+
+0.3340   K0  pi+                         TSS;
+0.1670   K+  pi0                         TSS;
+0.1645   K*0 pi+                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0835   K*+ pi0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0450   K*0 pi+ pi0                     PHSP;
+0.0450   K*+ pi+ pi-                     PHSP;
+0.0450   K*+ pi0 pi0                     PHSP;
+0.0580   rho+ K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   rho0 K+                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   omega K+                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K_2*-
+0.3340   anti-K0   pi-                         TSS;
+0.1670   K-  pi0                         TSS;
+0.1645   anti-K*0 pi-                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0835   K*- pi0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0450   anti-K*0 pi- pi0                     PHSP;
+0.0450   K*- pi+ pi-                     PHSP;
+0.0450   K*- pi0 pi0                     PHSP;
+0.0580   rho- K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   rho0 K-                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   omega K-                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K_2*0
+0.3340   K+  pi-                         TSS;
+0.1670   K0  pi0                         TSS;
+0.1645   K*+ pi-                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0835   K*0 pi0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0450   K*0 pi+ pi-                     PHSP;
+0.0450   K*0 pi0 pi0                     PHSP;
+0.0450   K*+ pi- pi0                     PHSP;
+0.0580   rho- K+                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   rho0 K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   omega K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay anti-K_2*0
+0.3340   K-  pi+                         TSS;
+0.1670   anti-K0   pi0                         TSS;
+0.1645   K*- pi+                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0835   anti-K*0 pi0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0450   anti-K*0 pi+ pi-                     PHSP;
+0.0450   anti-K*0 pi0 pi0                     PHSP;
+0.0450   K*- pi+ pi0                     PHSP;
+0.0580   rho+ K-                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   rho0 anti-K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0290   omega anti-K0                         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+
+
+
+
+# Decay K*(1410)
+Decay K'*0
+0.0467   K+  pi-                     VSS;
+0.0233   K0  pi0                     VSS;
+0.5760   K*+ pi-                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.2880   K*0 pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0440   rho- K+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0220   rho0 K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay anti-K'*0
+0.0467   K-  pi+                     VSS;
+0.0233   anti-K0   pi0               VSS;
+0.5760   K*- pi+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.2880   anti-K*0 pi0                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0440   rho+ K-                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0220   rho0 anti-K0                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K'*+
+0.0467   K0  pi+                     VSS;
+0.0233  K+  pi0                      VSS;
+0.5760   K*0 pi+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.2880   K*+ pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0440   rho+ K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0220   rho0 K+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K'*-
+0.0467   anti-K0   pi-               VSS;
+0.0233   K-  pi0                     VSS;
+0.5760   anti-K*0 pi-                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.2880   K*- pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0440   rho- K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0220  rho0 K-                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+
+
+# Decay K*(1680)
+Decay K''*0
+0.2580   K+  pi-                     VSS;
+0.1290   K0  pi0                     VSS;
+0.2093   K*+ pi-                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1047   K*0 pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1993   rho- K+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0997   rho0 K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay anti-K''*0
+0.2580   K-  pi+                     VSS;
+0.1290   anti-K0   pi0               VSS;
+0.2093   K*- pi+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1047   anti-K*0 pi0                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1993   rho+ K-                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0997   rho0 anti-K0                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K''*+
+0.2580   K0  pi+                     VSS;
+0.1290   K+  pi0                     VSS;
+0.2093   K*0 pi+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1047   K*+ pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1993   rho+ K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0997   rho0 K+                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay K''*-
+0.2580   anti-K0   pi-               VSS;
+0.1290   K-  pi0                     VSS;
+0.2093   anti-K*0 pi-                VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1047   K*- pi0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.1993   rho- K0                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0997   rho0 K-                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+
+Decay Xsd
+1.00000 d anti-s PYTHIA 42;
+Enddecay
+
+Decay anti-Xsd
+1.00000 anti-d s PYTHIA 42;
+Enddecay
+
+Decay Xsu
+1.00000 u anti-s PYTHIA 42;
+Enddecay
+
+Decay anti-Xsu
+1.00000 anti-u s PYTHIA 42;
+Enddecay
+
+# Xss decays can be uncommented when Jst74/lucomp.F recognizes Xss
+Decay Xss
+1.00000 s anti-s PYTHIA 42;
+Enddecay
+
+Decay anti-Xss
+1.00000 anti-s s PYTHIA 42;
+Enddecay
+
+#
+#  Light Mesons Updated to PDG 2008
+#
+Decay pi0
+0.988228297 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
+0.011738247 e+      e-      gamma                           PI0_DALITZ; #[Reconstructed PDG2011]
+0.000033392 e+      e+      e-      e-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000065 e+      e-                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay eta
+0.393100000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
+0.325700000 pi0     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.227400000 pi-     pi+     pi0                             ETA_DALITZ; #[Reconstructed PDG2011]
+0.046000000 gamma   pi-     pi+                             PHSP; #[Reconstructed PDG2011]
+0.007000000 gamma   e+      e-                              PHSP; #[Reconstructed PDG2011]
+0.000310000 gamma   mu+     mu-                             PHSP; #[Reconstructed PDG2011]
+0.000270000 gamma   gamma   pi0                             PHSP; #[Reconstructed PDG2011]
+0.000214200 pi+     pi-     e+      e-                      PHSP; #[Reconstructed PDG2011]
+0.000005800 mu+     mu-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay rho0
+1.000    pi+ pi-                         VSS;
+Enddecay
+Decay rho+
+1.000    pi+ pi0                         VSS;
+Enddecay
+Decay rho-
+1.000    pi- pi0                         VSS;
+Enddecay
+#
+Decay omega
+0.892000000 pi-     pi+     pi0                             OMEGA_DALITZ; #[Reconstructed PDG2011]
+0.082800000 pi0     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.015300000 pi-     pi+                                     VSS; #[Reconstructed PDG2011]
+0.000460000 eta     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.000770000 pi0     e+      e-                              PHOTOS PHSP; #[Reconstructed PDG2011]
+0.000130000 pi0     mu+     mu-                             PHOTOS PHSP; #[Reconstructed PDG2011]
+0.00150    pi+  pi- gamma                  PHSP;
+0.000066000 pi0     pi0     gamma                           PHSP; #[Reconstructed PDG2011]
+0.00050    pi+ pi- pi+ pi-                PHSP;
+0.000072800 e+      e-                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000090000 mu+     mu-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay eta'
+0.432000000 pi+     pi-     eta                             PHSP; #[Reconstructed PDG2011]
+0.217000000 pi0     pi0     eta                             PHSP; #[Reconstructed PDG2011]
+0.293511000 rho0    gamma                                   SVP_HELAMP  1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.027500000 omega   gamma                                   SVP_HELAMP  1.0 0.0 1.0 0.0; #[Reconstructed PDG2011]
+0.022200000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
+0.001680000 pi0     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.000109000 gamma   mu-     mu+                             PHOTOS   PHSP; #[Reconstructed PDG2011]
+0.003600000 pi+     pi-     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.002400000 pi+     pi-     e+      e-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay phi
+0.489000000 K+      K-                                      VSS; #[Reconstructed PDG2011]
+0.342000000 K_L0    K_S0                                    VSS; #[Reconstructed PDG2011]
+0.0425   rho+ pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0425   rho0 pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0425   rho- pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0250   pi+  pi- pi0                    PHSP;
+0.013090000 eta     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.000687600 pi0     gamma                                   VSP_PWAVE; #[Reconstructed PDG2011]
+0.000295400 e+      e-                                      PHOTOS      VLL; #[Reconstructed PDG2011]
+0.000287000 mu+     mu-                                     PHOTOS      VLL; #[Reconstructed PDG2011]
+0.000113000 pi0     pi0     gamma                           PHSP; #[Reconstructed PDG2011]
+0.000115000 eta     e+      e-                              PHSP; #[Reconstructed PDG2011]
+0.000322000 f_0     gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000074000 pi+     pi-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000047000 omega   pi0                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000041000 pi+     pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000004000 pi+     pi-     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000011200 pi0     e+      e-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000072700 pi0     eta     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000062500 eta'    gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000014000 mu+     mu-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay a_1+
+0.4920   rho0 pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.5080   rho+ pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay a_10
+0.5000   rho- pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.5000   rho+ pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay a_1-
+0.4920   rho0 pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.5080   rho- pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay a_2+
+0.3500   rho0 pi+                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.3500   rho+ pi0                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.1430   eta  pi+                        TSS;
+0.1000   omega pi+ pi0                    PHSP;
+0.0490   anti-K0   K+                         TSS;
+0.0027   pi+  gamma                       PHSP;
+0.0053   eta' pi+                        TSS;
+Enddecay
+#
+Decay a_2-
+0.3500   rho0 pi-                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.3500   rho- pi0                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.1430   eta  pi-                        TSS;
+0.1000   omega pi- pi0                    PHSP;
+0.0490   anti-K0   K-                         TSS;
+0.0027   pi-  gamma                       PHSP;
+0.0053   eta' pi-                        TSS;
+Enddecay
+#
+Decay a_20
+0.3500   rho+ pi-                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.3500   rho- pi+                        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.1430   eta  pi0                        TSS;
+0.1000   omega pi+ pi-                    PHSP;
+0.0245   K+   K-                         TSS;
+0.01225   K_L0  K_L0                        TSS;
+0.01225   K_S0  K_S0                        TSS;
+0.0027   pi0  gamma                       PHSP;
+0.0053   eta' pi0                        TSS;
+Enddecay
+#
+Decay b_1+
+0.9984   omega pi+                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0016   pi+  gamma                       VSP_PWAVE;
+Enddecay
+Decay b_1-
+0.9984   omega pi-                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0016   pi-  gamma                       VSP_PWAVE;
+Enddecay
+Decay b_10
+0.9984   omega pi0                        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+0.0016   pi0  gamma                       VSP_PWAVE;
+Enddecay
+#
+Decay a_00
+0.9000    eta  pi0                       PHSP;
+0.0500    K+   K-                        PHSP;
+0.0250    K_S0  K_S0                       PHSP;
+0.0250    K_L0  K_L0                       PHSP;
+Enddecay
+Decay a_0+
+0.9000    eta  pi+                       PHSP;
+0.1000    anti-K0    K+                        PHSP;
+Enddecay
+Decay a_0-
+0.9000    eta  pi-                       PHSP;
+0.1000    K0   K-                        PHSP;
+Enddecay
+#
+Decay f_0
+0.6667   pi+  pi-                        PHSP;
+0.3333   pi0  pi0                        PHSP;
+#0.1100   K+   K-                         PHSP;
+#0.0550   K_S0  K_S0                        PHSP;
+#0.0550   K_L0  K_L0                        PHSP;
+Enddecay
+#
+#
+# MK: Based on PDG 2014 without any attempt to really include everything. One
+# thing, which is missing is KK mode, but data are scattered quite lot and
+# I would also need to find place where to make space for it. For needs I
+# have at this moment, this should be sufficient
+#Decay f_0(1370)
+#0.17333 pi+ pi-           PHSP;
+#0.08667 pi0 pi0           PHSP;
+#0.26000 pi+ pi+ pi- pi-   PHSP;
+#0.32000 pi+ pi- pi0 pi0   PHSP;
+#0.10667 rho+ rho-         PHSP;
+#0.05333 rho0 rho0         PHSP;
+#Enddecay
+Decay f'_0
+0.5200   pi+  pi-                        PHSP;
+0.2600   pi0  pi0                        PHSP;
+0.0750   pi+ pi+ pi- pi-                 PHSP;
+0.0750   pi+ pi- pi0 pi0                 PHSP;
+0.0350   K+   K-                         PHSP;
+0.0175   K_S0  K_S0                        PHSP;
+0.0175   K_L0  K_L0                        PHSP;
+Enddecay
+#
+Decay f_1
+0.110000000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.043364159 rho0    pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.043442860 rho+    pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.043442860 rho-    pi+     pi0                             PHSP; #[Reconstructed PDG2011]
+0.094440999 a_00    pi0                                     VSS; #[Reconstructed PDG2011]
+0.094440999 a_0+    pi-                                     VSS; #[Reconstructed PDG2011]
+0.094440999 a_0-    pi+                                     VSS; #[Reconstructed PDG2011]
+0.086570916 eta     pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.043285458 eta     pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.020226114 K+      K-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.010152407 K0      anti-K0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.020226114 anti-K0 K+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.020226114 K0      K-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.055000000 gamma   rho0                                    PHSP; #[Reconstructed PDG2011]
+0.220000000 pi0     pi0     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 pi+     pi+     pi-     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000740000 phi     gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay f'_1
+0.2500   K+   K-   pi0                   PHSP;
+0.2500   K0   anti-K0   pi0                   PHSP;
+0.2500   anti-K0   K+   pi-                   PHSP;
+0.2500   K0   K-   pi+                   PHSP;
+Enddecay
+#
+Decay f_2
+0.5650   pi+  pi-                        TSS;
+0.2820   pi0  pi0                        TSS;
+0.028000000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.071000000 pi+     pi-     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.003000000 pi0     pi0     pi0     pi0                     PHSP; #[Reconstructed PDG2011]
+0.0230   K+   K-                         TSS;
+0.0115   K_S0  K_S0                        TSS;
+0.0115   K_L0  K_L0                        TSS;
+0.004000000 eta     eta                                     TSS; #[Reconstructed PDG2011]
+0.000016400 gamma   gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay f_0(1500)
+0.019000000 eta     eta'                                    PHSP; #[Reconstructed PDG2011]
+0.051000000 eta     eta                                     PHSP; #[Reconstructed PDG2011]
+0.1410   pi0  pi0  pi0  pi0              PHSP;
+0.3540   pi+  pi-  pi+  pi-              PHSP;
+0.2330   pi+  pi-                        PHSP;
+0.1160   pi0  pi0                        PHSP;
+0.0430   K+   K-                         PHSP;
+0.0215   K_S0  K_S0                      PHSP;
+0.0215   K_L0  K_L0                      PHSP;
+Enddecay
+#
+Decay f'_2
+0.443904021 K+      K-                                      TSS; #[Reconstructed PDG2011]
+0.221952010 K_S0    K_S0                                    TSS; #[Reconstructed PDG2011]
+0.221952010 K_L0    K_L0                                    TSS; #[Reconstructed PDG2011]
+0.104000000 eta     eta                                     TSS; #[Reconstructed PDG2011]
+0.005493862 pi+     pi-                                     TSS; #[Reconstructed PDG2011]
+0.002696987 pi0     pi0                                     TSS; #[Reconstructed PDG2011]
+0.000001110 gamma   gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay h_1
+0.3333   rho+ pi-                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.3333   rho- pi+                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.3334   rho0 pi0                        VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay h'_1
+0.2500   K*+  K-                         VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.2500   K*-  K+                         VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.2500   anti-K*0  K0                         VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+0.2500   K*0  anti-K0                         VVS_PWAVE  1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#
+Decay rho(2S)+
+0.4000   pi+ pi0                         PHSP;
+0.4000   pi+ pi+ pi- pi0                 PHSP;
+0.2000   pi+ pi0 pi0 pi0                 PHSP;
+Enddecay
+Decay rho(2S)-
+0.4000   pi- pi0                         PHSP;
+0.4000   pi- pi+ pi- pi0                 PHSP;
+0.2000   pi- pi0 pi0 pi0                 PHSP;
+Enddecay
+Decay rho(2S)0
+0.4000   pi+ pi-                         PHSP;
+0.3500   pi+ pi- pi+ pi-                 PHSP;
+0.1500   pi+ pi- pi0 pi0                 PHSP;
+0.1000   pi0 pi0 pi0 pi0                 PHSP;
+Enddecay
+Decay phi(1680)
+0.08   pi+ pi-                                      PHSP;
+0.05   pi+ pi+ pi-  pi-                             PHSP;
+0.10   pi0 pi+ pi-                                  PHSP;
+0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+0.12   pi0 pi0 pi+ pi-                              PHSP;
+0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+0.04   K+ K- pi+ pi-                                PHSP;
+0.02   K0 K- pi+                                    PHSP;
+0.02   anti-K0 K+ pi-                               PHSP;
+0.02   K0 K- pi+ pi+ pi-                            PHSP;
+0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+0.02   K0 K- pi0 pi+                                PHSP;
+0.02   anti-K0 K+ pi0 pi-                           PHSP;
+0.02   eta pi0 pi+ pi-                              PHSP;
+0.01   eta rho- pi0 pi+                             PHSP;
+0.01   eta rho+ pi0 pi-                             PHSP;
+Enddecay
+Decay rho(3S)0
+0.08   pi+ pi-                                      PHSP;
+0.05   pi+ pi+ pi-  pi-                             PHSP;
+0.10   pi0 pi+ pi-                                  PHSP;
+0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+0.12   pi0 pi0 pi+ pi-                              PHSP;
+0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+0.04   K+ K- pi+ pi-                                PHSP;
+0.02   K0 K- pi+                                    PHSP;
+0.02   anti-K0 K+ pi-                               PHSP;
+0.02   K0 K- pi+ pi+ pi-                            PHSP;
+0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+0.02   K0 K- pi0 pi+                                PHSP;
+0.02   anti-K0 K+ pi0 pi-                           PHSP;
+0.02   eta pi0 pi+ pi-                              PHSP;
+0.01   eta rho- pi0 pi+                             PHSP;
+0.01   eta rho+ pi0 pi-                             PHSP;
+Enddecay
+Decay omega(1650)
+0.08   pi+ pi-                                      PHSP;
+0.05   pi+ pi+ pi-  pi-                             PHSP;
+0.10   pi0 pi+ pi-                                  PHSP;
+0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+0.12   pi0 pi0 pi+ pi-                              PHSP;
+0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+0.04   K+ K- pi+ pi-                                PHSP;
+0.02   K0 K- pi+                                    PHSP;
+0.02   anti-K0 K+ pi-                               PHSP;
+0.02   K0 K- pi+ pi+ pi-                            PHSP;
+0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+0.02   K0 K- pi0 pi+                                PHSP;
+0.02   anti-K0 K+ pi0 pi-                           PHSP;
+0.02   eta pi0 pi+ pi-                              PHSP;
+0.01   eta rho- pi0 pi+                             PHSP;
+0.01   eta rho+ pi0 pi-                             PHSP;
+Enddecay
+#Decay rho(1900)
+#0.08   pi+ pi-                                      PHSP;
+#0.05   pi+ pi+ pi-  pi-                             PHSP;
+#0.10   pi0 pi+ pi-                                  PHSP;
+#0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+#0.12   pi0 pi0 pi+ pi-                              PHSP;
+#0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+#0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+#0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+#0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+#0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+#0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+#0.04   K+ K- pi+ pi-                                PHSP;
+#0.02   K0 K- pi+                                    PHSP;
+#0.02   anti-K0 K+ pi-                               PHSP;
+#0.02   K0 K- pi+ pi+ pi-                            PHSP;
+#0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+#0.02   K0 K- pi0 pi+                                PHSP;
+#0.02   anti-K0 K+ pi0 pi-                           PHSP;
+#0.02   eta pi0 pi+ pi-                              PHSP;
+#0.01   eta rho- pi0 pi+                             PHSP;
+#0.01   eta rho+ pi0 pi-                             PHSP;
+#Enddecay
+Decay omega(2S)
+0.08   pi+ pi-                                      PHSP;
+0.05   pi+ pi+ pi-  pi-                             PHSP;
+0.10   pi0 pi+ pi-                                  PHSP;
+0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+0.12   pi0 pi0 pi+ pi-                              PHSP;
+0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+0.04   K+ K- pi+ pi-                                PHSP;
+0.02   K0 K- pi+                                    PHSP;
+0.02   anti-K0 K+ pi-                               PHSP;
+0.02   K0 K- pi+ pi+ pi-                            PHSP;
+0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+0.02   K0 K- pi0 pi+                                PHSP;
+0.02   anti-K0 K+ pi0 pi-                           PHSP;
+0.02   eta pi0 pi+ pi-                              PHSP;
+0.01   eta rho- pi0 pi+                             PHSP;
+0.01   eta rho+ pi0 pi-                             PHSP;
+Enddecay
+#Decay rho(2150)
+#0.08   pi+ pi-                                      PHSP;
+#0.05   pi+ pi+ pi-  pi-                             PHSP;
+#0.10   pi0 pi+ pi-                                  PHSP;
+#0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+#0.12   pi0 pi0 pi+ pi-                              PHSP;
+#0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+#0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+#0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+#0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+#0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+#0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+#0.04   K+ K- pi+ pi-                                PHSP;
+#0.02   K0 K- pi+                                    PHSP;
+#0.02   anti-K0 K+ pi-                               PHSP;
+#0.02   K0 K- pi+ pi+ pi-                            PHSP;
+#0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+#0.02   K0 K- pi0 pi+                                PHSP;
+#0.02   anti-K0 K+ pi0 pi-                           PHSP;
+#0.02   eta pi0 pi+ pi-                              PHSP;
+#0.01   eta rho- pi0 pi+                             PHSP;
+#0.01   eta rho+ pi0 pi-                             PHSP;
+#Enddecay
+#Decay omega(1960)
+#0.08   pi+ pi-                                      PHSP;
+#0.05   pi+ pi+ pi-  pi-                             PHSP;
+#0.10   pi0 pi+ pi-                                  PHSP;
+#0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+#0.12   pi0 pi0 pi+ pi-                              PHSP;
+#0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+#0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+#0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+#0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+#0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+#0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+#0.04   K+ K- pi+ pi-                                PHSP;
+#0.02   K0 K- pi+                                    PHSP;
+#0.02   anti-K0 K+ pi-                               PHSP;
+#0.02   K0 K- pi+ pi+ pi-                            PHSP;
+#0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+#0.02   K0 K- pi0 pi+                                PHSP;
+#0.02   anti-K0 K+ pi0 pi-                           PHSP;
+#0.02   eta pi0 pi+ pi-                              PHSP;
+#0.01   eta rho- pi0 pi+                             PHSP;
+#0.01   eta rho+ pi0 pi-                             PHSP;
+#Enddecay
+#Decay rho(1965)
+#0.08   pi+ pi-                                      PHSP;
+#0.05   pi+ pi+ pi-  pi-                             PHSP;
+#0.10   pi0 pi+ pi-                                  PHSP;
+#0.10   pi0 pi+ pi+ pi- pi-                          PHSP;
+#0.12   pi0 pi0 pi+ pi-                              PHSP;
+#0.04   pi0 pi+ pi+ pi+ pi- pi- pi-                  PHSP;
+#0.14   pi0 pi0 pi+ pi+ pi- pi-                      PHSP;
+#0.05   pi0 pi0 pi0 pi+ pi-                          PHSP;
+#0.06   pi0 pi0 pi0 pi+ pi+ pi- pi-                  PHSP;
+#0.03   pi0 pi0 pi0 pi+ pi+ pi+ pi- pi- pi-          PHSP;
+#0.03   pi0 pi0 pi0 pi0 pi+ pi+ pi- pi-              PHSP;
+#0.04   K+ K- pi+ pi-                                PHSP;
+#0.02   K0 K- pi+                                    PHSP;
+#0.02   anti-K0 K+ pi-                               PHSP;
+#0.02   K0 K- pi+ pi+ pi-                            PHSP;
+#0.02   anti-K0 K+ pi- pi- pi+                       PHSP;
+#0.02   K0 K- pi0 pi+                                PHSP;
+#0.02   anti-K0 K+ pi0 pi-                           PHSP;
+#0.02   eta pi0 pi+ pi-                              PHSP;
+#0.01   eta rho- pi0 pi+                             PHSP;
+#0.01   eta rho+ pi0 pi-                             PHSP;
+#Enddecay
+#
+#
+#    cc=  mesons Updated to PDG 2008
+#
+Decay eta_c
+0.001300000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
+0.002700000 phi     phi                                     SVV_HELAMP 1.0 0.0 0.0 0.0 -1.0 0.0; #[Reconstructed PDG2011]
+0.002900000 phi     K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.0067    rho0 rho0                      SVV_HELAMP 1.0 0.0 0.0 0.0 -1.0 0.0;
+0.0133    rho+ rho-                      SVV_HELAMP 1.0 0.0 0.0 0.0 -1.0 0.0;
+0.012000000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001600000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.015000000 K+      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.0327    eta  pi+ pi-                   PHSP;
+0.0163    eta  pi0 pi0                   PHSP;
+0.0273    eta' pi+ pi-                   PHSP;
+0.0137    eta' pi0 pi0                   PHSP;
+0.0117    pi0  K+  K-                    PHSP;
+0.0233    K+ anti-K0  pi-                      PHSP;
+0.0233    K- K0 pi+                      PHSP;
+0.0117    K0 anti-K0 pi0                 PHSP;
+0.0046    K*+ K*-                        SVV_HELAMP 1.0 0.0 0.0 0.0 -1.0 0.0;
+0.0046    K*0 anti-K*0                   SVV_HELAMP 1.0 0.0 0.0 0.0 -1.0 0.0 ;
+0.01    K*0 K- pi+                     PHSP;
+0.01    anti-K*0 K+ pi-                     PHSP;
+#
+#March 2009 New Modes
+0.01500   K*0 anti-K*0 pi+ pi-   PHSP;
+0.007100000 K+      K-      pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.015000000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.001040000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.007600000 f_2     f_2                                     PHSP; #[Reconstructed PDG2011]
+0.027000000 f_2     f'_2                                    PHSP; #[Reconstructed PDG2011]
+#
+0.682497000 rndmflav anti-rndmflav PYTHIA 42;
+0.000063000 gamma   gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay eta_c(2S)
+ 0.019     K+ anti-K0  pi-                PHSP;
+ 0.019     K- K0 pi+                      PHSP;
+ 0.0095    pi0  K+  K-                    PHSP;
+ 0.0095    K0 anti-K0 pi0                 PHSP;
+0.943 rndmflav anti-rndmflav PYTHIA 42;
+Enddecay
+#
+Decay J/psi
+0.3 e+      e-                                      PHOTOS   VLL; #[Reconstructed PDG2011]
+0.7 mu+     mu-                                     PHOTOS   VLL; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay psi(2S)
+0.007720000 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.007700000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.003000000 tau+    tau-                                    PHOTOS  VLL; #[Reconstructed PDG2011]
+0.336000000 J/psi   pi+     pi-                             VVPIPI; #[Reconstructed PDG2011]
+0.177300000 J/psi   pi0     pi0                             VVPIPI; #[Reconstructed PDG2011]
+0.032800000 J/psi   eta                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.001300000 J/psi   pi0                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.096200000 gamma   chi_c0                                  PHSP; #[Reconstructed PDG2011]
+0.092000000 gamma   chi_c1                                  PHSP; #[Reconstructed PDG2011]
+0.087400000 gamma   chi_c2                                  PHSP; #[Reconstructed PDG2011]
+0.003400000 gamma   eta_c                                   PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000121000 gamma   eta'                                    PHSP; #[Reconstructed PDG2011]
+0.000210000 gamma   f_2                                     PHSP; #[Reconstructed PDG2011]
+0.003500000 pi+     pi-     pi+     pi-     pi+     pi-     pi0     PHSP; #[Reconstructed PDG2011]
+0.000350000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.002900000 pi+     pi-     pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+0.000200000 b_1+    pi-                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000200000 b_1-    pi+                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000240000 b_10    pi0                                     PARTWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000168000 pi+     pi-     pi0                             PHSP; #[Reconstructed PDG2011]
+0.0000545  K*0 anti-K0                    PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0000545  anti-K*0 K0                    PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000022  rho0 eta                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000021000 omega   pi0                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000028000 phi     eta                                     PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000008  rho+ pi-                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000008  rho- pi+                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000008  rho0 pi0                       PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000001  phi pi0                        PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000001  omega eta                      PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0000085 K*+ K-                         PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.0000085 K*- K+                         PARTWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+0.000185000 omega   K+      K-                              PHSP; #[Reconstructed PDG2011]
+0.000340000 K+      K-      pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000600000 p+      anti-p- pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000133000 p+      anti-p- pi0                             PHSP; #[Reconstructed PDG2011]
+0.000276000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
+0.000500000 K_1+    K-                                      PHSP; #[Reconstructed PDG2011]
+0.000500000 K_1-    K+                                      PHSP; #[Reconstructed PDG2011]
+0.000220000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.000280000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.000128000 Delta++ anti-Delta--                            PHSP; #[Reconstructed PDG2011]
+0.000220000 Sigma0  anti-Sigma0                             PHSP; #[Reconstructed PDG2011]
+0.00026   Sigma*+  anti-Sigma*-          PHSP;
+0.000180000 Xi-     anti-Xi+                                PHSP; #[Reconstructed PDG2011]
+0.000080000 pi+     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000063000 K+      K-                                      PHSP; #[Reconstructed PDG2011]
+0.000070000 phi     K-      K+                              PHSP; #[Reconstructed PDG2011]
+0.000117000 phi     pi-     pi+                             PHSP; #[Reconstructed PDG2011]
+0.000170000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
+0.0008 h_c pi0 PHSP;
+0.0       K0   anti-K0       PHSP;
+0.0       K_S0      K_S0     PHSP;
+0.0       K_L0      K_L0     PHSP;
+0.000054000 K_S0    K_L0                                    PHSP; #[Reconstructed PDG2011]
+#
+# March 2009 New Modes
+0.004800000 pi+     pi-     pi+     pi-     pi0     pi0     PHSP; #[Reconstructed PDG2011]
+0.001200000 pi+     pi-     pi+     pi-     eta             PHSP; #[Reconstructed PDG2011]
+0.001300000 K+      K-      pi+     pi-     eta             PHSP; #[Reconstructed PDG2011]
+0.001000000 K+      K-      pi+     pi-     pi+     pi-     pi0     PHSP; #[Reconstructed PDG2011]
+0.001900000 K+      K-      pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.001260000 K+      K-      pi+     pi-     pi0             PHSP; #[Reconstructed PDG2011]
+#
+0.013568632 rndmflav anti-rndmflav PYTHIA 42;
+0.103318590 g g g PYTHIA 92;
+0.007344778 gamma g g PYTHIA 92;
+0.000100000 Lambda0 anti-p- K+                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000180000 Lambda0 anti-p- K+      pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000280000 Lambda0 anti-Lambda0 pi+     pi-                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000260000 Sigma+  anti-Sigma-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000280000 Xi0     anti-Xi0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000060000 eta     p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000069000 omega   p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000320000 p+      anti-n0 pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000950000 eta     pi+     pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000450000 eta'    pi+     pi-     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 omega   pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000220000 omega   f_2                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000220000 rho0    K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000190000 K*0     anti-K_2*0                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000050000 rho0    p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000020000 pi+     pi-     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000730000 p+      anti-p- pi+     pi-     pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000060000 K+      K-      K+      K-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000110000 K+      K-      K+      K-      pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000031000 phi     eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000032000 omega   eta'                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000027000 p+      anti-p- K+      K-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000044000 phi     f'_2                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000870000 gamma   eta     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000400000 gamma   pi+     pi-     pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000190000 gamma   K+      K-      pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000029000 gamma   p+      anti-p-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000028000 gamma   pi+     pi-     p+      anti-p-         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+
+Decay psi(4040)
+0.000010700 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000014000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000005000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.002099938 D0      anti-D0                                 VSS; #[Reconstructed PDG2011]
+0.000899973 D+      D-                                      VSS; #[Reconstructed PDG2011]
+0.167895013 D*0     anti-D0                                 VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.167895013 anti-D*0 D0                                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.181494610 D*+     D-                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.181494610 D*-     D+                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.159695257 D*0     anti-D*0                                PHSP; #[Reconstructed PDG2011]
+0.098197084 D*+     D*-                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      anti-D0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      D-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-D0 D+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     anti-D0 pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D0      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      anti-D*0 pi-                            PHSP; #[Reconstructed PDG2011]
+0.000000000 D-      D*0     pi+                             PHSP; #[Reconstructed PDG2011]
+0.040298803 D_s+    D_s-                                    VSS; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay psi(4160)
+0.000008100 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000009999 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000006000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.039697852 D0      anti-D0                                 VSS; #[Reconstructed PDG2011]
+0.038697906 D+      D-                                      VSS; #[Reconstructed PDG2011]
+0.051997187 D*0     anti-D0                                 VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.051997187 anti-D*0 D0                                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.051497214 D*+     D-                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.051497214 D*-     D+                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.298613845 D*0     anti-D*0                                PHSP; #[Reconstructed PDG2011]
+0.308183327 D*+     D*-                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      anti-D0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      D-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-D0 D+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     anti-D0 pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D0      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      anti-D*0 pi-                            PHSP; #[Reconstructed PDG2011]
+0.000000000 D-      D*0     pi+                             PHSP; #[Reconstructed PDG2011]
+0.009999459 D_s+    D_s-                                    VSS; #[Reconstructed PDG2011]
+0.048897355 D_s*+   D_s-                                    VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.048897355 D_s*-   D_s+                                    VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.000000000 D_s+    D_s-    pi0                             PHSP; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay psi(4415)
+0.000009400 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000011000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.000007000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.024399331 D0      anti-D0                                 VSS; #[Reconstructed PDG2011]
+0.021899400 D+      D-                                      VSS; #[Reconstructed PDG2011]
+0.031999123 D*0     anti-D0                                 VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.031999123 anti-D*0 D0                                     VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.034299060 D*+     D-                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.034299060 D*-     D+                                      VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.345090544 D*0     anti-D*0                                PHSP; #[Reconstructed PDG2011]
+0.353890303 D*+     D*-                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      anti-D0 pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      D-      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-D0 D+      pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     D-      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D+      pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*+     anti-D0 pi-                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D*-     D0      pi+                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D+      anti-D*0 pi-                            PHSP; #[Reconstructed PDG2011]
+0.000000000 D-      D*0     pi+                             PHSP; #[Reconstructed PDG2011]
+0.011799677 D_s+    D_s-                                    VSS; #[Reconstructed PDG2011]
+0.041998849 D_s*+   D_s-                                    VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.041998849 D_s*-   D_s+                                    VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.026299279 D_s*+   D_s*-                                   PHSP; #[Reconstructed PDG2011]
+0.000000000 D_s+    D_s-    pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D_s*+   D_s-    pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D_s+    D_s*-   pi0                             PHSP; #[Reconstructed PDG2011]
+0.000000000 D_s+    D-      anti-K0                         PHSP; #[Reconstructed PDG2011]
+0.000000000 D_s-    D+      anti-K0                         PHSP; #[Reconstructed PDG2011]
+0.000000000 D0      D_s-    K+                              PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-D0 D_s+    K-                              PHSP; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_c0
+0.011600000 gamma   J/psi                                   PHSP; #[Reconstructed PDG2011]
+0.000228000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
+0.000222000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
+0.00243    pi0 pi0                        PHSP;
+0.00487    pi+ pi-                        PHSP;
+0.013800000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.002810000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.012000000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.008900000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.0100    rho+ pi- pi0                   PHSP;
+0.0100    rho- pi+ pi0                   PHSP;
+0.00057    K+   K-                        PHSP;
+0.000920000 phi     phi                                     PHSP; #[Reconstructed PDG2011]
+0.001700000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
+0.0036    anti-K*0  K+  pi-              PHSP;
+0.0036    K*0  K-  pi+                   PHSP;
+0.0043    K*+  anti-K0   pi-             PHSP;
+0.0043    K*-  K0  pi+                   PHSP;
+0.018000000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.002100000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
+0.002680000 eta     eta                                     PHSP; #[Reconstructed PDG2011]
+0.000330000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.00086    f_0 f_0                        PHSP;
+0.0       K0   anti-K0       PHSP;
+0.003160000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
+0.00282    K_L0      K_L0     PHSP;
+0.0       K_S0      K_L0     PHSP;
+#
+# March 2009 New Modes
+0.002030000 eta'    eta'                                    PHSP; #[Reconstructed PDG2011]
+0.002200000 omega   omega                                   PHSP; #[Reconstructed PDG2011]
+0.00325   K_1+ K-   PHSP;
+0.00325   K_1- K+   PHSP;
+0.000990000 K+      K-      phi                             PHSP; #[Reconstructed PDG2011]
+0.001140000 p+      anti-n0 pi-                             PHSP; #[Reconstructed PDG2011]
+0.000525   K+ anti-p- Lambda0   PHSP;
+0.000525   K- p+ Lambda0   PHSP;
+0.005800000 K_S0    K_S0    pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.00590   K_L0 K_L0 pi+ pi-   PHSP;
+0.00000   K0 anti-K0 pi+ pi-   PHSP;
+0.001400000 K+      K-      K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
+0.00150   K+ K- K_L0 K_L0   PHSP;
+0.00000   K+ K- K0 anti-K0   PHSP;
+#
+0.799360000 rndmflav anti-rndmflav PYTHIA 42;
+0.034000000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.005700000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.003100000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000570000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000370000 p+      anti-p- eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001050000 pi0     pi0     p+      anti-p-                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000420000 Sigma0  anti-Sigma0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000310000 Sigma+  anti-Sigma-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000320000 Xi0     anti-Xi0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000490000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_c1
+0.344000000 J/psi   gamma                                   VVP 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; #[Reconstructed PDG2011]
+0.007600000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.000073000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
+0.005800000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.004500000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.003900000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.0020    rho+ pi- pi0                   PHSP;
+0.0020    rho- pi+ pi0                   PHSP;
+0.0016    anti-K*0  K+  pi-              PHSP;
+0.0016    K*0  K-  pi+                   PHSP;
+0.001500000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
+0.0009    K*+  anti-K0   pi-             PHSP;
+0.0009    K*-  K0  pi+                   PHSP;
+0.000500000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
+0.000720000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
+0.0003    K+ K- K_S0 K_S0                PHSP;
+0.000118000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.00385    K+ anti-K0  pi-                PHSP;
+0.00385    K- K0 pi+                      PHSP;
+0.000560000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.00000    K0   anti-K0                   PHSP;
+0.00001    K_S0      K_S0                 PHSP;
+0.00001    K_L0      K_L0                 PHSP;
+0.00000    K_S0      K_L0                 PHSP;
+#
+# March 2009 New Modes
+0.002200000 pi+     pi-     eta                             PHSP; #[Reconstructed PDG2011]
+0.002400000 pi+     pi-     eta'                            PHSP; #[Reconstructed PDG2011]
+0.001910000 K+      K-      pi0                             PHSP; #[Reconstructed PDG2011]
+#
+0.587724 rndmflav anti-rndmflav PYTHIA 42;
+0.008700000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001180000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001200000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000330000 K+      K-      eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.002800000 f_2     eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000430000 K+      K-      phi                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000120000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000320000 K+      anti-p- Lambda0                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000084000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000229000 gamma   rho0                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000078000 gamma   omega                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+
+
+#
+Decay chi_c2
+0.195000000 gamma   J/psi                                   PHSP; #[Reconstructed PDG2011]
+0.000256000 gamma   gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000072000 p+      anti-p-                                 PHSP; #[Reconstructed PDG2011]
+0.00072   pi0 pi0                       TSS;
+0.00145    pi+ pi-                       TSS;
+0.011100000 pi+     pi-     pi+     pi-                     PHSP; #[Reconstructed PDG2011]
+0.001780000 K+      K-      K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.008600000 pi+     pi-     pi+     pi-     pi+     pi-     PHSP; #[Reconstructed PDG2011]
+0.009200000 pi+     pi-     K+      K-                      PHSP; #[Reconstructed PDG2011]
+0.004000000 rho0    pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.0046   rho+ pi- pi0                   PHSP;
+0.0046   rho- pi+ pi0                   PHSP;
+0.001090000 K+      K-                                      TSS; #[Reconstructed PDG2011]
+0.002400000 pi+     pi-     K_S0    K_S0                    PHSP; #[Reconstructed PDG2011]
+0.0003    K+  K- K_S0 K_S0               PHSP;
+0.001480000 phi     phi                                     PHSP; #[Reconstructed PDG2011]
+0.00115    anti-K*0  K+  pi-              PHSP;
+0.00115    K*0  K-  pi+                   PHSP;
+0.002500000 anti-K*0 K*0                                    PHSP; #[Reconstructed PDG2011]
+0.0016    K*+  anti-K0   pi-             PHSP;
+0.0016    K*-  K0  pi+                   PHSP;
+0.001320000 pi+     pi-     p+      anti-p-                 PHSP; #[Reconstructed PDG2011]
+0.000186000 Lambda0 anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.00000   K0   anti-K0       PHSP;
+0.000580000 K_S0    K_S0                                    PHSP; #[Reconstructed PDG2011]
+0.00065   K_L0      K_L0                  PHSP;
+0.00000   K_S0      K_L0     PHSP;
+#
+# March 2009 New Modes
+0.001900000 omega   omega                                   PHSP; #[Reconstructed PDG2011]
+0.0007   anti-K0 K+ pi-   PHSP;
+0.0007   K0 K- pi+   PHSP;
+0.001550000 K+      K-      phi                             PHSP; #[Reconstructed PDG2011]
+0.001100000 p+      anti-n0 pi-                             PHSP; #[Reconstructed PDG2011]
+#
+0.709461000 rndmflav anti-rndmflav PYTHIA 42;
+0.020000000 pi+     pi-     pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.002200000 K+      K-      pi0     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001400000 K+      K-      eta     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000520000 pi+     pi-     eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000540000 pi+     pi-     eta'                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000540000 eta     eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000330000 K+      K-      pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000470000 p+      anti-p- pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000200000 p+      anti-p- eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000850000 pi0     pi0     p+      anti-p-                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000155000 Xi-     anti-Xi+                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay psi(3770)
+0.410000000 D+      D-                                      VSS; #[Reconstructed PDG2011]
+0.520000000 D0      anti-D0                                 VSS; #[Reconstructed PDG2011]
+0.001930000 J/psi   pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.000800000 J/psi   pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.0073    gamma  chi_c0                  PHSP;
+0.0029    gamma  chi_c1                  PHSP;
+0.055850300 rndmflav anti-rndmflav PYTHIA 42;
+0.000900000 J/psi   eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000009700 e+      e-                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000310000 phi     eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay X_1(3872)
+1.000 rndmflav anti-rndmflav PYTHIA 42;
+Enddecay
+#
+#
+#    bb=  Mesons Updated to PDG 2008
+#
+Decay  eta_b
+1.000 rndmflav anti-rndmflav PYTHIA 42;
+Enddecay
+#
+Decay  Upsilon
+0.024800000 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.024800000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.026000000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.014959973 d anti-d PYTHIA 91;
+0.044879919 u anti-u PYTHIA 91;
+0.014959973 s anti-s PYTHIA 91;
+0.044879919 c anti-c PYTHIA 91;
+0.774328202 g g g PYTHIA 92;
+0.028922614 gamma g g PYTHIA 92;
+0.000063000 gamma   pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000017000 gamma   pi0     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000011400 gamma   K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000290000 gamma   pi+     pi-     K+      K-              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000250000 gamma   pi+     pi+     pi-     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000250000 gamma   pi+     pi+     pi+     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000240000 gamma   pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000150000 gamma   pi+     pi-     p+      anti-p-         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000040000 gamma   pi+     pi+     pi-     pi-     p+      anti-p- PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000020000 gamma   K+      K+      K-      K-              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000037000 gamma   f'_2                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000101000 gamma   f_2                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay  Upsilon(2S)
+0.019100000 e+      e-                                      PHOTOS  VLL; #[Reconstructed PDG2011]
+0.019300000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.020000000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.181000000 Upsilon pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.086000000 Upsilon pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+# V-> gamma S    Partial wave (L,S)=(0,1)
+0.038000000 gamma   chi_b0                                  HELAMP 1. 0. +1. 0.; #[Reconstructed PDG2011]
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.069000000 gamma   chi_b1                                  HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.071500000 gamma   chi_b2                                  HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                 1. 0. 1.7320508 0. 2.4494897 0.; #[Reconstructed PDG2011]
+0.00500 d anti-d PYTHIA 91;
+0.02000 u anti-u PYTHIA 91;
+0.00500 s anti-s PYTHIA 91;
+0.02000 c anti-c PYTHIA 91;
+0.42160 g g g PYTHIA 92;
+0.01600 gamma g g PYTHIA 92;
+0.000210000 Upsilon eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000390000 gamma   eta_b                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay  Upsilon(3S)
+0.0181    e+    e-              PHOTOS  VLL;
+0.021800000 mu+     mu-                                     PHOTOS  VLL; #[Reconstructed PDG2011]
+0.022900000 tau+    tau-                                    VLL; #[Reconstructed PDG2011]
+0.044000000 Upsilon pi+     pi-                             PHSP; #[Reconstructed PDG2011]
+0.022000000 Upsilon pi0     pi0                             PHSP; #[Reconstructed PDG2011]
+0.024500000 Upsilon(2S) pi+     pi-                         PHSP; #[Reconstructed PDG2011]
+0.018500000 Upsilon(2S) pi0     pi0                         PHSP; #[Reconstructed PDG2011]
+0.050000000 Upsilon(2S) gamma   gamma                       PHSP; #[Reconstructed PDG2011]
+# V-> gamma S    Partial wave (L,S)=(0,1)
+0.059000000 gamma   chi_b0(2P)                              HELAMP 1. 0. 1. 0.; #[Reconstructed PDG2011]
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.126000000 gamma   chi_b1(2P)                              HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.131000000 gamma   chi_b2(2P)                              HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                   1. 0. 1.7320508 0. 2.4494897 0.; #[Reconstructed PDG2011]
+0.00700 d anti-d PYTHIA 91;
+0.02800 u anti-u PYTHIA 91;
+0.00700 s anti-s PYTHIA 91;
+0.02800 c anti-c PYTHIA 91;
+0.37780 g g g PYTHIA 92;
+0.01000 gamma g g PYTHIA 92;
+0.003000000 gamma   chi_b0                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000510000 gamma   eta_b                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+
+Decay Upsilon(5S)
+0.5 B+ B- PHSP;
+0.481487200 g g g PYTHIA 92;
+0.000002800 e+      e-                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.005300000 Upsilon pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.007800000 Upsilon(2S) pi+     pi-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004800000 Upsilon(3S) pi+     pi-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000610000 Upsilon K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+
+Decay chi_b0
+# S-> gamma V    Partial wave (L,S)=(0,0)
+0.0500    gamma  Upsilon       HELAMP 1. 0. 1. 0.;
+0.949650000 rndmflav anti-rndmflav PYTHIA 42;
+0.000110000 pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000240000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_b1
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.350000000 gamma   Upsilon                                 HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+0.643080000 g g PYTHIA 91;
+0.000200000 pi+     pi-     K+      K-      pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000800000 pi+     pi+     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000150000 pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000350000 pi+     pi+     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000860000 pi+     pi+     pi-     pi-     K+      K-      pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000190000 pi+     pi+     pi+     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001700000 pi+     pi+     pi+     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000260000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000750000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000260000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001400000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_b2
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.220000000 gamma   Upsilon                                 PHSP; #[Reconstructed PDG2011]
+#0.2200    gamma  Upsilon       HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                      2.4494897 0. 1.7320508 0. 1. 0.;
+0.775550000 g g PYTHIA 91;
+0.000080000 pi+     pi-     K+      K-      pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000350000 pi+     pi+     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000110000 pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000210000 pi+     pi+     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000390000 pi+     pi+     pi-     pi-     K+      K-      pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000070000 pi+     pi+     pi+     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001000000 pi+     pi+     pi+     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000360000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000080000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001800000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_b0(2P)
+# S-> gamma V    Partial wave (L,S)=(0,0)
+0.009000000 gamma   Upsilon                                 HELAMP 1. 0. 1. 0.; #[Reconstructed PDG2011]
+0.046000000 gamma   Upsilon(2S)                             HELAMP 1. 0. 1. 0.; #[Reconstructed PDG2011]
+# S-> gamma V    Partial wave (L,S)=(0,0)
+0.00150   gamma  Upsilon_1(1D)       HELAMP 1. 0. 1. 0.;
+0.94350 g g PYTHIA 91;
+Enddecay
+#
+Decay chi_b1(2P)
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.085000000 gamma   Upsilon                                 HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+0.210000000 gamma   Upsilon(2S)                             HELAMP 1. 0. 1. 0. -1. 0. -1. 0.; #[Reconstructed PDG2011]
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.0097    gamma  Upsilon_1(1D) HELAMP 1. 0. 1. 0. -1. 0. -1. 0.;
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.0236    gamma  Upsilon_2(1D)   HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                        1. 0. 1.7320508 0. 2.4494897 0.;
+0.648650000 g g PYTHIA 91;
+0.016300000 omega   Upsilon                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000310000 pi+     pi-     K+      K-      pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000590000 pi+     pi+     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000100000 pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000550000 pi+     pi+     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001000000 pi+     pi+     pi-     pi-     K+      K-      pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000120000 pi+     pi+     pi+     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001200000 pi+     pi+     pi+     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000200000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000610000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000170000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001900000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay chi_b2(2P)
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.071000000 gamma   Upsilon                                 PHSP; #[Reconstructed PDG2011]
+#0.0710    gamma  Upsilon            HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                           2.4494897 0. 1.7320508 0. 1. 0.;
+0.162000000 gamma   Upsilon(2S)                             PHSP; #[Reconstructed PDG2011]
+#0.1620    gamma  Upsilon(2S)        HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                           2.4494897 0. 1.7320508 0. 1. 0.;
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.00023   gamma  Upsilon_1(1D)      PHSP;
+#0.00023   gamma  Upsilon_1(1D)      HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                           2.4494897 0. 1.7320508 0. 1. 0.;
+# T -> gamma T   Partial wave (L,S)=(0,2)
+0.00290         gamma Upsilon_2(1D)  PHSP;
+#0.00290         gamma Upsilon_2(1D) HELAMP -1. 0. -1.2247449 0.
+#                                           -1.2247449 0. -1. 0.
+#                                            1. 0.  1.2247449 0.
+#                                            1.2247449 0.  1. 0.;
+# spin 3 not yet in HELAMP.
+0.01420 gamma Upsilon_3(1D) PYTHIA 0;
+# T-> gamma 3    Partial wave (L,S)=(0,2)
+#0.01420   gamma  Upsilon_3(1D)    HELAMP 3.8729833 0. 3.1622777 0.
+#                                         2.4494897 0. 1.7320508. 0. 1. 0.
+#                                         1. 0. 1.7320508 0.  2.4494897 0.
+#                                         3.1622777 0. 3.8729833 0.;
+0.734240000 g g PYTHIA 91;
+0.011000000 omega   Upsilon                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000390000 pi+     pi+     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000090000 pi+     pi+     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000240000 pi+     pi+     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000470000 pi+     pi+     pi-     pi-     K+      K-      pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000090000 pi+     pi+     pi+     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001200000 pi+     pi+     pi+     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000140000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000420000 pi+     pi+     pi+     pi-     pi-     pi-     K+      K-      pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000090000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001300000 pi+     pi+     pi+     pi+     pi-     pi-     pi-     pi-     pi0     pi0     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay  h_b
+1.00000 g g PYTHIA 91;
+Enddecay
+
+Decay   chi_b0(3P)
+#see Kwong and Rosner, PRD 38,279 (1988)
+# S-> gamma V    Partial wave (L,S)=(0,0)
+0.01700         gamma Upsilon(3S)    HELAMP 1. 0. 1. 0.;
+# S-> gamma V    Partial wave (L,S)=(0,0)
+0.00400         gamma Upsilon_1(2D)  HELAMP 1. 0. 1. 0.;
+0.97900 g g PYTHIA 91;
+Enddecay
+
+Decay   chi_b1(3P)
+#see Kwong and Rosner, PRD 38,279 (1988)
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.15000         gamma Upsilon(3S)     HELAMP 1. 0. 1. 0. -1. 0. -1. 0.;
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.03100         gamma Upsilon_2(2D)   HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                             1. 0. 1.7320508 0. 2.4494897 0.;
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.01300         gamma Upsilon_1(2D)   HELAMP 1. 0. 1. 0. -1. 0. -1. 0.;
+0.80600 g g PYTHIA 91;
+Enddecay
+
+Decay   chi_b2(3P)
+#see Kwong and Rosner, PRD 38,279 (1988)
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.08700         gamma Upsilon(3S) PHSP;
+0.00000         gamma Upsilon(2S) PHSP;
+0.00000         gamma Upsilon     PHSP;
+#0.08700         gamma Upsilon(3S) HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                         2.4494897 0. 1.7320508 0. 1. 0.;
+#0.00000         gamma Upsilon(2S) HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                         2.4494897 0. 1.7320508 0. 1. 0.;
+#0.00000         gamma Upsilon     HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                         2.4494897 0. 1.7320508 0. 1. 0.;
+# spin 3 not yet in HELAMP
+0.02200         Upsilon_3(2D)   gamma   PHSP;
+# T -> gamma 3   Partial wave (L,S)=(0,2)
+#0.02200         gamma Upsilon_3(2D) HELAMP 3.8729833 0. 3.1622777 0.
+#                                           2.4494897 0. 1.7320508. 0. 1. 0.
+#                                           1. 0. 1.7320508 0.  2.4494897 0.
+#                                           3.1622777 0. 3.8729833 0.;
+# T -> gamma T   Partial wave (L,S)=(0,2)
+0.00400         gamma Upsilon_2(2D) PHSP;
+#0.00400         gamma Upsilon_2(2D) HELAMP -1. 0. -1.2247449 0.
+#                                           -1.2247449 0. -1. 0.
+#                                            1. 0.  1.2247449 0.
+#                                            1.2247449 0.  1. 0.;
+# T-> gamma V    Partial wave (L,S)=(0,2)
+0.00040         gamma Upsilon_1(2D) PHSP;
+#0.00040         gamma Upsilon_1(2D) HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                           2.4494897 0. 1.7320508 0. 1. 0.;
+0.88660 g g PYTHIA 91;
+Enddecay
+
+Decay   Upsilon_1(1D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00140         Upsilon  pi+    pi-     PHSP;
+0.00070         Upsilon  pi0    pi0     PHSP;
+# V-> gamma S    Partial wave (L,S)=(0,1)
+0.60200         gamma    chi_b0         HELAMP 1. 0. +1. 0.;
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.31800         gamma    chi_b1         HELAMP 1. 0. 1. 0. -1. 0. -1. 0.;
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.02600         gamma       chi_b2      HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                               1. 0. 1.7320508 0. 2.4494897 0.;
+0.05190 g g g PYTHIA 92;
+Enddecay
+
+Decay   Upsilon_2(1D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00140         Upsilon  pi+     pi-    PHSP;
+0.00070         Upsilon  pi0     pi0    PHSP;
+# T-> gamma T    Partial wave (L,S)=(0,2)
+0.20300         gamma  chi_b2       PHSP;
+#0.20300         gamma  chi_b2       HELAMP -1. 0. -1.2247449 0.
+#                                           -1.2247449 0. -1. 0.
+#                                            1. 0.  1.2247449 0.
+#                                            1.2247449 0.  1. 0.;
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.78500         gamma chi_b1      PHSP;
+#0.78500         gamma chi_b1      HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                         2.4494897 0. 1.7320508 0. 1. 0.;
+0.00990 g g g PYTHIA 92;
+Enddecay
+
+Decay   Upsilon_3(1D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00200         Upsilon  pi+     pi-    PHSP;
+0.00100         Upsilon  pi0     pi0    PHSP;
+0.95400         chi_b2   gamma          PHSP;
+0.04300 g g g PYTHIA 92;
+Enddecay
+
+Decay   Upsilon_1(2D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00000         Upsilon     pi+    pi-  PHSP;
+0.00000         Upsilon     pi0    pi0  PHSP;
+0.00000         Upsilon(2S) pi+    pi-  PHSP;
+0.00000         Upsilon(2S) pi0    pi0  PHSP;
+# V-> gamma S    Partial wave (L,S)=(0,1)
+0.51000         gamma       chi_b0(2P)  HELAMP 1. 0. +1. 0.;
+# V-> gamma V    Partial wave (L,S)=(0,1)
+0.26000         gamma       chi_b1(2P)  HELAMP 1. 0. 1. 0. -1. 0. -1. 0.;
+# V-> gamma T    Partial wave (L,S)=(0,1)
+0.01400         gamma       chi_b2(2P)  HELAMP 2.4494897 0. 1.7320508 0. 1. 0.                                               1. 0. 1.7320508 0. 2.4494897 0.;
+0.21600 g g g PYTHIA 92;
+Enddecay
+
+Decay   Upsilon_2(2D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00000         Upsilon     pi+    pi-  PHSP;
+0.00000         Upsilon     pi0    pi0  PHSP;
+0.00000         Upsilon(2S) pi+    pi-  PHSP;
+0.00000         Upsilon(2S) pi0    pi0  PHSP;
+# T-> gamma T    Partial wave (L,S)=(0,2)
+0.04000         gamma  chi_b2(2P)  PHSP;
+#0.04000         gamma  chi_b2(2P)   HELAMP -1. 0. -1.2247449 0.
+#                                           -1.2247449 0. -1. 0.
+#                                            1. 0.  1.2247449 0.
+#                                            1.2247449 0.  1. 0.;
+# T-> gamma V    Partial wave (L,S)=(0,2)   Use PHSP.
+0.13000         gamma chi_b1(2P)  PHSP;
+#0.13000         gamma chi_b1(2P)  HELAMP 1. 0. 1.7320508 0. 2.4494897 0.
+#                                         2.4494897 0. 1.7320508 0. 1. 0.;
+0.83000 g g g PYTHIA 92;
+Enddecay
+
+Decay   Upsilon_3(2D)
+#see Kwong and Rosner, PRD 38,279 (1988)
+0.00000         Upsilon     pi+    pi-  PHSP;
+0.00000         Upsilon     pi0    pi0  PHSP;
+0.00000         Upsilon(2S) pi+    pi-  PHSP;
+0.00000         Upsilon(2S) pi0    pi0  PHSP;
+0.72000         chi_b2(2P)  gamma       PHSP;
+0.28000 g g g PYTHIA 92;
+Enddecay
+
+Decay   h_b(2P)
+1.00000 g g PYTHIA 91;
+Enddecay
+Decay   h_b(3P)
+1.00000 g g PYTHIA 91;
+Enddecay
+Decay   eta_b2(1D)
+1.00000 g g PYTHIA 91;
+Enddecay
+Decay   eta_b2(2D)
+1.00000 g g PYTHIA 91;
+Enddecay
+#
+#   Charm Baryons
+#
+Decay Lambda_c+
+0.021000000 e+ nu_e Lambda0 PYTHIA 22;
+0.00500 e+ nu_e Sigma0 PYTHIA 22;
+0.00500 e+ nu_e Sigma*0 PYTHIA 22;
+0.00300 e+ nu_e n0 PYTHIA 22;
+0.00200 e+ nu_e Delta0 PYTHIA 22;
+0.00600 e+ nu_e p+ pi- PYTHIA 22;
+0.00600 e+ nu_e n0 pi0 PYTHIA 22;
+0.020000000 mu+ nu_mu Lambda0 PYTHIA 22;
+0.00500 mu+ nu_mu Sigma0 PYTHIA 22;
+0.00500 mu+ nu_mu Sigma*0 PYTHIA 22;
+0.00300 mu+ nu_mu n0 PYTHIA 22;
+0.00200 mu+ nu_mu Delta0 PYTHIA 22;
+0.00600 mu+ nu_mu p+ pi- PYTHIA 22;
+0.00600 mu+ nu_mu n0 pi0 PYTHIA 22;
+0.008600000 Delta++ K- PYTHIA 0;
+0.02500 Delta++ K*- PYTHIA 0;
+0.023000000 p+ anti-K0 PYTHIA 0;
+0.016000000 p+ anti-K*0 PYTHIA 0;
+0.00500 Delta+ anti-K0 PYTHIA 0;
+0.00500 Delta+ anti-K*0 PYTHIA 0;
+0.010700000 Lambda0 pi+ PYTHIA 0;
+0.00500 Lambda0 rho+ PYTHIA 0;
+0.010500000 Sigma0 pi+ PYTHIA 0;
+0.00400 Sigma0 rho+ PYTHIA 0;
+0.00400 Sigma*0 pi+ PYTHIA 0;
+0.00400 Sigma*0 rho+ PYTHIA 0;
+0.010000000 Sigma+ pi0 PYTHIA 0;
+0.005500000 Sigma+ eta PYTHIA 0;
+0.00200 Sigma+ eta' PYTHIA 0;
+0.00400 Sigma+ rho0 PYTHIA 0;
+0.027000000 Sigma+ omega PYTHIA 0;
+0.00300 Sigma*+ pi0 PYTHIA 0;
+0.008500000 Sigma*+ eta PYTHIA 0;
+0.00300 Sigma*+ rho0 PYTHIA 0;
+0.00300 Sigma*+ omega PYTHIA 0;
+0.003900000 Xi0 K+ PYTHIA 0;
+0.00200 Xi0 K*+ PYTHIA 0;
+0.002600000 Xi*0 K+ PYTHIA 0;
+0.00100 Delta++ pi- PYTHIA 0;
+0.00100 Delta++ rho- PYTHIA 0;
+0.00200 p+ pi0 PYTHIA 0;
+0.00100 p+ eta PYTHIA 0;
+0.00100 p+ eta' PYTHIA 0;
+0.00200 p+ rho0 PYTHIA 0;
+0.00200 p+ omega PYTHIA 0;
+0.000820000 p+ phi PYTHIA 0;
+0.002800000 p+ f_0 PYTHIA 0;
+0.00100 Delta+ pi0 PYTHIA 0;
+0.00100 Delta+ eta PYTHIA 0;
+0.00100 Delta+ eta' PYTHIA 0;
+0.00100 Delta+ rho0 PYTHIA 0;
+0.00100 Delta+ omega PYTHIA 0;
+0.00300 n0 pi+ PYTHIA 0;
+0.00300 n0 rho+ PYTHIA 0;
+0.00300 Delta0 pi+ PYTHIA 0;
+0.00300 Delta0 rho+ PYTHIA 0;
+0.00500 Lambda0 K+ PYTHIA 0;
+0.00500 Lambda0 K*+ PYTHIA 0;
+0.00200 Sigma0 K+ PYTHIA 0;
+0.00200 Sigma0 K*+ PYTHIA 0;
+0.00100 Sigma*0 K+ PYTHIA 0;
+0.00100 Sigma*0 K*+ PYTHIA 0;
+0.00200 Sigma+ K0 PYTHIA 0;
+0.002800000 Sigma+ K*0 PYTHIA 0;
+0.00100 Sigma*+ K0 PYTHIA 0;
+0.00100 Sigma*+ K*0 PYTHIA 0;
+0.064094509 u anti-d d su_0 PYTHIA 43;
+0.028102977 u anti-d d su_1 PYTHIA 43;
+0.017256214 u anti-s d su_0 PYTHIA 43;
+0.017256214 u anti-d d ud_0 PYTHIA 43;
+0.046838295 s uu_1 PYTHIA 43;
+0.069024855 u su_0 PYTHIA 43;
+0.069024855 u su_1 PYTHIA 43;
+0.014791040 d uu_1 PYTHIA 43;
+0.007395520 u ud_0 PYTHIA 43;
+0.007395520 u ud_1 PYTHIA 43;
+0.025400000 p+      K-      pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.033000000 p+      anti-K0 pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.012000000 p+      anti-K0 eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.026000000 p+      anti-K0 pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.023000000 p+      K-      pi+     pi0                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.011000000 p+      K*-     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001100000 p+      K-      pi+     pi+     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.008000000 p+      K-      pi+     pi0     pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000700000 p+      pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001800000 p+      pi+     pi+     pi-     pi-             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 p+      K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.036000000 Lambda0 pi+     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.015000000 Lambda0 pi+     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.011000000 Lambda0 pi+     rho0                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 Lambda0 pi+     pi+     pi-     pi0             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.009500000 Lambda0 pi+     eta                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.012000000 Lambda0 pi+     omega                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004700000 Lambda0 K+      anti-K0                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.036000000 Sigma+  pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.017000000 Sigma-  pi+     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.018000000 Sigma0  pi+     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.008300000 Sigma0  pi+     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 Sigma+  K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.003100000 Sigma+  phi                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.002500000 Xi-     K+      pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000000000 Sigma+  K+      pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+CDecay anti-Lambda_c-
+#
+Decay Xi_c0
+1.000 PYTHIA 42;
+Enddecay
+Decay anti-Xi_c0
+1.000 PYTHIA 42;
+Enddecay
+#
+Decay c-hadron
+0.08000 e+ nu_e s specflav PYTHIA 22;
+0.08000 mu+ nu_mu s specflav PYTHIA 22;
+0.76000 u anti-d s specflav PYTHIA 42;
+0.08000 u anti-s s specflav PYTHIA 42;
+Enddecay
+CDecay anti-c-hadron
+#
+Decay Sigma_c0
+1.0000    Lambda_c+  pi-                     PHSP;
+Enddecay
+Decay anti-Sigma_c0
+1.0000    anti-Lambda_c- pi+                     PHSP;
+Enddecay
+#
+Decay Sigma_c+
+1.0000    Lambda_c+  pi0                     PHSP;
+Enddecay
+Decay anti-Sigma_c-
+1.0000    anti-Lambda_c- pi0                     PHSP;
+Enddecay
+#
+Decay Xi_c+
+0.079535513 PYTHIA 42;
+0.079535513 Sigma*+ anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.025689971 Lambda0 K-      pi+     pi+                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.010339617 Sigma+  K-      pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.064423765 Sigma+  anti-K*0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.023065299 Sigma0  K-      pi+     pi+                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.043744532 Xi0     pi+                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.079535513 Xi-     pi+     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.186113099 Xi0     pi+     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.138391792 Xi0     pi-     pi+     pi+                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.182931679 Xi0     e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.005567486 Omega-  K+      pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.007158196 p+      K-      pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.009544262 p+      anti-K*0                                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.038177046 Sigma+  pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.014316392 Sigma-  pi+     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.011930327 Sigma+  K+      K-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Xi_c-
+0.079535513 PYTHIA 42;
+0.079535513 anti-Sigma*- K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.025689971 anti-Lambda0 K+      pi-     pi-                PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.010339617 anti-Sigma- K+      pi-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.064423765 anti-Sigma- K*0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.023065299 anti-Sigma0 K+      pi-     pi-                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.043744532 anti-Xi0 pi-                                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.079535513 anti-Xi+ pi-     pi-                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.186113099 anti-Xi0 pi-     pi0                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.138391792 anti-Xi0 pi+     pi-     pi-                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.182931679 anti-Xi0 e-      anti-nu_e                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.005567486 anti-Omega+ K-      pi-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.007158196 anti-p- K+      pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.009544262 anti-p- K*0                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.038177046 anti-Sigma- pi-     pi+                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.014316392 anti-Sigma+ pi-     pi-                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.011930327 anti-Sigma- K-      K+                          PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Sigma_c++
+1.0000    Lambda_c+  pi+                     PHSP;
+Enddecay
+Decay anti-Sigma_c--
+1.0000    anti-Lambda_c- pi-                     PHSP;
+Enddecay
+#
+Decay Xi'_c+
+0.1000    Lambda0   K-    pi+   pi+         PHSP;
+0.0800    Sigma0  K-    pi+   pi+         PHSP;
+0.8200    gamma  Xi_c+                    PHSP;
+Enddecay
+Decay anti-Xi'_c-
+0.1000    anti-Lambda0  K+    pi-   pi-        PHSP;
+0.0800    anti-Sigma0  K+    pi-   pi-        PHSP;
+0.8200    gamma   anti-Xi_c-                  PHSP;
+Enddecay
+#
+Decay Xi'_c0
+1.0000    gamma Xi_c0                     PHSP;
+Enddecay
+Decay anti-Xi'_c0
+1.0000    gamma anti-Xi_c0                    PHSP;
+Enddecay
+#
+#   Light Baryons
+#   Lambda0 updated Feb 2009
+Decay Lambda0
+0.638719992 p+      pi-                                     PHSP; #[Reconstructed PDG2011]
+0.357719992 n0      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.001741600 n0      gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000832160 p+      pi-     gamma                           PHSP; #[Reconstructed PDG2011]
+0.000831216 p+      e-      anti-nu_e                       PHOTOS   PHSP; #[Reconstructed PDG2011]
+0.000155040 p+      mu-     anti-nu_mu                      PHOTOS   PHSP; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay anti-Lambda0
+0.638719992 anti-p- pi+                                     PHSP; #[Reconstructed PDG2011]
+0.357719992 anti-n0 pi0                                     PHSP; #[Reconstructed PDG2011]
+0.001741600 anti-n0 gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000832160 anti-p- pi+     gamma                           PHSP; #[Reconstructed PDG2011]
+0.000831216 anti-p- e+      nu_e                            PHOTOS   PHSP; #[Reconstructed PDG2011]
+0.000155040 anti-p- mu+     nu_mu                           PHOTOS    PHSP; #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Lambda(1405)0
+0.3333    Sigma+   pi-    PHSP;
+0.3333    Sigma-   pi+    PHSP;
+0.3333    Sigma0   pi0    PHSP;
+Enddecay
+#
+Decay anti-Lambda(1405)0
+0.3333    anti-Sigma+   pi-   PHSP;
+0.3333    anti-Sigma-   pi+   PHSP;
+0.3333    anti-Sigma0   pi0   PHSP;
+Enddecay
+#
+Decay Lambda(1520)0
+0.23   p+     K-    PHSP;
+0.23   n0   anti-K0    PHSP;
+0.14    Sigma+   pi-    PHSP;
+0.14    Sigma-   pi+    PHSP;
+0.14   Sigma0   pi0    PHSP;
+0.0333  Lambda0  pi0  pi0                       PHSP;
+0.0667  Lambda0  pi+  pi-                       PHSP;
+0.003   Sigma+   pi-  pi0   PHSP;
+0.003   Sigma-   pi+  pi0   PHSP;
+0.001   Sigma0   pi0  pi0   PHSP;
+0.002   Sigma0   pi+  pi-   PHSP;
+0.011   Lambda0  gamma    PHSP;
+Enddecay
+#
+Decay anti-Lambda(1520)0
+0.23 anti-p-     K+    PHSP;
+0.23 anti-n0     K0    PHSP;
+0.14    anti-Sigma-   pi+   PHSP;
+0.14    anti-Sigma+   pi-   PHSP;
+0.14    anti-Sigma0   pi0   PHSP;
+0.0333  anti-Lambda0  pi0  pi0                  PHSP;
+0.0667  anti-Lambda0  pi+  pi-                  PHSP;
+0.003   anti-Sigma+   pi-  pi0   PHSP;
+0.003   anti-Sigma-   pi+  pi0   PHSP;
+0.001   anti-Sigma0   pi0  pi0   PHSP;
+0.002   anti-Sigma0   pi+  pi-   PHSP;
+0.011   anti-Lambda0  gamma   PHSP;
+Enddecay
+#
+Decay Lambda(1600)0
+0.176   p+     K-    PHSP;
+0.176   n0   anti-K0    PHSP;
+0.216    Sigma+   pi-    PHSP;
+0.216    Sigma-   pi+    PHSP;
+0.216    Sigma0   pi0    PHSP;
+Enddecay
+#
+Decay anti-Lambda(1600)0
+0.176   anti-p-     K+   PHSP;
+0.176   anti-n0   K0    PHSP;
+0.216    anti-Sigma+   pi-   PHSP;
+0.216   anti-Sigma-   pi+   PHSP;
+0.216   anti-Sigma0   pi0   PHSP;
+Enddecay
+#
+Decay Lambda(1670)0
+0.10   p+     K-    PHSP;
+0.10   n0   anti-K0    PHSP;
+0.16    Sigma+   pi-    PHSP;
+0.16    Sigma-   pi+    PHSP;
+0.16    Sigma0   pi0    PHSP;
+0.32    Lambda0  eta                            PHSP;
+Enddecay
+#
+Decay anti-Lambda(1670)0
+0.10   anti-p-     K+   PHSP;
+0.10   anti-n0   K0    PHSP;
+0.16    anti-Sigma+   pi-   PHSP;
+0.16    anti-Sigma-   pi+   PHSP;
+0.16    anti-Sigma0   pi0   PHSP;
+0.32    anti-Lambda0   eta                       PHSP;
+Enddecay
+#
+Decay Lambda(1690)0
+0.125   p+     K-    PHSP;
+0.125   n0   anti-K0    PHSP;
+0.10    Sigma+   pi-    PHSP;
+0.10    Sigma-   pi+    PHSP;
+0.10    Sigma0   pi0    PHSP;
+0.0833  Lambda0  pi0  pi0                       PHSP;
+0.1667  Lambda0  pi+  pi-                       PHSP;
+0.067   Sigma+   pi-  pi0   PHSP;
+0.067   Sigma-   pi+  pi0   PHSP;
+0.022   Sigma0   pi0  pi0   PHSP;
+0.044   Sigma0   pi+  pi-   PHSP;
+Enddecay
+#
+Decay anti-Lambda(1690)0
+0.125   anti-p-     K+    PHSP;
+0.125   anti-n0   K0    PHSP;
+0.10    anti-Sigma+   pi-    PHSP;
+0.10    anti-Sigma-   pi+    PHSP;
+0.10    anti-Sigma0   pi0    PHSP;
+0.0833  anti-Lambda0  pi0  pi0                       PHSP;
+0.1667  anti-Lambda0  pi+  pi-                       PHSP;
+0.067   anti-Sigma+   pi-  pi0   PHSP;
+0.067   anti-Sigma-   pi+  pi0   PHSP;
+0.022   anti-Sigma0   pi0  pi0   PHSP;
+0.044   anti-Sigma0   pi+  pi-   PHSP;
+Enddecay
+#
+Decay Lambda(1800)0
+0.165   p+     K-    PHSP;
+0.165   n0   anti-K0    PHSP;
+0.08    Sigma+   pi-    PHSP;
+0.08    Sigma-   pi+    PHSP;
+0.08    Sigma0   pi0    PHSP;
+0.003    Sigma*+   pi-    PHSP;
+0.003    Sigma*-   pi+    PHSP;
+0.004    Sigma*0   pi0    PHSP;
+0.21   p+     K*-    PHSP;
+0.21   n0   anti-K*0    PHSP;
+Enddecay
+#
+Decay anti-Lambda(1800)0
+0.165   anti-p-     K+    PHSP;
+0.165   anti-n0   K0    PHSP;
+0.08    anti-Sigma+   pi-    PHSP;
+0.08    anti-Sigma-   pi+    PHSP;
+0.08    anti-Sigma0   pi0    PHSP;
+0.003    anti-Sigma*+   pi-    PHSP;
+0.003    anti-Sigma*-   pi+    PHSP;
+0.004    anti-Sigma*0   pi0    PHSP;
+0.21   anti-p-     K*+    PHSP;
+0.21   anti-n0   K*0    PHSP;
+Enddecay
+#
+Decay Lambda(1810)0
+0.165   p+     K-    PHSP;
+0.165   n0   anti-K0    PHSP;
+0.08    Sigma+   pi-    PHSP;
+0.08    Sigma-   pi+    PHSP;
+0.08    Sigma0   pi0    PHSP;
+0.003    Sigma*+   pi-    PHSP;
+0.003    Sigma*-   pi+    PHSP;
+0.004    Sigma*0   pi0    PHSP;
+0.21   p+     K*-    PHSP;
+0.21   n0   anti-K*0    PHSP;
+Enddecay
+#
+Decay anti-Lambda(1810)0
+0.165   anti-p-     K+    PHSP;
+0.165   anti-n0   K0    PHSP;
+0.08    anti-Sigma+   pi-    PHSP;
+0.08    anti-Sigma-   pi+    PHSP;
+0.08    anti-Sigma0   pi0    PHSP;
+0.003    anti-Sigma*+   pi-    PHSP;
+0.003    anti-Sigma*-   pi+    PHSP;
+0.004    anti-Sigma*0   pi0    PHSP;
+0.21   anti-p-     K*+    PHSP;
+0.21   anti-n0   K*0    PHSP;
+Enddecay
+#
+Decay Lambda(1820)0
+0.34     p+     K-                             PHSP;
+0.34     n0   anti-K0                          PHSP;
+0.06    Sigma+   pi-                            PHSP;
+0.06    Sigma-   pi+                            PHSP;
+0.06    Sigma0   pi0                            PHSP;
+0.04    Sigma*+   pi-                            PHSP;
+0.04    Sigma*-   pi+                            PHSP;
+0.04    Sigma*0   pi0                            PHSP;
+0.01    Lambda0  eta                            PHSP;
+0.003   Sigma+   pi-  pi0                       PHSP;
+0.004   Sigma-   pi+  pi0                       PHSP;
+0.001   Sigma0   pi0  pi0                       PHSP;
+0.002   Sigma0   pi+  pi-                       PHSP;
+Enddecay
+#
+Decay anti-Lambda(1820)0
+0.34     anti-p-     K+                             PHSP;
+0.34     anti-n0   K0                          PHSP;
+0.06    anti-Sigma+   pi-                            PHSP;
+0.06    anti-Sigma-   pi+                            PHSP;
+0.06    anti-Sigma0   pi0                            PHSP;
+0.04    anti-Sigma*+   pi-                            PHSP;
+0.04    anti-Sigma*-   pi+                            PHSP;
+0.04    anti-Sigma*0   pi0                            PHSP;
+0.01    anti-Lambda0  eta                            PHSP;
+0.003  anti-Sigma+   pi-  pi0                       PHSP;
+0.004  anti-Sigma-   pi+  pi0                       PHSP;
+0.001  anti-Sigma0   pi0  pi0                       PHSP;
+0.002  anti-Sigma0   pi+  pi-                       PHSP;
+Enddecay
+#
+Decay Lambda(1830)0
+0.05     p+     K-                             PHSP;
+0.05     n0   anti-K0                          PHSP;
+0.24    Sigma+   pi-                            PHSP;
+0.24    Sigma-   pi+                            PHSP;
+0.24    Sigma0   pi0                            PHSP;
+0.06    Sigma*+   pi-                            PHSP;
+0.06    Sigma*-   pi+                            PHSP;
+0.06    Sigma*0   pi0                            PHSP;
+Enddecay
+#
+Decay anti-Lambda(1830)0
+0.05     anti-p-     K+                             PHSP;
+0.05     anti-n0   K0                          PHSP;
+0.24    anti-Sigma+   pi-                            PHSP;
+0.24    anti-Sigma-   pi+                            PHSP;
+0.24    anti-Sigma0   pi0                            PHSP;
+0.06    anti-Sigma*+   pi-                            PHSP;
+0.06    anti-Sigma*-   pi+                            PHSP;
+0.06    anti-Sigma*0   pi0                            PHSP;
+Enddecay
+#
+#
+Decay Sigma(1660)0
+0.07     p+     K-                             PHSP;
+0.07     n0   anti-K0                          PHSP;
+0.16   Lambda0 pi0                             PHSP;
+0.35    Sigma+   pi-                            PHSP;
+0.35    Sigma-   pi+         PHSP;
+Enddecay
+#
+Decay anti-Sigma(1660)0
+0.07     anti-p-     K+                             PHSP;
+0.07     anti-n0   K0                          PHSP;
+0.16   anti-Lambda0 pi0                             PHSP;
+0.35    anti-Sigma+   pi-                            PHSP;
+0.35    anti-Sigma-   pi+      PHSP;
+Enddecay
+#
+Decay Sigma(1670)0
+0.07     p+     K-                             PHSP;
+0.07     n0   anti-K0                          PHSP;
+0.16   Lambda0 pi0                             PHSP;
+0.35    Sigma+   pi-                            PHSP;
+0.35    Sigma-   pi+         PHSP;
+Enddecay
+#
+Decay anti-Sigma(1670)0
+0.07     anti-p-     K+                             PHSP;
+0.07     anti-n0   K0                          PHSP;
+0.16   anti-Lambda0 pi0                             PHSP;
+0.35    anti-Sigma+   pi-                            PHSP;
+0.35    anti-Sigma-   pi+      PHSP;
+Enddecay
+#
+Decay Sigma(1775)0
+0.215     p+     K-                             PHSP;
+0.215     n0   anti-K0                          PHSP;
+0.20   Lambda0 pi0                             PHSP;
+0.02  Sigma+   pi-                            PHSP;
+0.02  Sigma-   pi+         PHSP;
+0.055  Sigma*+   pi-                            PHSP;
+0.055  Sigma*-   pi+         PHSP;
+0.22   Lambda(1520)0 pi0                             PHSP;
+Enddecay
+#
+Decay anti-Sigma(1775)0
+0.215     anti-p-     K+                             PHSP;
+0.215     anti-n0   K0                          PHSP;
+0.20   anti-Lambda0 pi0                             PHSP;
+0.02  anti-Sigma+   pi-                            PHSP;
+0.02  anti-Sigma-   pi+         PHSP;
+0.055  anti-Sigma*+   pi-                            PHSP;
+0.055  anti-Sigma*-   pi+         PHSP;
+0.22   anti-Lambda(1520)0 pi0                             PHSP;
+Enddecay
+Decay Sigma+
+0.515454300 p+      pi0                                     PHSP; #[Reconstructed PDG2011]
+0.482854300 n0      pi+                                     PHSP; #[Reconstructed PDG2011]
+0.001225905 p+      gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000445905 n0      pi+     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000019590 Lambda0 e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Sigma-
+0.515454300 anti-p- pi0                                     PHSP; #[Reconstructed PDG2011]
+0.482854300 anti-n0 pi-                                     PHSP; #[Reconstructed PDG2011]
+0.001225905 anti-p- gamma                                   PHSP; #[Reconstructed PDG2011]
+0.000445905 anti-n0 pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000019590 anti-Lambda0 e-      anti-nu_e                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Delta+
+0.6630    p+  pi0                       PHSP;
+0.3310    n0  pi+                       PHSP;
+0.0060    p+  gamma                      PHSP;
+Enddecay
+Decay anti-Delta-
+0.6630    anti-p-  pi0                      PHSP;
+0.3310    anti-n0  pi-                      PHSP;
+0.0060    anti-p-  gamma                     PHSP;
+Enddecay
+#
+Decay Delta++
+1.0000    p+  pi+                       PHSP;
+Enddecay
+Decay anti-Delta--
+1.0000    anti-p- pi-                       PHSP;
+Enddecay
+#
+Decay Xi*0
+0.3330    Xi0   pi0                     PHSP;
+0.6670    Xi-   pi+                     PHSP;
+Enddecay
+Decay anti-Xi*0
+0.3330    anti-Xi0   pi0                    PHSP;
+0.6670    anti-Xi+   pi-                    PHSP;
+Enddecay
+#
+Decay Delta0
+0.3310    p+    pi-                     PHSP;
+0.6630    n0    pi0                     PHSP;
+0.0060    n0    gamma                    PHSP;
+Enddecay
+Decay anti-Delta0
+0.3310    anti-p-   pi+                     PHSP;
+0.6630    anti-n0   pi0                     PHSP;
+0.0060    anti-n0   gamma                    PHSP;
+Enddecay
+#
+Decay Delta-
+1.0000    n0    pi-                     PHSP;
+Enddecay
+Decay anti-Delta+
+1.0000    anti-n0   pi+                     PHSP;
+Enddecay
+#
+Decay Sigma-
+0.998015700 n0      pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000460000 n0      pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001017000 n0      e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000450000 n0      mu-     anti-nu_mu                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000057300 Lambda0 e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Sigma+
+0.998015700 anti-n0 pi+                                     PHSP; #[Reconstructed PDG2011]
+0.000460000 anti-n0 pi+     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.001017000 anti-n0 e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000450000 anti-n0 mu+     nu_mu                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000057300 anti-Lambda0 e+      nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Sigma0
+0.995024876 gamma   Lambda0                                 PHSP; #[Reconstructed PDG2011]
+0.004975124 Lambda0 e+      e-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Sigma0
+0.995024876 gamma   anti-Lambda0                            PHSP; #[Reconstructed PDG2011]
+0.004975124 anti-Lambda0 e-      e+                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Sigma*-
+0.8800    Lambda0   pi-                     PHSP;
+0.0600    Sigma0  pi-                     PHSP;
+0.0600    Sigma-  pi0                     PHSP;
+Enddecay
+Decay anti-Sigma*+
+0.8800    anti-Lambda0  pi+                    PHSP;
+0.0600    anti-Sigma0  pi+                    PHSP;
+0.0600    anti-Sigma+  pi0                    PHSP;
+Enddecay
+#
+Decay Sigma*+
+0.8800    Lambda0   pi+                     PHSP;
+0.0600    Sigma+  pi0                     PHSP;
+0.0600    Sigma0  pi+                     PHSP;
+Enddecay
+Decay anti-Sigma*-
+0.8800    anti-Lambda0  pi-                    PHSP;
+0.0600    anti-Sigma-  pi0                    PHSP;
+0.0600    anti-Sigma0  pi-                    PHSP;
+Enddecay
+#
+Decay Sigma*0
+0.8800    Lambda0   pi0                     PHSP;
+0.0600    Sigma+  pi-                     PHSP;
+0.0600    Sigma-  pi+                     PHSP;
+Enddecay
+Decay anti-Sigma*0
+0.8800    anti-Lambda0  pi0                    PHSP;
+0.0600    anti-Sigma-  pi+                    PHSP;
+0.0600    anti-Sigma+  pi-                    PHSP;
+Enddecay
+#
+Decay Xi0
+0.995242400 Lambda0 pi0                                     PHSP; #[Reconstructed PDG2011]
+0.001162400 Lambda0 gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000007600 Lambda0 e+      e-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.003330000 Sigma0  gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000253000 Sigma+  e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000004600 Sigma+  mu-     anti-nu_mu                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Xi0
+0.995242400 anti-Lambda0 pi0                                PHSP; #[Reconstructed PDG2011]
+0.001162400 anti-Lambda0 gamma                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000007600 anti-Lambda0 e-      e+                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.003330000 anti-Sigma0 gamma                               PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000253000 anti-Sigma- e+      nu_e                        PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000004600 anti-Sigma- mu+     nu_mu                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Xi-
+0.998870000 Lambda0 pi-                                     PHSP; #[Reconstructed PDG2011]
+0.000127000 Sigma-  gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000563000 Lambda0 e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000350000 Lambda0 mu-     anti-nu_mu                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000087000 Sigma0  e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Xi+
+0.998870000 anti-Lambda0 pi+                                PHSP; #[Reconstructed PDG2011]
+0.000127000 anti-Sigma+ gamma                               PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000563000 anti-Lambda0 e+      nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000350000 anti-Lambda0 mu+     nu_mu                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000087000 anti-Sigma0 e+      nu_e                        PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Xi*-
+0.6670    Xi0   pi-                     PHSP;
+0.3330    Xi-   pi0                     PHSP;
+Enddecay
+Decay anti-Xi*+
+0.6670    anti-Xi0  pi+                     PHSP;
+0.3330    anti-Xi+  pi0                     PHSP;
+Enddecay
+#
+Decay Omega-
+0.675949296 Lambda0 K-                                      PHSP; #[Reconstructed PDG2011]
+0.233949296 Xi0     pi-                                     PHSP; #[Reconstructed PDG2011]
+0.084828169 Xi-     pi0                                     PHSP; #[Reconstructed PDG2011]
+0.000000000 Xi-     pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000493521 Xi*0    pi-                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004779718 Xi0     e-      anti-nu_e                       PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Omega+
+0.675949296 anti-Lambda0 K+                                 PHSP; #[Reconstructed PDG2011]
+0.233949296 anti-Xi0 pi+                                    PHSP; #[Reconstructed PDG2011]
+0.084828169 anti-Xi+ pi0                                    PHSP; #[Reconstructed PDG2011]
+0.000000000 anti-Xi+ pi-     pi+                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000493521 anti-Xi*0 pi+                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.004779718 anti-Xi0 e+      nu_e                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+#
+Decay Sigma_c*0
+1.0000    Lambda_c+  pi-                     PHSP;
+Enddecay
+CDecay anti-Sigma_c*0
+#
+Decay Sigma_c*+
+1.0000    Lambda_c+  pi0                     PHSP;
+Enddecay
+CDecay anti-Sigma_c*-
+#
+Decay Sigma_c*++
+1.0000    Lambda_c+  pi+                     PHSP;
+Enddecay
+CDecay anti-Sigma_c*--
+#
+Decay Xi_c*0
+0.5000    Xi_c0  pi0                     PHSP;
+0.5000    Xi_c0  gamma                   PHSP;
+Enddecay
+CDecay anti-Xi_c*0
+#
+Decay Xi_c*+
+0.5000    Xi_c+  pi0                     PHSP;
+0.5000    Xi_c+  gamma                   PHSP;
+Enddecay
+CDecay anti-Xi_c*-
+#
+Decay   Omega_c0
+1.00000 PYTHIA 42;
+Enddecay
+#
+CDecay  anti-Omega_c0
+#
+Decay Omega_c*0
+1.0000    Omega_c0  gamma                   PHSP;
+Enddecay
+#
+CDecay anti-Omega_c*0
+#
+Decay Xu0
+#                    X_u^0 -> u anti-u
+#
+1.0 u anti-u PYTHIA 42;
+Enddecay
+Decay Xu+
+#                    X_u^+ -> u anti-d
+#
+1.0 u anti-d PYTHIA 42;
+Enddecay
+CDecay Xu-
+
+#lange - PYTHIA is making h_c mesons - better add a decay
+# channel for them.
+Decay h_c
+0.01 J/psi pi0 PHSP;
+0.5   eta_c gamma      PHSP;
+0.49 rndmflav anti-rndmflav PYTHIA 42;
+Enddecay
+
+# 12/08/03 RJT  Update b-baryon decays...
+Decay Lambda_b0
+# add arbitrary Lb0 -> J/psi p K- (TO CHECK)
+  0.01000    J/psi    p+    K-                             PHSP;
+  0.00047    Lambda0         J/psi                        PHSP;
+  0.00038    Lambda0         psi(2S)                      PHSP;
+  0.00100    Lambda0         eta_c                        PHSP;
+
+# # PR LHCb 27 Apr 2004, addition of Pythia decays
+# 0.398544837 anti-u d c ud_0 PYTHIA 23;
+# 0.082218903 anti-u c d ud_0 PYTHIA 43;
+# 0.072280354 anti-c s c ud_0 PYTHIA 43;
+# 0.010842053 anti-u d u ud_0 PYTHIA 22;
+# 0.010842053 anti-c s u ud_0 PYTHIA 22;
+Enddecay
+
+Decay anti-Lambda_b0
+# add arbitrary Lb0 -> J/psi p K- (TO CHECK)
+  0.01000    J/psi    anti-p-    K+                        PHSP;
+  0.00047    anti-Lambda0    J/psi                        PHSP;
+  0.00038    anti-Lambda0    psi(2S)                      PHSP;
+  0.001000   anti-Lambda0    eta_c       PHSP;
+  0.00080    anti-n0    anti-D0                           PHSP;
+
+# 0.398544837 u anti-d anti-c anti-ud_0 PYTHIA 23;
+# 0.082218903 u anti-c anti-d anti-ud_0 PYTHIA 43;
+# 0.072280354 c anti-s anti-c anti-ud_0 PYTHIA 43;
+# 0.010842053 u anti-d anti-u anti-ud_0 PYTHIA 22;
+# 0.010842053 c anti-s anti-u anti-ud_0 PYTHIA 22;
+Enddecay
+
+Decay Xi_b-
+#                  SemiLeptonic Decays
+  0.05460    Xi_c0      e-    anti-nu_e                   PHSP;
+  0.05460    Xi_c0      mu-   anti-nu_mu                  PHSP;
+  0.02000    Xi_c0      tau-  anti-nu_tau                 PHSP;
+#                  Hadronic Decays with Xi_c0
+  0.00600    Xi_c0      pi-                               PHSP;
+  0.02200    Xi_c0      pi-     pi+       pi-             PHSP;
+  0.00055    Xi_c0      K-                                PHSP;
+  0.02200    Xi_c0      D_s-                              PHSP;
+  0.00047    Xi-        J/psi                             PHSP;
+# added by D.Litvintsev 12/8/03:
+  0.00038    Xi-        psi(2S)                           PHSP;
+  0.00018    D0         Lambda0   pi-                     PHSP;
+  0.00020    Sigma_c0   K-                                PHSP;
+  0.00020    Omega_c0   K-                                PHSP;
+#
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.38757 d anti-u d cs_0 PYTHIA 43;
+0.16995 d anti-u d cs_1 PYTHIA 43;
+0.06335 s anti-u d cs_0 PYTHIA 43;
+0.00568 d anti-u s cs_1 PYTHIA 43;
+0.00797 d anti-u s cs_0 PYTHIA 43;
+0.06148 s anti-c d cs_0 PYTHIA 43;
+0.06918 d anti-u d cd_0 PYTHIA 43;
+0.03999 s anti-c d cd_0 PYTHIA 43;
+0.00865 d anti-u d su_0 PYTHIA 43;
+0.00500 s anti-c d su_0 PYTHIA 43;
+Enddecay
+
+Decay anti-Xi_b+
+#                  SemiLeptonic Decays
+  0.05460    anti-Xi_c0      e+    nu_e                   PHSP;
+  0.05460    anti-Xi_c0      mu+   nu_mu                  PHSP;
+  0.02000    anti-Xi_c0      tau+  nu_tau                 PHSP;
+#                  Hadronic Decays with anti-Xi_c0
+  0.00600    anti-Xi_c0      pi+                          PHSP;
+  0.02200    anti-Xi_c0      pi+     pi+       pi-        PHSP;
+  0.00055    anti-Xi_c0      K+                           PHSP;
+  0.02200    anti-Xi_c0      D_s+                         PHSP;
+  0.00047    anti-Xi+        J/psi                        PHSP;
+# added by D.Litvintsev 12/8/03:
+  0.00038    anti-Xi+        psi(2S)                      PHSP;
+  0.00018    anti-D0         anti-Lambda0   pi+           PHSP;
+  0.00020    anti-Sigma_c0   K+                           PHSP;
+  0.00020    anti-Omega_c0   K+                           PHSP;
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.38757 u anti-d anti-d anti-cs_0 PYTHIA 43;
+0.16995 u anti-d anti-d anti-cs_1 PYTHIA 43;
+0.06335 u anti-s anti-d anti-cs_0 PYTHIA 43;
+0.00568 u anti-d anti-s anti-cs_1 PYTHIA 43;
+0.00797 u anti-d anti-s anti-cs_0 PYTHIA 43;
+0.06148 c anti-s anti-d anti-cs_0 PYTHIA 43;
+0.06918 u anti-d anti-d anti-cd_0 PYTHIA 43;
+0.03999 c anti-s anti-d anti-cd_0 PYTHIA 43;
+0.00865 u anti-d anti-d anti-su_0 PYTHIA 43;
+0.00500 c anti-s anti-d anti-su_0 PYTHIA 43;
+Enddecay
+
+Decay Xi_b0
+#                  SemiLeptonic Decays
+  0.05460    Xi_c+      e-    anti-nu_e                   PHSP;
+  0.05460    Xi_c+      mu-   anti-nu_mu                  PHSP;
+  0.02000    Xi_c+      tau-  anti-nu_tau                 PHSP;
+#                  Hadronic Decays with Xi_c+
+  0.00600    Xi_c+      pi-                               PHSP;
+  0.02200    Xi_c+      pi-     pi+       pi-             PHSP;
+  0.00055    Xi_c+      K-                                PHSP;
+  0.02200    Xi_c+      D_s-                              PHSP;
+  0.00047    Xi0        J/psi                             PHSP;
+# added by D.Litvintsev 12/8/03:
+  0.00020    D0         Lambda0                           PHSP;
+  0.00010    Lambda_c+  K-                                PHSP;
+  0.00020    Sigma_c0   anti-K0                           PHSP;
+  0.00020    Omega_c0   K0                                PHSP;
+#
+#  Additional decays from hep-ph/9709372 scaled to the Lambda_c0 pi rate
+  0.00020    Xi'_c+     pi-                               PHSP;
+  0.00003    Xi_c0      pi0                               PHSP;
+  0.00015    Xi_c0      eta                               PHSP;
+  0.00004    Xi_c0      eta'                              PHSP;
+  0.00020    Xi'_c0     pi0                               PHSP;
+  0.00020    Xi'_c0     eta                               PHSP;
+  0.00030    Xi'_c0     eta'                              PHSP;
+  0.00040    Sigma_c+   K-                                PHSP;
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.58591 d anti-u s cu_0 PYTHIA 43;
+0.01363 s anti-u s cu_1 PYTHIA 43;
+0.09539 s anti-u s cc_1 PYTHIA 43;
+0.10900 s anti-u d cu_1 PYTHIA 43;
+0.01363 d anti-u d uu_1 PYTHIA 43;
+Enddecay
+
+Decay anti-Xi_b0
+  0.05460    anti-Xi_c-      e+    nu_e                   PHSP;
+  0.05460    anti-Xi_c-      mu+   nu_mu                  PHSP;
+  0.02000    anti-Xi_c-      tau+  nu_tau                 PHSP;
+#                  Hadronic Decays with anti-Xi_c-
+  0.00600    anti-Xi_c-      pi+                          PHSP;
+  0.02200    anti-Xi_c-      pi+     pi+       pi-        PHSP;
+  0.00055    anti-Xi_c-      K+                           PHSP;
+  0.02200    anti-Xi_c-      D_s+                         PHSP;
+  0.00047    anti-Xi0        J/psi                        PHSP;
+# added by D.Litvintsev 12/8/03:
+  0.00020    anti-D0         anti-Lambda0                 PHSP;
+  0.00010    anti-Lambda_c-  K+                           PHSP;
+  0.00020    anti-Sigma_c0   K0                           PHSP;
+  0.00020    anti-Omega_c0   anti-K0                      PHSP;
+#
+#  Additional decays from hep-ph/9709372 scaled to the Lambda_c0 pi rate
+  0.00020    anti-Xi'_c-     pi+                          PHSP;
+  0.00003    anti-Xi_c0      pi0                          PHSP;
+  0.00015    anti-Xi_c0      eta                          PHSP;
+  0.00004    anti-Xi_c0      eta'                         PHSP;
+  0.00020    anti-Xi'_c0     pi0                          PHSP;
+  0.00020    anti-Xi'_c0     eta                          PHSP;
+  0.00030    anti-Xi'_c0     eta'                         PHSP;
+  0.00040    anti-Sigma_c-   K+                           PHSP;
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.58591 u anti-d anti-s anti-cu_0 PYTHIA 43;
+0.01363 u anti-s anti-s anti-cu_1 PYTHIA 43;
+0.09539 u anti-s anti-s anti-cc_1 PYTHIA 43;
+0.10900 u anti-s anti-d anti-cu_1 PYTHIA 43;
+0.01363 u anti-d anti-d anti-uu_1 PYTHIA 43;
+Enddecay
+
+# added by D.Litvintsev 12/8/03:
+Decay Omega_b-
+#                  SemiLeptonic Decays
+  0.05460    Omega_c0      e-    anti-nu_e                PHSP;
+  0.05460    Omega_c0      mu-   anti-nu_mu               PHSP;
+  0.02000    Omega_c0      tau-  anti-nu_tau              PHSP;
+#                  Hadronic Decays with Xi_c+
+  0.00600    Omega_c0      pi-                            PHSP;
+  0.02200    Omega_c0      pi-     pi+       pi-          PHSP;
+  0.00055    Omega_c0      K-                             PHSP;
+  0.02200    Omega_c0      D_s-                           PHSP;
+  0.0011     D0            Xi-                            PHSP;
+#
+  0.00047    Omega-        J/psi                          PHSP;
+  0.00038    Omega-        psi(2S)                        PHSP;
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.68192 d anti-u s cs_0 PYTHIA 43;
+0.10910 d anti-u d cs_0 PYTHIA 43;
+0.02728 d anti-u s su_0 PYTHIA 43;
+Enddecay
+
+Decay anti-Omega_b+
+#                  SemiLeptonic Decays
+  0.05460    anti-Omega_c0      e+    nu_e                PHSP;
+  0.05460    anti-Omega_c0      mu+   nu_mu               PHSP;
+  0.02000    anti-Omega_c0      tau+  nu_tau              PHSP;
+#                  Hadronic Decays with Xi_c+
+  0.00600    anti-Omega_c0      pi+                       PHSP;
+  0.02200    anti-Omega_c0      pi+     pi+       pi-     PHSP;
+  0.00055    anti-Omega_c0      K+                        PHSP;
+  0.02200    anti-Omega_c0      D_s+                      PHSP;
+  0.0011     anti-D0            anti-Xi+                  PHSP;
+#
+  0.00047    anti-Omega+        J/psi                     PHSP;
+  0.00038    anti-Omega+        psi(2S)                   PHSP;
+#  aaa 10/19/05 Do not if this is correct but filling out with inclusives
+0.68192 u anti-d anti-s anti-cs_0 PYTHIA 43;
+0.10910 u anti-d anti-d anti-cs_0 PYTHIA 43;
+0.02728 u anti-d anti-s anti-su_0 PYTHIA 43;
+Enddecay
+
+
+Decay Sigma_b+
+  1.00000    Lambda_b0   pi+                              PHSP;
+Enddecay
+Decay anti-Sigma_b-
+  1.00000    anti-Lambda_b0   pi-                         PHSP;
+Enddecay
+
+Decay Sigma_b-
+  1.00000    Lambda_b0   pi-                              PHSP;
+Enddecay
+Decay anti-Sigma_b+
+  1.00000    anti-Lambda_b0   pi+                         PHSP;
+Enddecay
+
+Decay Sigma_b0
+  1.00000    Lambda_b0   gamma                    PHOTOS  PHSP;
+Enddecay
+Decay anti-Sigma_b0
+  1.00000    anti-Lambda_b0   gamma               PHOTOS  PHSP;
+Enddecay
+
+
+#
+#   B_c Mesons
+#
+
+Decay B_c-
+0.01600    tau-       anti-nu_tau               SLN;
+#
+#                  SemiLeptonic Decays
+0.01900    J/psi      e-      anti-nu_e         PHOTOS  PHSP;
+0.00094    psi(2S)    e-      anti-nu_e         PHOTOS  PHSP;
+0.00750    eta_c      e-      anti-nu_e         PHOTOS  PHSP;
+0.00020    eta_c(2S)  e-      anti-nu_e         PHOTOS  PHSP;
+0.00004    anti-D0    e-      anti-nu_e         PHOTOS  PHSP;
+0.00018    anti-D*0   e-      anti-nu_e         PHOTOS  PHSP;
+0.04030    anti-B_s0  e-      anti-nu_e         PHOTOS  PHSP;
+0.05060    anti-B_s*0 e-      anti-nu_e         PHOTOS  PHSP;
+0.00340    anti-B0    e-      anti-nu_e         PHOTOS  PHSP;
+0.00580    anti-B*0   e-      anti-nu_e         PHOTOS  PHSP;
+#
+0.01900    J/psi      mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00094    psi(2S)    mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00750    eta_c      mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00020    eta_c(2S)  mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00004    anti-D0    mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00018    anti-D*0   mu-     anti-nu_mu        PHOTOS  PHSP;
+0.04030    anti-B_s0  mu-     anti-nu_mu        PHOTOS  PHSP;
+0.05060    anti-B_s*0 mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00340    anti-B0    mu-     anti-nu_mu        PHOTOS  PHSP;
+0.00580    anti-B*0   mu-     anti-nu_mu        PHOTOS  PHSP;
+#
+0.00480    J/psi      tau-    anti-nu_tau               PHSP;
+0.00008    psi(2S)    tau-    anti-nu_tau               PHSP;
+0.00230    eta_c      tau-    anti-nu_tau               PHSP;
+0.000016   eta_c(2S)  tau-    anti-nu_tau               PHSP;
+0.00002    anti-D0    tau-    anti-nu_tau               PHSP;
+0.00008    anti-D*0   tau-    anti-nu_tau               PHSP;
+#
+#
+#                  Hadronic Decays
+0.00200    eta_c      pi-                   PHSP;
+0.00420    rho-       eta_c                 SVS;
+0.00013    eta_c      K-                    PHSP;
+0.00020    K*-        eta_c                 SVS;
+0.00130    J/psi      pi-                   SVS;
+0.00400    J/psi      rho-                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K-                    SVS;
+0.00022    J/psi      K*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.000053   D-         D0                    PHSP;
+0.000075   D*0        D-                    SVS;
+0.000049   D*-        D0                    SVS;
+0.00033    D*-        D*0                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.0000048  D_s-       D0                    PHSP;
+0.0000071  D*0        D_s-                  SVS;
+0.0000045  D_s*-      D0                    SVS;
+0.000026   D_s*-      D*0                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.0000003  D-         anti-D0               PHSP;
+0.0000003  anti-D*0   D-                    SVS;
+0.0000004  D*-        anti-D0               SVS;
+0.0000016  anti-D*0   D*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.0000066  D_s-       anti-D0               PHSP;
+0.0000063  anti-D*0   D_s-                  SVS;
+0.0000085  D_s*-      anti-D0               SVS;
+0.0000404  D_s*-      anti-D*0              SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.00280    eta_c      D_s-                  PHSP;
+0.00270    D_s*-      eta_c                 SVS;
+0.00015    eta_c      D-                    PHSP;
+0.00010    D*-        eta_c                 SVS;
+0.00170    J/psi      D_s-                  SVS;
+0.00670    J/psi      D_s*-                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D-                    SVS;
+0.00028    J/psi      D*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.16400    anti-B_s0  pi-                   PHSP;
+0.07200    rho-       anti-B_s0             SVS;
+0.01060    anti-B_s0  K-                    PHSP;
+0.00000    K*-        anti-B_s0             SVS;
+0.06500    anti-B_s*0 pi-                   SVS;
+0.20200    anti-B_s*0 rho-                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00370    anti-B_s*0 K-                    SVS;
+0.00000    anti-B_s*0 K*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.01060    anti-B0    pi-                   PHSP;
+0.00960    rho-       anti-B0               SVS;
+0.00070    anti-B0    K-                    PHSP;
+0.00015    K*-        anti-B0               SVS;
+0.00950    anti-B*0   pi-                   SVS;
+0.02570    anti-B*0   rho-                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00055    anti-B*0   K-                    SVS;
+0.00058    anti-B*0   K*-                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00037    B-         pi0                   PHSP;
+0.00034    rho0       B-                    SVS;
+0.01980    B-         K0                    PHSP;
+0.00430    K*0        B-                    SVS;
+0.00033    B*-        pi0                   SVS;
+0.00090    B*-        rho0                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.01600    B*-        K0                    SVS;
+0.01670    B*-        K*0                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+# PR LHCb 09 Apr 2004 Add B_c+ -> rho0 pi+
+  0.00002    rho0       pi-                   SVS;
+0.06005 anti-c s PYTHIA 42;
+# PR LHCb 27 Apr 2004 Add Pythia Modes
+#
+#  ash 10/27/03 Do not if this is correct but filling out with unknown cs
+#0.0200235 cs_0 anti-uu_0 PYTHIA 63;
+#0.0400470 cs_1 anti-uu_1 PYTHIA 63;
+#
+Enddecay
+
+# 09/15/03 A. Sanchez: Using BR's from hep-ph/0308214
+#
+# Total Br = 0.939865 + .06135 cs
+Decay B_c+
+0.01600    tau+       nu_tau                   SLN;
+#
+#                  SemiLeptonic Decays
+0.01900    J/psi      e+          nu_e         PHOTOS  PHSP;
+0.00094    psi(2S)    e+          nu_e         PHOTOS  PHSP;
+0.00750    eta_c      e+          nu_e         PHOTOS  PHSP;
+0.00020    eta_c(2S)  e+          nu_e         PHOTOS  PHSP;
+0.00004    D0         e+          nu_e         PHOTOS  PHSP;
+0.00018    D*0        e+          nu_e         PHOTOS  PHSP;
+0.04030    B_s0       e+          nu_e         PHOTOS  PHSP;
+0.05060    B_s*0      e+          nu_e         PHOTOS  PHSP;
+0.00340    B0         e+          nu_e         PHOTOS  PHSP;
+0.00580    B*0        e+          nu_e         PHOTOS  PHSP;
+#
+0.01900    J/psi      mu+         nu_mu        PHOTOS  PHSP;
+0.00094    psi(2S)    mu+         nu_mu        PHOTOS  PHSP;
+0.00750    eta_c      mu+         nu_mu        PHOTOS  PHSP;
+0.00020    eta_c(2S)  mu+         nu_mu        PHOTOS  PHSP;
+0.00004    D0         mu+         nu_mu        PHOTOS  PHSP;
+0.00018    D*0        mu+         nu_mu        PHOTOS  PHSP;
+0.04030    B_s0       mu+         nu_mu        PHOTOS  PHSP;
+0.05060    B_s*0      mu+         nu_mu        PHOTOS  PHSP;
+0.00340    B0         mu+         nu_mu        PHOTOS  PHSP;
+0.00580    B*0        mu+         nu_mu        PHOTOS  PHSP;
+#
+0.00480    J/psi      tau+        nu_tau               PHSP;
+0.00008    psi(2S)    tau+        nu_tau               PHSP;
+0.00230    eta_c      tau+        nu_tau               PHSP;
+0.000016   eta_c(2S)  tau+        nu_tau               PHSP;
+0.00002    D0         tau+        nu_tau               PHSP;
+0.00008    D*0        tau+        nu_tau               PHSP;
+#
+#                  Hadronic Decays
+0.00200    eta_c      pi+                   PHSP;
+0.00420    rho+       eta_c                 SVS;
+0.00013    eta_c      K+                    PHSP;
+0.00020    K*+        eta_c                 SVS;
+0.00130    J/psi      pi+                   SVS;
+0.00400    J/psi      rho+                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00011    J/psi      K+                    SVS;
+0.00022    J/psi      K*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.000053   D+         anti-D0               PHSP;
+0.000075   anti-D*0   D+                    SVS;
+0.000049   D*+        anti-D0               SVS;
+0.00033    D*+        anti-D*0              SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.0000048  D_s+       anti-D0               PHSP;
+0.0000071  anti-D*0   D_s+                  SVS;
+0.0000045  D_s*+      anti-D0               SVS;
+0.000026   D_s*+      anti-D*0              SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.0000003  D+         D0                    PHSP;
+0.0000003  D*0        D+                    SVS;
+0.0000004  D*+        D0                    SVS;
+0.0000016  D*0        D*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.0000066  D_s+       D0                    PHSP;
+0.0000063  D*0        D_s+                  SVS;
+0.0000085  D_s*+      D0                    SVS;
+0.0000404  D_s*+      D*0                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.00280    eta_c      D_s+                  PHSP;
+0.00270    D_s*+      eta_c                 SVS;
+0.00015    eta_c      D+                    PHSP;
+0.00010    D*+        eta_c                 SVS;
+0.00170    J/psi      D_s+                  SVS;
+0.00670    J/psi      D_s*+                 SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00009    J/psi      D+                    SVS;
+0.00028    J/psi      D*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+#
+0.16400    B_s0       pi+                   PHSP;
+0.07200    rho+       B_s0                  SVS;
+0.01060    B_s0       K+                    PHSP;
+0.00000    K*+        B_s0                  SVS;
+0.06500    B_s*0      pi+                   SVS;
+0.20200    B_s*0      rho+                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00370    B_s*0      K+                    SVS;
+0.00000    B_s*0      K*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.01060    B0         pi+                   PHSP;
+0.00960    rho+       B0                    SVS;
+0.00070    B0         K+                    PHSP;
+0.00015    K*+        B0                    SVS;
+0.00950    B*0        pi+                   SVS;
+0.02570    B*0        rho+                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00055    B*0        K+                    SVS;
+0.00058    B*0        K*+                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.00037    B+         pi0                   PHSP;
+0.00034    rho0       B+                    SVS;
+0.01980    B+         anti-K0               PHSP;
+0.00430    K*0        B+                    SVS;
+0.00033    B*+        pi0                   SVS;
+0.00090    B*+        rho0                  SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+0.01600    B*+        anti-K0               SVS;
+0.01670    B*+        K*0                   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
+# PR LHCb 09 Apr 2004 Add B_c+ -> rho0 pi+
+  0.00002    rho0       pi+                   SVS;
+0.06005 c anti-s PYTHIA 42;
+# PR LHCb 27 Apr 2004 Add Pythia Modes
+#
+#  ash 10/27/03 Do not if this is correct but filling out with unknown cs
+#0.0200235 anti-cs_0 uu_0 PYTHIA 63;
+#0.0400470 anti-cs_1 uu_1 PYTHIA 63;
+#
+Enddecay
+
+
+#  Add excited Lambda_c decays (R.J. Tesarek  12/9/03)
+#  Just a guess for the last two BR [Lambda_c(2593)+].
+Decay Lambda_c(2593)+
+0.096585366 Sigma_c++ pi-                                   PHSP; #[Reconstructed PDG2011]
+0.096585366 Sigma_c0 pi+                                    PHSP; #[Reconstructed PDG2011]
+0.190000000 Lambda_c+ pi+     pi-                           PHSP; #[Reconstructed PDG2011]
+0.096585366 Sigma_c+ pi0                                    PHSP; #[Reconstructed PDG2011]
+0.036219512 Lambda_c+ pi0     pi0                           PHSP; #[Reconstructed PDG2011]
+0.004024390 Lambda_c+ gamma                                 PHSP; #[Reconstructed PDG2011]
+0.240000000 Sigma_c*++ pi-                                  PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.240000000 Sigma_c*0 pi+                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Lambda_c(2593)-
+0.096585366 anti-Sigma_c-- pi+                              PHSP; #[Reconstructed PDG2011]
+0.096585366 anti-Sigma_c0 pi-                               PHSP; #[Reconstructed PDG2011]
+0.190000000 anti-Lambda_c- pi-     pi+                      PHSP; #[Reconstructed PDG2011]
+0.096585366 anti-Sigma_c- pi0                               PHSP; #[Reconstructed PDG2011]
+0.036219512 anti-Lambda_c- pi0     pi0                      PHSP; #[Reconstructed PDG2011]
+0.004024390 anti-Lambda_c- gamma                            PHSP; #[Reconstructed PDG2011]
+0.240000000 anti-Sigma_c*-- pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.240000000 anti-Sigma_c*0 pi-                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+#
+Decay Lambda_c(2625)+
+0.670000000 Lambda_c+ pi+     pi-                           PHSP; #[Reconstructed PDG2011]
+0.320294118 Lambda_c+ pi0                                   PHSP; #[Reconstructed PDG2011]
+0.009705882 Lambda_c+ gamma                                 PHSP; #[Reconstructed PDG2011]
+Enddecay
+Decay anti-Lambda_c(2625)-
+0.670000000 anti-Lambda_c- pi-     pi+                      PHSP; #[Reconstructed PDG2011]
+0.320294118 anti-Lambda_c- pi0                              PHSP; #[Reconstructed PDG2011]
+0.009705882 anti-Lambda_c- gamma                            PHSP; #[Reconstructed PDG2011]
+Enddecay
+
+#  Add excited B hadrons (LHCb PR 10/03/04)
+#  Reference : Pythia 6.205 decay table
+#  PDG Id = 5312
+Decay Xi'_b-
+  1.0000     Xi_b-    gamma       PHSP;
+Enddecay
+Decay anti-Xi'_b+
+  1.0000     anti-Xi_b+  gamma    PHSP;
+Enddecay
+#  PDG Id = 5322
+Decay Xi'_b0
+  1.0000     Xi_b0    gamma       PHSP;
+Enddecay
+Decay anti-Xi'_b0
+  1.0000     anti-Xi_b0  gamma    PHSP;
+Enddecay
+#  PDG Id = 10521
+Decay B_0*+
+  0.6670     B0     pi+           PHSP;
+  0.3330     B+     pi0           PHSP;
+Enddecay
+Decay B_0*-
+  0.6670     anti-B0  pi-         PHSP;
+  0.3330     B-       pi0         PHSP;
+Enddecay
+#  PDG Id = 20523 Broad : S wave
+Decay B'_1+
+  0.6670     B*0      pi+         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.3330     B*+      pi0         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay B'_1-
+  0.6670     anti-B*0   pi-       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.3330     B*-        pi0       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#  PDG Id = 10523  Narrow : D wave
+Decay B_1+
+  0.6670     B*0      pi+         VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.3330     B*+      pi0         VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay B_1-
+  0.6670     anti-B*0   pi-       VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.3330     B*-        pi0       VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+#  PDG Id = 525 Narrow : D wave
+Decay B_2*+
+  0.3000     B0     pi+           TSS;
+  0.1500     B+     pi0           TSS;
+  0.1600     B*0    pi+           TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.0800     B*+    pi0           TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.1300     B*0    pi+    pi0    PHSP;
+  0.0600     B*+    pi+    pi-    PHSP;
+  0.0800     B0     pi+    pi0    PHSP;
+  0.0400     B+     pi+    pi-    PHSP;
+Enddecay
+Decay B_2*-
+  0.3000     anti-B0  pi-         TSS;
+  0.1500     B-       pi0         TSS;
+  0.1600     anti-B*0  pi-        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.0800     B*-      pi0         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.1300     anti-B*0  pi-   pi0  PHSP;
+  0.0600     B*-      pi-    pi+  PHSP;
+  0.0800     anti-B0  pi-    pi0  PHSP;
+  0.0400     B-       pi-    pi+  PHSP;
+Enddecay
+#  PDG Id = 10511
+Decay B_0*0
+  0.6670     B+     pi-           PHSP;
+  0.3330     B0     pi0           PHSP;
+Enddecay
+Decay anti-B_0*0
+  0.6670     B-     pi+           PHSP;
+  0.3330     anti-B0   pi0        PHSP;
+Enddecay
+#  PDG Id = 20513 Broad : S wave
+Decay B'_10
+  0.6670     B*+    pi-           VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.3330     B*0    pi0           VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay anti-B'_10
+  0.6670     B*-    pi+           VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.3330     anti-B*0   pi0       VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#  PDG Id = 10513 Narrow : D wave
+Decay B_10
+  0.6670     B*+    pi-           VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.3330     B*0    pi0           VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay anti-B_10
+  0.6670     B*-    pi+           VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.3330     anti-B*0   pi0       VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+#  PDG Id = 515
+Decay B_2*0
+  0.3000     B+    pi-            TSS;
+  0.1500     B0    pi0            TSS;
+  0.1600     B*+   pi-            TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.0800     B*0   pi0            TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.1300     B*+   pi-   pi0      PHSP;
+  0.0600     B*0   pi+   pi-      PHSP;
+  0.0800     B+    pi-   pi0      PHSP;
+  0.0400     B0    pi+   pi-      PHSP;
+Enddecay
+Decay anti-B_2*0
+  0.3000     B-    pi+            TSS;
+  0.1500     anti-B0  pi0         TSS;
+  0.1600     B*-   pi+            TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.0800     anti-B*0  pi0        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.1300     B*-   pi+  pi0       PHSP;
+  0.0600     anti-B*0  pi-  pi+   PHSP;
+  0.0800     B-    pi+   pi0      PHSP;
+  0.0400     anti-B0   pi-   pi+  PHSP;
+Enddecay
+#  PDG Id = 10531
+Decay B_s0*0
+  0.5000     B+   K-              PHSP;
+  0.5000     B0   anti-K0         PHSP;
+Enddecay
+Decay anti-B_s0*0
+  0.5000     B-   K+              PHSP;
+  0.5000     anti-B0   K0         PHSP;
+Enddecay
+#  PDG Id = 20533   Broad : S wave
+Decay B'_s10
+  0.5000     B*+  K-              VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.5000     B*0  anti-K0         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay anti-B'_s10
+  0.5000     B*-  K+              VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.5000     anti-B*0   K0        VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+#  PDG Id = 10533   Narrow : D wave
+Decay B_s10
+  0.5000     B*+  K-              VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.5000     B*0  anti-K0         VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay anti-B_s10
+  0.5000     B*-  K+              VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.5000     anti-B*0    K0       VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+#  PDG Id = 535   Narrow : D wave
+Decay B_s2*0
+  0.3000     B+   K-              TSS;
+  0.3000     B0   anti-K0         TSS;
+  0.2000     B*+  K-              TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.2000     B*0  anti-K0         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+Decay anti-B_s2*0
+  0.3000     B-   K+              TSS;
+  0.3000     anti-B0  K0          TSS;
+  0.2000     B*-  K+              TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.2000     anti-B*0 K0          TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+#  PDG Id = 543
+Decay B_c*+
+  1.0000     B_c+  gamma          VSP_PWAVE;
+Enddecay
+Decay B_c*-
+  1.0000     B_c-  gamma          VSP_PWAVE;
+Enddecay
+#  PDG Id = 545  Narrow : D wave
+Decay B_c2*+
+  0.3000     B0    D+             TSS;
+  0.3000     B+    D0             TSS;
+  0.2000     B*0   D+             TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.2000     B*+   D0             TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+Decay B_c2*-
+  0.3000     anti-B0  D-          TSS;
+  0.3000     B-    anti-D0        TSS;
+  0.2000     anti-B*0  D-         TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+  0.2000     B*-   anti-D0        TVS_PWAVE 0.0 0.0 1.0 0.0 0.0 0.0;
+Enddecay
+#  PDG Id = 5114
+Decay Sigma_b*-
+  1.0000     Lambda_b0  pi-       PHSP;
+Enddecay
+Decay anti-Sigma_b*+
+  1.0000     anti-Lambda_b0  pi+  PHSP;
+Enddecay
+# PDG Id = 5224
+Decay Sigma_b*+
+  1.0000     Lambda_b0  pi+       PHSP;
+Enddecay
+Decay anti-Sigma_b*-
+  1.0000     anti-Lambda_b0  pi-  PHSP;
+Enddecay
+# PDG Id = 5214
+Decay Sigma_b*0
+  1.0000     Lambda_b0  pi0       PHSP;
+Enddecay
+Decay anti-Sigma_b*0
+  1.0000     anti-Lambda_b0  pi0  PHSP;
+Enddecay
+#  PDG Id = 5314
+Decay Xi_b*-
+  1.0000     Xi_b-    gamma       PHSP;
+Enddecay
+Decay anti-Xi_b*+
+  1.0000     anti-Xi_b+  gamma    PHSP;
+Enddecay
+#  PDG Id = 5324
+Decay Xi_b*0
+  1.0000     Xi_b0   gamma        PHSP;
+Enddecay
+Decay anti-Xi_b*0
+  1.0000     anti-Xi_b0 gamma     PHSP;
+Enddecay
+#  PDG Id = 5334
+Decay Omega_b*-
+  1.0000     Omega_b-   gamma     PHSP;
+Enddecay
+Decay anti-Omega_b*+
+  1.0000     anti-Omega_b+  gamma PHSP;
+Enddecay
+#  PDG Id = 10541
+Decay B_c0*+
+  0.5000     B0   D+              PHSP;
+  0.5000     B+   D0              PHSP;
+Enddecay
+Decay B_c0*-
+  0.5000     anti-B0  D-          PHSP;
+  0.5000     B-       anti-D0     PHSP;
+Enddecay
+#  PDG Id = 10543  Narrow : D wave
+Decay B_c1+
+  0.5000     B*0      D+          VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.5000     B*+      D0          VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+Decay B_c1-
+  0.5000     anti-B*0  D-         VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+  0.5000     B*-       anti-D0    VVS_PWAVE 0.0 0.0 0.0 0.0 1.0 0.0;
+Enddecay
+#  PDG Id = 20543 Broad : S wave
+Decay B'_c1+
+  0.5000     B*0       D+         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.5000     B*+       D0         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+Decay B'_c1-
+  0.5000     anti-B*0  D-         VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+  0.5000     B*-       anti-D0    VVS_PWAVE 1.0 0.0 0.0 0.0 0.0 0.0;
+Enddecay
+
+# Excited charmed Baryons   LHCb PR 3-05-2006
+Decay Xi_cc*++
+  0.08 e+  nu_e     Xi_c+   PHSP ;
+  0.08 mu+ nu_mu    Xi_c+   PHSP ;
+0.51 u anti-d s cu_0 PYTHIA 42;
+0.25 u anti-d s cu_1 PYTHIA 42;
+0.05 u anti-s s cu_0 PYTHIA 42;
+0.03 u anti-s s cu_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Xi_cc*--
+  0.08 e-  anti-nu_e  anti-Xi_c-   PHSP;
+  0.08 mu- anti-nu_mu anti-Xi_c-   PHSP;
+0.51 anti-u d anti-s anti-cu_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cu_0 PYTHIA 42;
+0.05 anti-u s anti-s anti-cu_1 PYTHIA 42;
+0.03 anti-u s anti-s anti-cu_1 PYTHIA 42;
+Enddecay
+
+Decay Xi_cc++
+  0.08 e+  nu_e     Xi_c+   PHSP ;
+  0.08 mu+ nu_mu    Xi_c+   PHSP ;
+0.51 u anti-d s cu_0 PYTHIA 42;
+0.25 u anti-d s cu_1 PYTHIA 42;
+0.05 u anti-s s cu_0 PYTHIA 42;
+0.03 u anti-s s cu_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Xi_cc--
+  0.08 e-  anti-nu_e  anti-Xi_c-   PHSP;
+  0.08 mu- anti-nu_mu anti-Xi_c-   PHSP;
+0.51 anti-u d anti-s anti-cu_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cu_0 PYTHIA 42;
+0.05 anti-u s anti-s anti-cu_1 PYTHIA 42;
+0.03 anti-u s anti-s anti-cu_1 PYTHIA 42;
+Enddecay
+
+Decay Xi_cc*+
+  0.08 e+  nu_e    Xi_c0    PHSP;
+  0.08 mu+ nu_mu   Xi_c0    PHSP;
+0.51 u anti-d s cd_0 PYTHIA 42;
+0.25 u anti-d s cd_1 PYTHIA 42;
+0.05 u anti-s s cd_0 PYTHIA 42;
+0.03 u anti-s s cd_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Xi_cc*-
+  0.08 e-  anti-nu_e    anti-Xi_c0    PHSP;
+  0.08 mu- anti-nu_mu   anti-Xi_c0    PHSP;
+0.51 anti-u d anti-s anti-cd_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cd_1 PYTHIA 42;
+0.05 anti-u s anti-s anti-cd_0 PYTHIA 42;
+0.03 anti-u s anti-s anti-cd_1 PYTHIA 42;
+Enddecay
+
+Decay Xi_cc+
+  0.08 e+  nu_e    Xi_c0    PHSP;
+  0.08 mu+ nu_mu   Xi_c0    PHSP;
+0.51 u anti-d s cd_0 PYTHIA 42;
+0.25 u anti-d s cd_1 PYTHIA 42;
+0.05 u anti-s s cd_0 PYTHIA 42;
+0.03 u anti-s s cd_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Xi_cc-
+  0.08 e-  anti-nu_e    anti-Xi_c0    PHSP;
+  0.08 mu- anti-nu_mu   anti-Xi_c0    PHSP;
+0.51 anti-u d anti-s anti-cd_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cd_1 PYTHIA 42;
+0.05 anti-u s anti-s anti-cd_0 PYTHIA 42;
+0.03 anti-u s anti-s anti-cd_1 PYTHIA 42;
+Enddecay
+
+Decay Omega_cc+
+  0.08 e+  nu_e   Omega_c0   PHSP;
+  0.08 mu+ nu_mu  Omega_c0   PHSP;
+0.51 u anti-d s cs_0 PYTHIA 42;
+0.25 u anti-d s cs_1 PYTHIA 42;
+0.05 u anti-s s cs_0 PYTHIA 42;
+0.03 u anti-s s cs_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Omega_cc-
+  0.08 e-  anti-nu_e   anti-Omega_c0   PHSP;
+  0.08 mu- anti-nu_mu  anti-Omega_c0   PHSP;
+0.51 anti-u d anti-s anti-cs_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cs_1 PYTHIA 42;
+0.05 anti-u s anti-s anti-cs_0 PYTHIA 42;
+0.03 anti-u s anti-s anti-cs_1 PYTHIA 42;
+Enddecay
+
+Decay Omega_cc*+
+  0.08 e+  nu_e   Omega_c0   PHSP;
+  0.08 mu+ nu_mu  Omega_c0   PHSP;
+0.51 u anti-d s cs_0 PYTHIA 42;
+0.25 u anti-d s cs_1 PYTHIA 42;
+0.05 u anti-s s cs_0 PYTHIA 42;
+0.03 u anti-s s cs_1 PYTHIA 42;
+Enddecay
+
+Decay anti-Omega_cc*-
+  0.08 e-  anti-nu_e   anti-Omega_c0   PHSP;
+  0.08 mu- anti-nu_mu  anti-Omega_c0   PHSP;
+0.51 anti-u d anti-s anti-cs_0 PYTHIA 42;
+0.25 anti-u d anti-s anti-cs_1 PYTHIA 42;
+0.05 anti-u s anti-s anti-cs_0 PYTHIA 42;
+0.03 anti-u s anti-s anti-cs_1 PYTHIA 42;
+Enddecay
+
+Decay K_L0
+#0.202464226 pi+     e-      anti-nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.202464226 pi-     e+      nu_e                            PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.135033299 pi+     mu-     anti-nu_mu                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.135033299 pi-     mu+     nu_mu                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000025738 pi0     pi+     e-      anti-nu_e                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000025738 pi0     pi-     e+      nu_e                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000006205 pi+     e-      anti-nu_e    e+      e-              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000006205 pi-     e+      nu_e    e+      e-              PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.194795855 pi0     pi0     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.125231606 pi+     pi-     pi0                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.001880711 pi+     e-      anti-nu_e    gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.001880711 pi-     e+      nu_e    gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000277023 pi+     mu-     anti-nu_mu   gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000277023 pi-     mu+     nu_mu   gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000040995 pi+     pi-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000001262 pi0     gamma   gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000000016 pi0     gamma   e+      e-                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000545653 gamma   gamma                                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000009265 e+      e-      gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000000355 mu+     mu-     gamma                           PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000000584 e+      e-      gamma   gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+#0.000000007 mu+     mu-     gamma   gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]
+Enddecay
+
+End

--- a/MC/config/PWGHF/pythia8/generator/pythia8_Mode2_noforcedecays.cfg
+++ b/MC/config/PWGHF/pythia8/generator/pythia8_Mode2_noforcedecays.cfg
@@ -1,0 +1,39 @@
+### authors: Fabrizio Grosa (fabrizio.grosa@cern.ch)
+
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 13600. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.
+
+### switching on Pythia Mode2
+ColourReconnection:mode 1
+ColourReconnection:allowDoubleJunRem off
+ColourReconnection:m0 0.3
+ColourReconnection:allowJunctions on
+ColourReconnection:junctionCorrection 1.20
+ColourReconnection:timeDilationMode 2
+ColourReconnection:timeDilationPar 0.18
+StringPT:sigma 0.335
+StringZ:aLund 0.36
+StringZ:bLund 0.56
+StringFlav:probQQtoQ 0.078
+StringFlav:ProbStoUD 0.2
+StringFlav:probQQ1toQQ0join 0.0275,0.0275,0.0275,0.0275
+MultiPartonInteractions:pT0Ref 2.15
+BeamRemnants:remnantMode 1
+BeamRemnants:saturation 5
+
+# Correct decay lengths (wrong in PYTHIA8 decay table)
+# Lb
+5122:tau0 = 0.4390
+# Xic0
+4132:tau0 = 0.0455
+# OmegaC
+4332:tau0 = 0.0803


### PR DESCRIPTION
@fchinu this PR adds the config for the B->JPsi(->MuMu) + X MC using the EVTGEN decayer. Only the decays of B hadrons to charmonia are kept, and for the main ones the BR is multiplied x10 (to be discussed if we have to keep those with high mass state charmonia or not). The JPsi is forced to decay 70% of the times into MuMu and 30% of the times in EE, to evaluate residual contaminations. Can you please check the decays?

The test for the ini file has still to be added.
