### PR TITLE
Disable CTP lumi in TPC reco if not active

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -1341,7 +1341,10 @@ for tf in range(1, NTIMEFRAMES + 1):
       anchor_corrmaplumi_mode = '--corrmap-lumi-mode ' + anchor_corrmaplumi_mode
    
    tpc_corr_scaling_options = anchor_lumi_type + ' ' + anchor_corrmaplumi_mode
-   
+   if not isActive('CTP'):
+      # CTP digits won't be produced for this timeframe (CTP not in the readout detector list)
+      tpc_corr_scaling_options += ' --disable-ctp-lumi-request'
+
    # why not simply?
    # tpc_corr_scaling_options = ('--lumi-type 1', '')[tpcDistortionType != 0]
 


### PR DESCRIPTION
Just a possible easy solution to the issue reported in O2-7050, however more work is probably required.