### PR TITLE
Add diffraction-tuned pythia8 inel generator

### DIFF
--- a/MC/config/common/ini/pythia8_inel_difftuned.ini
+++ b/MC/config/common/ini/pythia8_inel_difftuned.ini
@@ -1,0 +1,2 @@
+[GeneratorPythia8]
+config=${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg

--- a/MC/config/common/ini/tests/pythia8_inel_difftuned.C
+++ b/MC/config/common/ini/tests/pythia8_inel_difftuned.C
@@ -1,0 +1,24 @@
+int External() {
+  std::string path{"o2sim_Kine.root"};
+
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie()) {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree) {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  auto nEvents = tree->GetEntries();
+  if (nEvents == 0) {
+    std::cerr << "No event of interest\n";
+    return 1;
+  }
+  return 0;
+}

--- a/MC/config/common/ini/tests/pythia8_inel_difftuned.C
+++ b/MC/config/common/ini/tests/pythia8_inel_difftuned.C
@@ -1,4 +1,4 @@
-int External() {
+int pythia8() {
   std::string path{"o2sim_Kine.root"};
 
   TFile file(path.c_str(), "READ");

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -19,6 +19,7 @@ SigmaTotal:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTotal 78.6
 SigmaTotal:sigmaElastic 0.0
-SigmaDiffractive:sigmaSD 21.25
-SigmaDiffractive:sigmaDD 9.78
-SigmaDiffractive:sigmaCD 0.0
+SigmaDiffractive:sigmaXB 10,625
+SigmaDiffractive:sigmaAX 10,625
+SigmaDiffractive:sigmaXX 9.78
+SigmaDiffractive:sigmaAXB 0.0

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -1,0 +1,26 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 14000. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.	
+
+### adjust diffraction
+### note that PYTHIA calculates the ND sigma via a
+### 'remaining from total' formula: no need to put
+### that in by hand
+
+SigmaTotal:mode 0
+SigmaDiffractive:mode 0
+SigmaTotal:sigmaTotal 78.6
+SigmaTotal:sigmaElastic 0.0
+SigmaDiffractive:sigmaSD 21.25
+SigmaDiffractive:sigmaDD 9.78
+SigmaDiffractive:sigmaCD 0.0
+
+

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -15,7 +15,7 @@ ParticleDecays:tau0Max 10.
 ### 'remaining from total' formula: no need to put
 ### that in by hand
 
-SigmaTotal:mode 0
+SigmaTot:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTotal 78.6
 SigmaTotal:sigmaElastic 0.0

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -15,7 +15,7 @@ ParticleDecays:tau0Max 10.
 ### 'remaining from total' formula: no need to put
 ### that in by hand
 
-SigmaTot:mode 0
+SigmaTotal:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTot 78.6
 SigmaTotal:sigmaEl 0.0

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -22,5 +22,3 @@ SigmaTotal:sigmaElastic 0.0
 SigmaDiffractive:sigmaSD 21.25
 SigmaDiffractive:sigmaDD 9.78
 SigmaDiffractive:sigmaCD 0.0
-
-

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -17,7 +17,7 @@ ParticleDecays:tau0Max 10.
 
 SigmaTot:mode 0
 SigmaDiffractive:mode 0
-SigmaTotal:sigmaTotal 78.6
+SigmaTotal:sigmaTot 78.6
 SigmaTotal:sigmaEl 0.0
 SigmaTotal:sigmaXB 10.625
 SigmaTotal:sigmaAX 10.625

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -19,7 +19,7 @@ SigmaTotal:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTotal 78.6
 SigmaTotal:sigmaElastic 0.0
-SigmaDiffractive:sigmaXB 10,625
-SigmaDiffractive:sigmaAX 10,625
+SigmaDiffractive:sigmaXB 10.625
+SigmaDiffractive:sigmaAX 10.625
 SigmaDiffractive:sigmaXX 9.78
 SigmaDiffractive:sigmaAXB 0.0

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -18,7 +18,7 @@ ParticleDecays:tau0Max 10.
 SigmaTot:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTotal 78.6
-SigmaTotal:sigmaElastic 0.0
+SigmaTotal:sigmaEl 0.0
 SigmaTotal:sigmaXB 10.625
 SigmaTotal:sigmaAX 10.625
 SigmaTotal:sigmaXX 9.78

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -1,7 +1,7 @@
 ### beams
 Beams:idA 2212			# proton
 Beams:idB 2212 			# proton
-Beams:eCM 14000. 		# GeV
+Beams:eCM 13600. 		# GeV
 
 ### processes
 SoftQCD:inelastic on		# all inelastic processes

--- a/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
+++ b/MC/config/common/pythia8/generator/pythia8_inel_difftuned.cfg
@@ -19,7 +19,7 @@ SigmaTotal:mode 0
 SigmaDiffractive:mode 0
 SigmaTotal:sigmaTotal 78.6
 SigmaTotal:sigmaElastic 0.0
-SigmaDiffractive:sigmaXB 10.625
-SigmaDiffractive:sigmaAX 10.625
-SigmaDiffractive:sigmaXX 9.78
-SigmaDiffractive:sigmaAXB 0.0
+SigmaTotal:sigmaXB 10.625
+SigmaTotal:sigmaAX 10.625
+SigmaTotal:sigmaXX 9.78
+SigmaTotal:sigmaAXB 0.0


### PR DESCRIPTION
This PR adds PYTHIA8 settings in which the single / double / non-diffractive components of inelastic pp events have their relative abundances tuned to match the corresponding fractions obtained previously from 7 TeV data. More details can be found in the JIRA ticket [PWDUD-65](https://its.cern.ch/jira/browse/PWGUD-65); thanks also to @romainschotter for testing this configuration prior to opening the PR and helping me fix some minor issues.

Once merged, it would be good to proceed to a full reconstruction test to calculate a revised trigger efficiency. Given the increased diffractive component, it's likely that the trigger efficiency will go down - if all goes well, it should be much closer to the one obtained in the pp 13.6 TeV vdM analysis. 