### PR TITLE
Fix seg fault caused by stale particle indices after coalescence from HF decays

### DIFF
--- a/MC/config/common/external/generator/CoalescencePythia8.h
+++ b/MC/config/common/external/generator/CoalescencePythia8.h
@@ -152,6 +152,9 @@ bool CoalescencePythia8(Pythia8::Event& event, std::vector<unsigned int> inputPd
       for (int iN{0}; iN < neutrons[iC].size(); ++iN) {
         if (nuclearMask & (1 << kDeuteron)) {
           coalHappened |= doCoal(event, iC, pdgList[kDeuteron], massList[kDeuteron], trivialCoal, coalescenceRadius, nuclFromDecay, protons[iC][iP], neutrons[iC][iN]);
+          if (nuclFromDecay && coalHappened) {
+            return true;
+          }
         }
         if (nuclearMask & (1 << kTriton)) {
           for (int iN2{iN + 1}; iN2 < neutrons[iC].size(); ++iN2) {

--- a/MC/config/common/external/generator/CoalescencePythia8.h
+++ b/MC/config/common/external/generator/CoalescencePythia8.h
@@ -107,6 +107,7 @@ bool doCoal(Pythia8::Event& event, int charge, int pdgCode, float mass, bool tri
 bool CoalescencePythia8(Pythia8::Event& event, std::vector<unsigned int> inputPdgList = {}, bool trivialCoal = false, double coalMomentum = 0.4, int firstDauID = -1, int lastDauId = -1, float maxRapidity = 1.)
 {
   const double coalescenceRadius{0.5 * 1.122462 * coalMomentum};
+
   // if coalescence from a heavy hadron, loop only between firstDauID and lastDauID
   int loopStart = firstDauID > -1 ? firstDauID : 0;
   int loopEnd = lastDauId > -1 ? lastDauId : event.size() - 1;

--- a/MC/config/common/external/generator/CoalescencePythia8.h
+++ b/MC/config/common/external/generator/CoalescencePythia8.h
@@ -144,7 +144,7 @@ bool CoalescencePythia8(Pythia8::Event& event, std::vector<unsigned int> inputPd
       lambdas[event[iPart].id() > 0].push_back(iPart);
     }
   }
-  // run coalescence
+  // Run coalescence
   bool nuclFromDecay = firstDauID > -1;
   bool coalHappened = false;
 

--- a/MC/config/common/external/generator/CoalescencePythia8.h
+++ b/MC/config/common/external/generator/CoalescencePythia8.h
@@ -159,22 +159,34 @@ bool CoalescencePythia8(Pythia8::Event& event, std::vector<unsigned int> inputPd
         if (nuclearMask & (1 << kTriton)) {
           for (int iN2{iN + 1}; iN2 < neutrons[iC].size(); ++iN2) {
             coalHappened |= doCoal(event, iC, pdgList[kTriton], massList[kTriton], trivialCoal, coalescenceRadius, nuclFromDecay, protons[iC][iP], neutrons[iC][iN], neutrons[iC][iN2]);
+            if (nuclFromDecay && coalHappened) {
+              return true;
+            }
           }
         }
         if (nuclearMask & (1 << kHe3)) {
           for (int iP2{iP + 1}; iP2 < protons[iC].size(); ++iP2) {
             coalHappened |= doCoal(event, iC, pdgList[kHe3], massList[kHe3], trivialCoal, coalescenceRadius, nuclFromDecay, protons[iC][iP], protons[iC][iP2], neutrons[iC][iN]);
+            if (nuclFromDecay && coalHappened) {
+              return true;
+            }
           }
         }
         if (nuclearMask & (1 << kHyperTriton)) {
           for (int iL{0}; iL < lambdas[iC].size(); ++iL) {
             coalHappened |= doCoal(event, iC, pdgList[kHyperTriton], massList[kHyperTriton], trivialCoal, coalescenceRadius, nuclFromDecay, protons[iC][iP], neutrons[iC][iN], lambdas[iC][iL]);
+            if (nuclFromDecay && coalHappened) {
+              return true;
+            }
           }
         }
         if (nuclearMask & (1 << kHe4)) {
           for (int iP2{iP + 1}; iP2 < protons[iC].size(); ++iP2) {
             for (int iN2{iN + 1}; iN2 < neutrons[iC].size(); ++iN2) {
               coalHappened |= doCoal(event, iC, pdgList[kHe4], massList[kHe4], trivialCoal, coalescenceRadius, nuclFromDecay, protons[iC][iP], protons[iC][iP2], neutrons[iC][iN], neutrons[iC][iN2]);
+              if (nuclFromDecay && coalHappened) {
+                return true;
+              }
             }
           }
         }


### PR DESCRIPTION
Fix a segmentation fault in the coalescence afterburner by returning immediately after successful coalescence in a heavy-hadron decay. When coalescence occurs, one or more nucleons are removed from the event, invalidating the stored particle indices. If the loops continue, the code may attempt to access an invalid index and crash.

This PR proposes a minimal fix for the analysis of deuterons from Λb decays, but the same fix should probably be applied to all occurrences.

@fgrosa , @MRazza879 