### PR TITLE
Keep the ZEM geometry instead of skipping the whole ZDC module

### DIFF
--- a/MC/bin/o2dpg_sim_config.py
+++ b/MC/bin/o2dpg_sim_config.py
@@ -183,6 +183,12 @@ def create_geant_config(args, externalConfigString):
     # ----- add default settings -----
 
     add(config, {"MFTBase.buildAlignment" : "true"})
+
+    # Keep the ZEM calorimeters, drop the +-113 m beam line that makes the ZDC
+    # expensive to transport. --with-ZDC asks for the whole thing, and an explicit
+    # "--skipModules ZDC" still removes the module altogether.
+    if not getattr(args, "with_ZDC", False) and "ZDC" not in getattr(args, "skipModules", []):
+        add(config, {"ZDCSimParam.buildBeamLine" : "false"})
     add(config, {"GenTPCLoopers.colsys" : args.col})
 
     # ----- apply external overwrites from command line -------

--- a/MC/bin/o2dpg_sim_workflow.py
+++ b/MC/bin/o2dpg_sim_workflow.py
@@ -110,7 +110,7 @@ parser.add_argument('-j', '--n-workers', dest='n_workers', help='number of worke
 parser.add_argument('--force-n-workers', dest='force_n_workers', action='store_true', help='by default, number of workers is re-computed '
                                                                                            'for given interaction rate; '
                                                                                            'pass this to avoid that')
-parser.add_argument('--skipModules',nargs="*", help="List of modules to skip in geometry budget (and therefore processing)", default=["ZDC"])
+parser.add_argument('--skipModules',nargs="*", help="List of modules to skip in geometry budget (and therefore processing)", default=[])
 parser.add_argument('--skipReadout',nargs="*", help="List of modules to take out from readout", default=[""])
 parser.add_argument('--with-ZDC', action='store_true', help='Enable ZDC in workflow')
 parser.add_argument('-seed',help='random seed number', default=None)
@@ -273,18 +273,12 @@ with open(config_key_param_path, "w") as f:
    print(f"INFO: Written additional config key parameters to JSON {config_key_param_path}")
    json.dump(anchorConfig, f, indent=2)
 
-# Processing skipped material budget (modules):
-# - If user did NOT specify --with-ZDC
-# - AND ZDC is not already in the list
-# --> append ZDC automatically
-if args.with_ZDC:
-   # User wants ZDC to *not* be skipped → ensure it's removed
-   args.skipModules = [m for m in args.skipModules if m != "ZDC"]
-else:
-   # If user did not request --with-ZDC,
-   # auto-append ZDC unless already present
-   if "ZDC" not in args.skipModules:
-      args.skipModules.append("ZDC")
+# The ZDC geometry is the +-113 m beam line, its magnets, ZN, ZP and ZEM. What it
+# costs in transport time is the beam line; ZEM sits at z = 7.6 m and carries
+# 217 kg of material inside the FIT and FDD acceptance. Without --with-ZDC we
+# therefore drop the beam line and keep ZEM, instead of dropping the whole module
+# -- see ZDCSimParam.buildBeamLine in create_geant_config(). ZDC stays out of the
+# readout either way, which the deactivate_detector('ZDC') below takes care of.
 
 # with this we can tailor the workflow to the presence of
 # certain detectors

--- a/MC/run/ANCHOR/anchorMC.sh
+++ b/MC/run/ANCHOR/anchorMC.sh
@@ -344,7 +344,6 @@ fi
 
 # -- CREATE THE MC JOB DESCRIPTION ANCHORED TO RUN --
 
-MODULES="--skipModules ZDC"
 
 # publish MCPRODINFO for first few jobs of a production
 # if external script exported PUBLISH_MCPRODINFO, it will be published anyways

--- a/MC/run/ANCHOR/anchorMC_DataEmbedding.sh
+++ b/MC/run/ANCHOR/anchorMC_DataEmbedding.sh
@@ -300,7 +300,6 @@ fi
 
 # -- CREATE THE MC JOB DESCRIPTION ANCHORED TO RUN --
 
-MODULES="--skipModules ZDC"
 
 # publish MCPRODINFO for first few jobs of a production
 # if external script exported PUBLISH_MCPRODINFO, it will be published anyways


### PR DESCRIPTION
This changes the simulation default from skipping the ZDC module to dropping only its +-113 m beam line, so the ZEM material stays in the transport geometry.

- The ZDC geometry is the +-113 m beam line, its magnets, ZN, ZP and ZEM; the transport cost is the beam line, while ZEM sits at z = 7.6 m.
- ZEM carries 217 kg of material between z = 745 and 862 cm, spanning eta 2.8 to 5.6, which is inside the FIT and FDD acceptance.
- --skipModules no longer defaults to ZDC; create_geant_config() sets ZDCSimParam.buildBeamLine=false instead, unless --with-ZDC is given.
- An explicit --skipModules ZDC still removes the module altogether.
- ZDC stays out of digitisation and reconstruction as before, which the existing deactivate_detector('ZDC') already handles.
- The MODULES variable removed from the two anchor scripts was never referenced; it read as if anchored MC opted out of ZDC, which the workflow default decided.
- Requires ZDCSimParam.buildBeamLine in AliceO2.

https://its.cern.ch/jira/browse/O2-7158