### PR TITLE
Fix Xic- name used in geant4 configuration

### DIFF
--- a/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
+++ b/MC/config/PWGHF/pythia8/decayer/geant4_externaldecayer_charmbaryon.in
@@ -65,4 +65,4 @@
 /mcPhysics/biasing/setParticles proton neutron pi+ pi-
 
 # external decayer
-/mcPhysics/setExtDecayerSelection omega_c0 anti_omega_c0 xi_c0 anti_xi_c0 xi_c+ xi_c-
+/mcPhysics/setExtDecayerSelection omega_c0 anti_omega_c0 xi_c0 anti_xi_c0 xi_c+ anti_xi_c+


### PR DESCRIPTION
Xic- particles were not being properly decayed in Geant4 because `xi_c-` does not correspond to any particle name in the Geant4 particle table

Tagging @gluparel, @xinyepeng, @stefanopolitano, and @wuctlby since also the charm baryon MC anchored to pp ref is affected