### PR TITLE
DPG: update FIT digitizer parameters for 2023 and 2024 data

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -97,10 +97,22 @@ def create_sim_config(args):
         add(config, {"FwdMatching.cutFcn" : "cut3SigmaXYAngles"})
 
     # FIT digitizer settings
+    #2023 pp
+    if 534125 <= int(args.run) and int(args.run) <= 543113:
+        add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
+        if COLTYPEIR == "pp":
+           # central and semicentral FT0 thresholds 
+           add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
+           # FV0 trigger settings
+           add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
     # 2023 PbPb
     if 543437 <= int(args.run) and int(args.run) <= 545367:
         add(config, {"FT0DigParam.mMip_in_V": "7", "FT0DigParam.mMV_2_Nchannels": "2", "FT0DigParam.mMV_2_NchannelsInverse": "0.5"})
         add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+        # central and semicentral FT0 thresholds 
+        add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
+        # FV0 trigger settings
+        add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "1080"})
     # 2024
     # first and last run of 2024
     if 546088 <= int(args.run) and int(args.run) <= 560623:
@@ -111,6 +123,15 @@ def create_sim_config(args):
         if COLTYPEIR == "PbPb":
             # 4 ADC channels / MIP
             add(config, {"FV0DigParam.adcChannelsPerMip": "4"})
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "1433", "FT0DigParam.mtrg_semicentral_trh": "35"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "1080"})
+        if COLTYPEIR == "pp":
+            # central and semicentral FT0 thresholds 
+            add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})
+            # FV0 trigger settings
+            add(config, {"FV0DigParam.NchannelsLevel": "2", "FV0DigParam.InnerChargeLevel": "4", "FV0DigParam.OuterChargeLevel": "4", "FV0DigParam.ChargeLevel": "8"})
     # 2025
     # first and last run of 2025
     if 562260 <= int(args.run) and int(args.run) <= 568721:

--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -99,7 +99,6 @@ def create_sim_config(args):
     # FIT digitizer settings
     #2023 pp
     if 534125 <= int(args.run) and int(args.run) <= 543113:
-        add(config, {"FV0DigParam.adcChannelsPerMip": "15"})
         if COLTYPEIR == "pp":
            # central and semicentral FT0 thresholds 
            add(config, {"FT0DigParam.mtrg_central_trh": "40", "FT0DigParam.mtrg_semicentral_trh": "20"})


### PR DESCRIPTION
This PR updates the FIT digitizer configuration in O2DPG for Run 3 data-taking periods in 2023 and 2024.

The changes add period-dependent FIT settings for:

Pb–Pb data from 2023,
pp data from 2023,
Pb–Pb data from 2024,
pp data from 2024.

In particular, the PR introduces updated FT0 central and semicentral trigger thresholds and FV0 trigger parameters for the corresponding run ranges and collision systems.