### PR TITLE
Patches to allow storing ConfiParam jsons in the AOD metadata

### DIFF
--- a/DATA/common/getCommonArgs.sh
+++ b/DATA/common/getCommonArgs.sh
@@ -10,16 +10,18 @@ if [[ -z $SEVERITY || -z $NUMAID || -z $SHMSIZE || -z $FILEWORKDIR || -z $EPNSYN
 fi
 
 ARGS_ALL="--session ${OVERRIDE_SESSION:-default} --severity $SEVERITY --shm-segment-id ${O2JOBSHMID:-$NUMAID} --shm-segment-size $SHMSIZE ${ARGS_ALL_EXTRA:-} --early-forward-policy noraw"
-ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;keyval.output_dir=/dev/null;${ALL_EXTRA_CONFIG:-}"
+ARGS_ALL_CONFIG="keyval.input_dir=$FILEWORKDIR;"
 if [[ $EPNSYNCMODE == 1 ]]; then
   ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
   ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring ${GEN_TOPO_RESOURCE_MONITORING:-15} ${GEN_TOPO_RESOURCE_MONITORING:+--dpl-stats-min-online-publishing-interval $GEN_TOPO_RESOURCE_MONITORING}"
-  ARGS_ALL_CONFIG+="NameConf.mCCDBServer=$GEN_TOPO_EPN_CCDB_SERVER;"
+  ARGS_ALL_CONFIG+="keyval.output_dir=/dev/null;NameConf.mCCDBServer=$GEN_TOPO_EPN_CCDB_SERVER;"
   export DPL_CONDITION_BACKEND=$GEN_TOPO_EPN_CCDB_SERVER
   [[ -z ${O2_DPL_DEPLOYMENT_MODE:-} ]] && O2_DPL_DEPLOYMENT_MODE=OnlineECS
 elif [[ "${ENABLE_METRICS:-}" != "1" ]]; then
   ARGS_ALL+=" --monitoring-backend no-op://"
 fi
+ARGS_ALL_CONFIG+="${ALL_EXTRA_CONFIG:-}"
+
 [[ $SHMTHROW == 0 ]] && ARGS_ALL+=" --bad-alloc-max-attempts 60 --bad-alloc-attempt-interval 1000"
 [[ ! -z ${SHM_MANAGER_SHMID:-} && ${GEN_TOPO_CALIB_WORKFLOW:-} != 1 ]] && ARGS_ALL+=" --no-cleanup --shm-no-cleanup on --shmid $SHM_MANAGER_SHMID"
 [[ $NORATELOG == 1 ]] && ARGS_ALL+=" --fairmq-rate-logging 0"

--- a/DATA/production/configurations/asyncReco/setenv_extra.sh
+++ b/DATA/production/configurations/asyncReco/setenv_extra.sh
@@ -540,7 +540,6 @@ elif [[ $ALIGNLEVEL == 1 ]]; then
   TRACKTUNETPCINNER="trackTuneParams.tpcCovInnerType=2;trackTuneParams.tpcCovInner[0]=0.05;trackTuneParams.tpcCovInner[1]=0.2;trackTuneParams.tpcCovInner[2]=0.0003;trackTuneParams.tpcCovInner[3]=0.0013;trackTuneParams.tpcCovInner[4]=0.0059300284;trackTuneParams.tpcCovInnerSlope[0]=1.4794650254467986e-08;trackTuneParams.tpcCovInnerSlope[1]=5.9178601017871944e-08;trackTuneParams.tpcCovInnerSlope[2]=8.87679015268079e-11;trackTuneParams.tpcCovInnerSlope[3]=3.846609066161676e-10;trackTuneParams.tpcCovInnerSlope[4]=1.7546539235412473e-09;"
   TRACKTUNETPCOUTER="trackTuneParams.tpcCovOuterType=2;trackTuneParams.tpcCovOuter[0]=0.05;trackTuneParams.tpcCovOuter[1]=0.2;trackTuneParams.tpcCovOuter[2]=0.0003;trackTuneParams.tpcCovOuter[3]=0.0013;trackTuneParams.tpcCovOuter[4]=0.0059300284;trackTuneParams.tpcCovOuterSlope[0]=1.4794650254467986e-08;trackTuneParams.tpcCovOuterSlope[1]=5.9178601017871944e-08;trackTuneParams.tpcCovOuterSlope[2]=8.87679015268079e-11;trackTuneParams.tpcCovOuterSlope[3]=3.846609066161676e-10;trackTuneParams.tpcCovOuterSlope[4]=1.7546539235412473e-09;"
 
-
 fi
 
 TRACKTUNETPC=${TPCEXTRAERR-}
@@ -844,6 +843,11 @@ fi
 if [[ $ALIEN_JDL_PREPROPAGATE == "1" ]] ; then
   export ARGS_EXTRA_PROCESS_o2_aod_producer_workflow+=" --propagate-tracks --propagate-tracks-max-xiu 5"
 fi
+
+if [[ $ALIEN_JDL_CONFIG2AODMETA == "1" ]] ; then
+  export ARGS_EXTRA_PROCESS_o2_aod_producer_workflow+=" --collect-config-files"
+fi
+
 
 # possibility to bias the MeanVertex from the CCDB, see https://github.com/AliceO2Group/AliceO2/pull/15549
 if [[ -n $ALIEN_JDL_MVBIAS ]]; then


### PR DESCRIPTION
Goes with https://github.com/AliceO2Group/AliceO2/pull/15645

Disable ConfigParam outputs only in EPNSYNC mode.

JDL option to force AODProducer to collect ConfigParam jsons: CONFIG2AODMETA = "1";