### PR TITLE
PWGDQ: add PbPb Bottomonia gap-trigger generator case

### DIFF
--- a/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedBottomoniaSignals_gaptriggered_dq.C
+++ b/MC/config/PWGDQ/external/generator/generator_pythia8_withInjectedBottomoniaSignals_gaptriggered_dq.C
@@ -24,6 +24,9 @@ public:
       case 0: // generate bottomonia cocktail at forward rapidity
         mGeneratorParam = (Generator*)GeneratorCocktailBottomoniaToMuonEvtGen_pp13TeV(); 
         break;
+      case 1: // generate bottomonia cocktail at FwdY for PbPb 5p36TeV
+        mGeneratorParam = (Generator*)GeneratorCocktailBottomoniaToMuonEvtGen_PbPb5TeV();
+        break;
     }
     mGeneratorParam->Init();  
   }


### PR DESCRIPTION
Add a new generator case for injected Bottomonia gap-triggered PbPb production.

This PR adds:
- case 1 in generator_pythia8_withInjectedBottomoniaSignals_gaptriggered_dq.C
- support for GeneratorCocktailBottomoniaToMuonEvtGen_PbPb5TeV()