### PR TITLE
Give the QED interaction spec the size of the QED event pool

### DIFF
--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -659,7 +659,11 @@ if includeQED:
       includeQED = False
    else:
       qedrate = INTRATE * QEDXSecExpected[COLTYPE] / XSecSys[COLTYPE]   # hadronic interaction rate * cross_section_ratio
-      qedspec = 'qed' + ',' + str(qedrate) + ',10000000:' + str(NEventsQED)
+      # the QED events are reused in a round robin, so both numbers are the size of the QED pool.
+      # Older O2 versions wrap the QED event IDs at the first number instead of the second one and
+      # would otherwise put event IDs into the MC labels which are not in the QED kinematics.
+      # See https://its.cern.ch/jira/browse/O2-7132
+      qedspec = 'qed' + ',' + str(qedrate) + ',' + str(NEventsQED) + ':' + str(NEventsQED)
 
 PreCollContextTask['cmd'] = task_finalizer([
       '${O2_ROOT}/bin/o2-steer-colcontexttool',


### PR DESCRIPTION
This fixes a problem in the QED specification handed to the collision context tool.

- The MC number string was 10000000:NEventsQED, so the round robin wrapped the QED event IDs at 10000000 instead of at the number of events the workflow simulates, and the MC labels named QED events which do not exist.
- Both numbers are NEventsQED now, which also repairs the labels on the O2 versions already deployed.

https://its.cern.ch/jira/browse/O2-7132