### PR TITLE
Let learned resource estimates replace dynamic sampling in anchorMC

### DIFF
--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -59,6 +59,8 @@ print_help()
   echo "ALIEN_JDL_RUN_TIME_SPAN_FILE=FILE, use a run-time-span file to exclude bad data-taking periods"
   echo "ALIEN_JDL_INVERT_IRFRAME_SELECTION, invertes the choice of ALIEN_JDL_RUN_TIME_SPAN_FILE"
   echo "ALIEN_JDL_CCDB_CONDITION_NOT_AFTER, sets the condition_not_after timestamp for CCDB queries"
+  echo "ALIEN_O2DPG_FILEGRAPH=FILE, delete intermediate files early, using a FileIOGraph report"
+  echo "ALIEN_O2DPG_RESOURCES=FILE, use resource estimates learned by a pilot run instead of sampling them"
   echo "DISABLE_QC, set this to disable QC, e.g. to 1"
   echo "CYCLE, to set a cycle number different than 0"
   echo "NSIGEVENTS, to enforce a specific upper limit of events in a timeframe (not counting orbit-early) events"
@@ -430,8 +432,15 @@ else
 fi
 echo_info "Workflow will run with target specification ${targetString}"
 
+# resource estimates learned by a pilot run (o2dpg_sim_metrics.py json-stat)
+# replace the runtime sampling; without them we sample dynamically as before
+RESOURCE_ARGS="--dynamic-resources"
+if [ -n "${ALIEN_O2DPG_RESOURCES}" ]; then
+  RESOURCE_ARGS="--update-resources ${ALIEN_O2DPG_RESOURCES}"
+fi
+
 ${O2DPG_ROOT}/MC/bin/o2_dpg_workflow_runner.py -f workflow.json -tt ${targetString}                                    \
-                                               --cpu-limit ${ALIEN_JDL_CPULIMIT:-8} --dynamic-resources                \
+                                               --cpu-limit ${ALIEN_JDL_CPULIMIT:-8} ${RESOURCE_ARGS}                     \
                                                ${ALIEN_O2DPG_FILEGRAPH:+--remove-files-early ${ALIEN_O2DPG_FILEGRAPH}} \
                                                ${ALIEN_O2DPG_ADDITIONAL_WORKFLOW_RUNNER_ARGS}
 


### PR DESCRIPTION
`anchorMC.sh` passes `--dynamic-resources` unconditionally, so resource estimates learned by a pilot job could only ever be *added on top of* runtime sampling, never used instead of it. This adds an `ALIEN_O2DPG_RESOURCES` hook, mirroring the existing `ALIEN_O2DPG_FILEGRAPH` one.

When the variable names a file, `--update-resources <file>` is passed and `--dynamic-resources` is not. Without it the invocation is byte-for-byte what it was.

The file is the `json-stat` output of `MC/utils/o2dpg_sim_metrics.py`:

```bash
o2dpg_sim_metrics.py json-stat -p pipeline_metric_<pid>.log -o learned.json -w workflow.json
export ALIEN_O2DPG_RESOURCES=${PWD}/learned.json
```

### Tested on the GRID

Nine anchored jobs (2024 pp `apass1`, run 553185, 2 TF) pinned to `ALICE::CERN::CERN-SIRIUS`, in three arms of three: legacy runner with dynamic sampling, new runner with dynamic sampling, and new runner with learned estimates plus early file removal. All nine returned `ANCHORMC_RC=0`.

With the hook set, the runner logs the injection actually taking effect — 74 MEM, 74 CPU and 46 walltime overrides, replacing the workflow's placeholder defaults:

```
INFO Applying learned resource estimates from: /workdir/learned.json
INFO   MEM  geomprefetch    500.0 MB -> 1203.3 MB
INFO   CPU  geomprefetch    0.000 cores -> 0.892 cores
```

Walltime could not distinguish the arms: the within-arm spread (617–1887 s in one arm at fixed `SPLITID` on one CE) is far larger than any difference between arm means (1041 / 1106 / 916 s). That is a statement about GRID variance, not about this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)