### PR TITLE
Make the non-prompt injection ratio configurable and fix EvtGen decay definitions

### DIFF
--- a/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSIJPSITODIELECTRON.DEC
+++ b/MC/config/PWGDQ/EvtGen/DecayTablesEvtgen/BTOPSIJPSITODIELECTRON.DEC
@@ -13,7 +13,7 @@ Decay B0
 0.0001     psi(2S)  K+  pi-  pi0     PHSP;
 0.0004     psi(2S)  K_10              PHSP;
 ###
-0.000620000 psi(2S) K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000620000 psi(2S) K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
 
 0.000435500 J/psi   K_S0                                    SVS; #[Reconstructed PDG2011]
 0.000435500 J/psi   K_L0                                    SVS; #[Reconstructed PDG2011]
@@ -30,7 +30,7 @@ Decay B0
 0.0005     J/psi  K_2*0              PHSP;
 0.000094000 J/psi   phi     K0                              PHSP; #[Reconstructed PDG2011]
 ####
-0.000871000 J/psi   K0                                      PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000871000 J/psi   K0                                      SVS;  #[New mode added] #[Reconstructed PDG2011]
 0.000310000 J/psi   omega   K0                              PHSP;  #[New mode added] #[Reconstructed PDG2011]
 0.000009500 J/psi   eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
 0.000019000 J/psi   pi+     pi-                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
@@ -40,15 +40,15 @@ Decay B0
 0.000660000 J/psi   K*0     pi+     pi-                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
 
 # --- chi_c1 ---
-  0.000011200   chi_c1   pi0              SVS;
+  0.000011200   chi_c1   pi0              PHSP;
   0.000395000   chi_c1   K0               SVS;
   0.000497000   chi_c1   K+   pi-         PHSP;
   0.000320000   chi_c1   K0   pi+  pi-    PHSP;
   0.000350000   chi_c1   K+   pi0  pi-    PHSP;
 
 # --- chi_c2 ---
-  0.000015000   chi_c2   K0               SVS;
-  0.000049000   chi_c2   K*0              SVV_HELAMP 1.0 0.0 0.0;
+  0.000015000   chi_c2   K0               STS;
+  0.000049000   chi_c2   K*0              PHSP;
   0.000072000   chi_c2   K+   pi-         PHSP;
   0.000174000   chi_c2   pi+  pi-  K0     PHSP;
   0.000074000   chi_c2   pi-  pi0  K+     PHSP;
@@ -67,7 +67,7 @@ Decay anti-B0
 0.0001     psi(2S)  K-  pi+  pi0     PHSP;
 0.0004     psi(2S)  anti-K_10              PHSP;
 ###
-0.000620000 psi(2S) anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000620000 psi(2S) anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
 
 0.000435500 J/psi   K_S0                                    SVS; #[Reconstructed PDG2011]
 0.000435500 J/psi   K_L0                                    SVS; #[Reconstructed PDG2011]
@@ -84,7 +84,7 @@ Decay anti-B0
 0.0005     J/psi  anti-K_2*0              PHSP;
 0.000094000 J/psi   phi     anti-K0                         PHSP; #[Reconstructed PDG2011]
 ###
-0.000871000 J/psi   anti-K0                                 PHSP;  #[New mode added] #[Reconstructed PDG2011]
+0.000871000 J/psi   anti-K0                                 SVS;  #[New mode added] #[Reconstructed PDG2011]
 0.000310000 J/psi   omega   anti-K0                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
 0.000009500 J/psi   eta                                     PHSP;  #[New mode added] #[Reconstructed PDG2011]
 0.000019000 J/psi   pi-     pi+                             PHSP;  #[New mode added] #[Reconstructed PDG2011]
@@ -94,15 +94,15 @@ Decay anti-B0
 0.000660000 J/psi   anti-K*0 pi-     pi+                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
 
 # --- chi_c1 ---
-  0.000011200   chi_c1   pi0              SVS;
+  0.000011200   chi_c1   pi0              PHSP;
   0.000395000   chi_c1   anti-K0          SVS;
   0.000497000   chi_c1   K-   pi+         PHSP;
   0.000320000   chi_c1   anti-K0 pi- pi+  PHSP;
   0.000350000   chi_c1   K-   pi0  pi+    PHSP;
 
 # --- chi_c2 ---
-  0.000015000   chi_c2   anti-K0          SVS;
-  0.000049000   chi_c2   anti-K*0         SVV_HELAMP 1.0 0.0 0.0;
+  0.000015000   chi_c2   anti-K0          STS;
+  0.000049000   chi_c2   anti-K*0         PHSP;
   0.000072000   chi_c2   K-   pi+         PHSP;
   0.000174000   chi_c2   pi-  pi+ anti-K0 PHSP;
   0.000074000   chi_c2   pi+  pi0  K-     PHSP;
@@ -139,16 +139,16 @@ Decay B+
 0.000011800 J/psi   p+      anti-Lambda0                    PHSP;  #[New mode added] #[Reconstructed PDG2011]
 
 # --- chi_c1 ---
-  0.000022000   chi_c1   pi+              SVS;
+  0.000022000   chi_c1   pi+              PHSP;
   0.000474000   chi_c1   K+               SVS;
-  0.000300000   chi_c1   K*+              SVV_HELAMP 1.0 0.0 0.0;
+  0.000300000   chi_c1   K*+              SVV_HELAMP PKHplus PKphHplus PKHzero PKphHzero PKHminus PKphHminus;
   0.000329000   chi_c1   K+   pi0         PHSP;
   0.000580000   chi_c1   K0   pi+         PHSP;
   0.000374000   chi_c1   K+   pi+  pi-    PHSP;
 
 # --- chi_c2 ---
-  0.000110000   chi_c2   K+               SVS;
-  0.000120000   chi_c2   K*+              SVV_HELAMP 1.0 0.0 0.0;
+  0.000110000   chi_c2   K+               STS;
+  0.000120000   chi_c2   K*+              PHSP;
   0.000062000   chi_c2   K+   pi0         PHSP;
   0.000124000   chi_c2   K0   pi+         PHSP;
   0.000134000   chi_c2   K+   pi+  pi-    PHSP;
@@ -184,16 +184,16 @@ Decay B-
 0.000011800 J/psi   anti-p- Lambda0                         PHSP;  #[New mode added] #[Reconstructed PDG2011]
 
 # --- chi_c1 ---
-  0.000022000   chi_c1   pi-              SVS;
+  0.000022000   chi_c1   pi-              PHSP;
   0.000474000   chi_c1   K-               SVS;
-  0.000300000   chi_c1   K*-              SVV_HELAMP 1.0 0.0 0.0;
+  0.000300000   chi_c1   K*-              SVV_HELAMP PKHminus PKphHminus PKHzero PKphHzero PKHplus PKphHplus;
   0.000329000   chi_c1   K-   pi0         PHSP;
   0.000580000   chi_c1   anti-K0 pi-      PHSP;
   0.000374000   chi_c1   K-   pi-  pi+    PHSP;
 
 # --- chi_c2 ---
-  0.000110000   chi_c2   K-               SVS;
-  0.000120000   chi_c2   K*-              SVV_HELAMP 1.0 0.0 0.0;
+  0.000110000   chi_c2   K-               STS;
+  0.000120000   chi_c2   K*-              PHSP;
   0.000062000   chi_c2   K-   pi0         PHSP;
   0.000124000   chi_c2   anti-K0 pi-      PHSP;
   0.000134000   chi_c2   K-   pi-  pi+    PHSP;
@@ -242,7 +242,7 @@ Decay B_s0
 0.0000023   phi    e+     e-                   BTOSLLALI;
 
 # --- chi_c1 ---
-  0.0001970   chi_c1   phi   SVV_HELAMP 1.0 0.0 0.0;
+  0.0001970   chi_c1   phi   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
 Enddecay
 
 Decay anti-B_s0
@@ -287,27 +287,27 @@ Decay anti-B_s0
 0.0000023   phi    e-     e+                   BTOSLLALI;
 
 # --- chi_c1 ---
-  0.0001970   chi_c1   phi   SVV_HELAMP 1.0 0.0 0.0;
+  0.0001970   chi_c1   phi   SVV_HELAMP 1.0 0.0 1.0 0.0 1.0 0.0;
 Enddecay
 
 Decay Lambda_b0
 ###
 0.00038    Lambda0         psi(2S)                      PHSP;
 0.00047    Lambda0         J/psi                        PHSP;
-  0.0000760   chi_c1   p       K-      PHSP;
-  0.0000050   chi_c1   p       pi-     PHSP;
-  0.0000770   chi_c2   p       K-      PHSP;
-  0.0000048   chi_c2   p       pi-     PHSP;
+  0.0000760   chi_c1   p+       K-      PHSP;
+  0.0000050   chi_c1   p+       pi-     PHSP;
+  0.0000770   chi_c2   p+       K-      PHSP;
+  0.0000048   chi_c2   p+       pi-     PHSP;
 Enddecay
 
 Decay anti-Lambda_b0
 ###
 0.00038    anti-Lambda0    psi(2S)                      PHSP;
 0.00047    anti-Lambda0    J/psi                        PHSP;
-  0.0000760   chi_c1   anti-p  K+      PHSP;
-  0.0000050   chi_c1   anti-p  pi+     PHSP;
-  0.0000770   chi_c2   anti-p  K+      PHSP;
-  0.0000048   chi_c2   anti-p  pi+     PHSP;
+  0.0000760   chi_c1   anti-p-  K+      PHSP;
+  0.0000050   chi_c1   anti-p-  pi+     PHSP;
+  0.0000770   chi_c2   anti-p-  K+      PHSP;
+  0.0000048   chi_c2   anti-p-  pi+     PHSP;
 Enddecay
 
 Decay Xi_b-

--- a/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_OO_gaptriggered_dq.C
+++ b/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_OO_gaptriggered_dq.C
@@ -23,8 +23,32 @@ public:
 
     mGeneratedEvents = 0;
     mInverseTriggerRatio = inputTriggerRatio; 
+
+  // Read INPUT_TRIGGER_RATIO from the shell environment.
+  // If it is not defined, keep the default constructor value.
+  const char* envTriggerRatio = gSystem->Getenv("INPUT_TRIGGER_RATIO");
+
+  if (envTriggerRatio && envTriggerRatio[0] != '\0') {
+    const int valueFromEnv = TString(envTriggerRatio).Atoi();
+
+    if (valueFromEnv > 0) {
+      inputTriggerRatio = valueFromEnv;
+    } else {
+      printf(
+        "WARNING: invalid INPUT_TRIGGER_RATIO=%s, using default value %d\n",
+        envTriggerRatio,
+        inputTriggerRatio);
+    }
+  }
+
+  mGeneratedEvents = 0;
+  mInverseTriggerRatio = inputTriggerRatio;
+
+  printf("Input trigger ratio: %d\n", mInverseTriggerRatio);
+
     // define minimum bias event generator
     auto seed = (gRandom->TRandom::GetSeed() % 900000000);
+
     TString pathconfigMB = gSystem->ExpandPathName("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_OO_536.cfg");
     pythiaMBgen.readFile(pathconfigMB.Data());
     pythiaMBgen.readString("Random:setSeed on");

--- a/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_OO_gaptriggered_dq.C
+++ b/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_OO_gaptriggered_dq.C
@@ -19,7 +19,7 @@ class GeneratorPythia8NonPromptInjectedOOGapTriggeredDQ : public o2::eventgen::G
 public:
   
   /// constructor
-  GeneratorPythia8NonPromptInjectedOOGapTriggeredDQ(int inputTriggerRatio = 5)  {
+  GeneratorPythia8NonPromptInjectedOOGapTriggeredDQ(int inputTriggerRatio = 2)  {
 
     mGeneratedEvents = 0;
     mInverseTriggerRatio = inputTriggerRatio; 


### PR DESCRIPTION
This PR updates the non-prompt gap-triggered generator configuration and fixes inconsistent EvtGen decay definitions.
The changes include:
- set the default input trigger ratio to 2;
- allow overriding the ratio through the `INPUT_TRIGGER_RATIO` environment variable;
- fall back to the default value when the environment variable is unset or invalid;
- fix inconsistent decay models in `BTOPSIJPSITODIELECTRON.DEC` following the standard `DECAY.DEC`;
- fix missing `SVV_HELAMP` arguments and incorrect EvtGen particle names.
The updated generator and decay table were tested successfully with local event generation.