### PR TITLE
Make the non-prompt injection ratio configurable also for p-O

### DIFF
--- a/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_pO_gaptriggered_dq.C
+++ b/MC/config/PWGDQ/external/generator/generator_pythia8_NonPromptSignals_pO_gaptriggered_dq.C
@@ -19,10 +19,33 @@ class GeneratorPythia8NonPromptInjectedpOGapTriggeredDQ : public o2::eventgen::G
 public:
   
   /// constructor
-  GeneratorPythia8NonPromptInjectedpOGapTriggeredDQ(int inputTriggerRatio = 5)  {
+  GeneratorPythia8NonPromptInjectedpOGapTriggeredDQ(int inputTriggerRatio = 2)  {
 
     mGeneratedEvents = 0;
-    mInverseTriggerRatio = inputTriggerRatio; 
+    mInverseTriggerRatio = inputTriggerRatio;
+
+	// Read INPUT_TRIGGER_RATIO from the shell environment.
+	// If it is not defined, keep the default constructor value.
+  	const char* envTriggerRatio = gSystem->Getenv("INPUT_TRIGGER_RATIO");
+
+  	if (envTriggerRatio && envTriggerRatio[0] != '\0') {
+    	const int valueFromEnv = TString(envTriggerRatio).Atoi();
+
+    	if (valueFromEnv > 0) {
+      	inputTriggerRatio = valueFromEnv;
+    	} else {
+      	printf(
+        	"WARNING: invalid INPUT_TRIGGER_RATIO=%s, using default value %d\n",
+        	envTriggerRatio,
+        	inputTriggerRatio);
+    	}
+  	}
+
+  	mGeneratedEvents = 0;
+  	mInverseTriggerRatio = inputTriggerRatio;
+
+  	printf("Input trigger ratio: %d\n", mInverseTriggerRatio);
+
     // define minimum bias event generator
     auto seed = (gRandom->TRandom::GetSeed() % 900000000);
     TString pathconfigMB = gSystem->ExpandPathName("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/pythia8/generator/pythia8_pO_961.cfg");


### PR DESCRIPTION
Following the commit for O-O (see https://github.com/AliceO2Group/O2DPG/commit/c53f5cd07020a69d7dc61c8774573481d00aeea2) from donglovo, the non-prompt injection ratio has now also made configurable for the p-O case.

I copy here below the description from the commit above, as this one is identical:

* Set the non-prompt injection ratio to 2

Change the default injection ratio from 5 to 2 for the non-prompt gap-triggered generators, corresponding to one injected signal event every two generated events.

* Allow input trigger ratio configuration via environment variable

Read INPUT_TRIGGER_RATIO from the environment and use it to override the default input trigger ratio. Fall back to the constructor default when the variable is unset or invalid.