### PR TITLE
Add a few EPOS4 configurations

### DIFF
--- a/MC/config/common/epos4/generator/NeNe_536TeV_EPOS4.optns
+++ b/MC/config/common/epos4/generator/NeNe_536TeV_EPOS4.optns
@@ -1,0 +1,33 @@
+!--------------------------------------------------------------------
+!           Neon-Neon collisions without hydro and with hadronic cascade
+!--------------------------------------------------------------------
+
+!---------------------------------------
+!            Define run
+!---------------------------------------
+
+application hadron !hadron-hadron, hadron-nucleus, or nucleus-nucleus
+set laproj 10  !projectile atomic number
+set maproj 20 !projectile mass number
+set latarg 10 !target atomic number
+set matarg 20 !target mass number
+set ecms 5360 !sqrt(s)_pp
+set istmax 25 !max status considered for storage
+
+ftime on     !string formation time non-zero
+!suppressed decays:
+nodecays
+ 110 20 2130 -2130 2230 -2230 1130 -1130 1330 -1330 2330 -2330 3331 -3331
+end
+
+set ninicon 1            !number of initial conditions used for hydro evolution
+core full                !core/corona activated
+hydro off                !hydro disabled
+eos off                  !eos disabled (epos standard EoS)
+hacas full               !hadronic cascade activated (UrQMD)
+set nfreeze 1            !number of freeze out events per hydro event
+set modsho 1             !printout every modsho events
+set centrality 0         !0=min bias
+set ihepmc 2             !HepMC output enabled on stdout
+fillTree4(C1)            !C1 sets impact parameter as centrality variable
+set nfull 10

--- a/MC/config/common/epos4/generator/OO_536TeV_EPOS4.optns
+++ b/MC/config/common/epos4/generator/OO_536TeV_EPOS4.optns
@@ -1,0 +1,33 @@
+!--------------------------------------------------------------------
+!           Oxygen-Oxygen collisions without hydro and with hadronic cascade
+!--------------------------------------------------------------------
+
+!---------------------------------------
+!            Define run
+!---------------------------------------
+
+application hadron !hadron-hadron, hadron-nucleus, or nucleus-nucleus
+set laproj 8  !projectile atomic number
+set maproj 16 !projectile mass number
+set latarg 8  !target atomic number
+set matarg 16 !target mass number
+set ecms 5360 !sqrt(s)_pp
+set istmax 25 !max status considered for storage
+
+ftime on     !string formation time non-zero
+!suppressed decays:
+nodecays
+ 110 20 2130 -2130 2230 -2230 1130 -1130 1330 -1330 2330 -2330 3331 -3331
+end
+
+set ninicon 1            !number of initial conditions used for hydro evolution
+core full                !core/corona activated
+hydro off                !hydro disabled
+eos off                  !eos disabled (epos standard EoS)
+hacas full               !hadronic cascade activated (UrQMD)
+set nfreeze 1            !number of freeze out events per hydro event
+set modsho 1             !printout every modsho events
+set centrality 0         !0=min bias
+set ihepmc 2             !HepMC output enabled on stdout
+fillTree4(C1)            !C1 sets impact parameter as centrality variable
+set nfull 10

--- a/MC/config/common/epos4/generator/pO_962TeV_EPOS4.optns
+++ b/MC/config/common/epos4/generator/pO_962TeV_EPOS4.optns
@@ -1,0 +1,34 @@
+!--------------------------------------------------------------------
+!           proton-Oxigen collisions at 9.62 TeV without hydro and with hadronic cascade
+!--------------------------------------------------------------------
+
+!---------------------------------------
+!            Define run
+!---------------------------------------
+
+application hadron !hadron-hadron, hadron-nucleus, or nucleus-nucleus
+set laproj 1  !projectile atomic number
+set maproj 1  !projectile mass number
+set latarg 8  !target atomic number
+set matarg 16 !target mass number
+set ecms 9620 !sqrt(s_NN)
+set istmax 25 !max status considered for storage
+
+ftime on     !string formation time non-zero
+!suppressed decays:
+nodecays
+ 110 20 2130 -2130 2230 -2230 1130 -1130 1330 -1330 2330 -2330 3331 -3331
+end
+
+set ninicon 1            !number of initial conditions used for hydro evolution
+core full                !core/corona activated
+hydro off                !hydro disabled
+eos off                  !eos disabled (epos standard EoS)
+hacas full               !hadronic cascade activated (UrQMD)
+set nfreeze 1            !number of freeze out events per hydro event
+set modsho 1             !printout every modsho events
+set centrality 0         !0=min bias
+set ihepmc 2             !HepMC output enabled on stdout
+fillTree4(C1)            !C1 sets impact parameter as centrality variable
+hepmc_rapcms 0.346225    !boost output to real asymmetric p/O beam frame (p: 6800 GeV, O: 3400 GeV)
+set nfull 10

--- a/MC/config/common/epos4/generator/pO_962TeV_EPOS4_hydro.optns
+++ b/MC/config/common/epos4/generator/pO_962TeV_EPOS4_hydro.optns
@@ -1,0 +1,34 @@
+!--------------------------------------------------------------------
+!           proton-Oxigen collisions at 9.62 TeV with hydro and with hadronic cascade
+!--------------------------------------------------------------------
+
+!---------------------------------------
+!            Define run
+!---------------------------------------
+
+application hadron !hadron-hadron, hadron-nucleus, or nucleus-nucleus
+set laproj 1  !projectile atomic number
+set maproj 1  !projectile mass number
+set latarg 8  !target atomic number
+set matarg 16 !target mass number
+set ecms 9620 !sqrt(s_NN)
+set istmax 25 !max status considered for storage
+
+ftime on     !string formation time non-zero
+!suppressed decays:
+nodecays
+ 110 20 2130 -2130 2230 -2230 1130 -1130 1330 -1330 2330 -2330 3331 -3331
+end
+
+set ninicon 1            !number of initial conditions used for hydro evolution
+core full                !core/corona activated
+hydro hlle               !hydro activated
+eos x3ff                 !eos activated (epos standard EoS)
+hacas full               !hadronic cascade activated (UrQMD)
+set nfreeze 1            !number of freeze out events per hydro event
+set modsho 1             !printout every modsho events
+set centrality 0         !0=min bias
+set ihepmc 2             !HepMC output enabled on stdout
+fillTree4(C1)            !C1 sets impact parameter as centrality variable
+hepmc_rapcms 0.346225    !boost output to real asymmetric p/O beam frame (p: 6800 GeV, O: 3400 GeV)
+set nfull 10

--- a/MC/config/common/ini/GeneratorEPOS4NeNe536TeV.ini
+++ b/MC/config/common/ini/GeneratorEPOS4NeNe536TeV.ini
@@ -1,0 +1,12 @@
+#NEV_TEST> 10
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
+funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/epos4/generator/NeNe_536TeV_EPOS4.optns", 2147483647)
+
+[GeneratorFileOrCmd]
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
+bMaxSwitch=none
+
+# Set to version 2 if EPOS4.0.0 is used
+[HepMC]
+version=3

--- a/MC/config/common/ini/GeneratorEPOS4OO536TeV.ini
+++ b/MC/config/common/ini/GeneratorEPOS4OO536TeV.ini
@@ -1,0 +1,12 @@
+#NEV_TEST> 10
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
+funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/epos4/generator/OO_536TeV_EPOS4.optns", 2147483647)
+
+[GeneratorFileOrCmd]
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
+bMaxSwitch=none
+
+# Set to version 2 if EPOS4.0.0 is used
+[HepMC]
+version=3

--- a/MC/config/common/ini/GeneratorEPOS4pO962TeV.ini
+++ b/MC/config/common/ini/GeneratorEPOS4pO962TeV.ini
@@ -1,0 +1,12 @@
+#NEV_TEST> 10
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
+funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/epos4/generator/pO_962TeV_EPOS4.optns", 2147483647)
+
+[GeneratorFileOrCmd]
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
+bMaxSwitch=none
+
+# Set to version 2 if EPOS4.0.0 is used
+[HepMC]
+version=3

--- a/MC/config/common/ini/GeneratorEPOS4pO962TeV_hydro.ini
+++ b/MC/config/common/ini/GeneratorEPOS4pO962TeV_hydro.ini
@@ -1,0 +1,13 @@
+#NEV_TEST> 2
+#---> GeneratorEPOS4pO962TeV
+[GeneratorExternal]
+fileName=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/generator_EPOS4.C
+funcName=generateEPOS4("${O2DPG_MC_CONFIG_ROOT}/MC/config/common/epos4/generator/pO_962TeV_EPOS4_hydro.optns", 2147483647)
+
+[GeneratorFileOrCmd]
+cmd=${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/epos4/epos.sh
+bMaxSwitch=none
+
+# Set to version 2 if EPOS4.0.0 is used
+[HepMC]
+version=3

--- a/MC/config/common/ini/tests/GeneratorEPOS4NeNe536TeV.C
+++ b/MC/config/common/ini/tests/GeneratorEPOS4NeNe536TeV.C
@@ -1,0 +1,78 @@
+int External()
+{
+  std::string path{"o2sim_Kine.root"};
+
+  // Check that file exists, can be opened and has the correct tree
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie())
+  {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree*)file.Get("o2sim");
+  if (!tree)
+  {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+
+  std::vector<o2::MCTrack>* tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  // Check if all events are filled
+  auto nEvents = tree->GetEntries();
+  for (Long64_t i = 0; i < nEvents; ++i)
+  {
+    tree->GetEntry(i);
+    if (tracks->empty())
+    {
+      std::cerr << "Empty entry found at event " << i << "\n";
+      return 1;
+    }
+  }
+
+  // Check if there are 10 events, as customarily set in the ini file
+  // Heavy-ion collisions with hydro and hadronic cascade are very slow to simulate
+  if (nEvents != 10)
+  {
+    std::cerr << "Expected 10 events, got " << nEvents << "\n";
+    return 1;
+  }
+
+  // ---- Neon-Neon parameters ----
+  constexpr int kNeonPDG = 1000100200;     // Ne-20 ion
+  constexpr double kEnucleon = 5360.;      // GeV per nucleon
+  constexpr int kA = 20;                   // Neon mass number
+  constexpr double kNeonEnergy = kA * kEnucleon / 2.0; // beam energy in GeV
+
+  // Check if each event has two neon ions at expected energy
+  for (int i = 0; i < nEvents; i++)
+  {
+    tree->GetEntry(i);
+    int count = 0;
+
+    for (int idxMCTrack = 0; idxMCTrack < tracks->size(); ++idxMCTrack)
+    {
+      auto track = tracks->at(idxMCTrack);
+      double energy = track.GetEnergy();
+
+      // 50 MeV tolerance (floating point safety)
+      if (std::abs(energy - kNeonEnergy) < 5e-2 &&
+          track.GetPdgCode() == kNeonPDG)
+      {
+        count++;
+      }
+    }
+
+    if (count < 2)
+    {
+      std::cerr << "Event " << i
+                << " has less than 2 neon ions at "
+                << kNeonEnergy << " GeV\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/MC/config/common/ini/tests/GeneratorEPOS4OO536TeV.C
+++ b/MC/config/common/ini/tests/GeneratorEPOS4OO536TeV.C
@@ -1,0 +1,78 @@
+int External()
+{
+  std::string path{"o2sim_Kine.root"};
+
+  // Check that file exists, can be opened and has the correct tree
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie())
+  {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree)
+  {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  // Check if all events are filled
+  auto nEvents = tree->GetEntries();
+  for (Long64_t i = 0; i < nEvents; ++i)
+  {
+    tree->GetEntry(i);
+    if (tracks->empty())
+    {
+      std::cerr << "Empty entry found at event " << i << "\n";
+      return 1;
+    }
+  }
+
+  // Check if there are 10 events, as customly set in the ini file
+  // Heavy-ion collisions with hydro and hadronic cascade are very slow to simulate
+  if (nEvents != 10)
+  {
+    std::cerr << "Expected 10 event, got " << nEvents << "\n";
+    return 1;
+  }
+
+  // ---- Oxygen-Oxygen parameters ----
+  constexpr int kOxygenPDG = 1000080160;   // O-16 ion
+  constexpr double kEnucleon = 5360.;      // GeV per nucleon
+  constexpr int kA = 16;                   // Oxygen mass number
+  constexpr double kOxygenEnergy = kA * kEnucleon / 2.0; // 85760 / 2 GeV
+
+  // Check if each event has two oxygen ions at expected energy
+  for (int i = 0; i < nEvents; i++)
+  {
+    tree->GetEntry(i);
+    int count = 0;
+
+    for (int idxMCTrack = 0; idxMCTrack < tracks->size(); ++idxMCTrack)
+    {
+      auto track = tracks->at(idxMCTrack);
+      double energy = track.GetEnergy();
+
+      // 50 MeV tolerance (floating point safety)
+      if (std::abs(energy - kOxygenEnergy) < 5e-2 &&
+          track.GetPdgCode() == kOxygenPDG)
+      {
+        count++;
+      }
+    }
+
+    if (count < 2)
+    {
+      std::cerr << "Event " << i
+                << " has less than 2 oxygen ions at "
+                << kOxygenEnergy << " GeV\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/MC/config/common/ini/tests/GeneratorEPOS4pO962TeV.C
+++ b/MC/config/common/ini/tests/GeneratorEPOS4pO962TeV.C
@@ -1,0 +1,99 @@
+int External()
+{
+  std::string path{"o2sim_Kine.root"};
+
+  // Check that file exists, can be opened and has the correct tree
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie())
+  {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree)
+  {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  // Check if all events are filled
+  auto nEvents = tree->GetEntries();
+  for (Long64_t i = 0; i < nEvents; ++i)
+  {
+    tree->GetEntry(i);
+    if (tracks->empty())
+    {
+      std::cerr << "Empty entry found at event " << i << "\n";
+      return 1;
+    }
+  }
+
+  // Check if there are 10 events, as customly set in the ini file (NEV_TEST)
+  if (nEvents != 10)
+  {
+    std::cerr << "Expected 10 events, got " << nEvents << "\n";
+    return 1;
+  }
+
+  // ---- proton-Oxygen parameters ----
+  // The .optns file boosts the output from the symmetric NN CM frame (where
+  // each nucleon carries ecms/2) to the real asymmetric p/O beam frame via
+  // "hepmc_rapcms <kRapcms>", so E_p = (ecms/2)*exp(+kRapcms) and
+  // E_O-nucleon = (ecms/2)*exp(-kRapcms). Keep kRapcms in sync with the value
+  // set in pO_962TeV_EPOS4.optns / pO_962TeV_EPOS4_hydro.optns.
+  constexpr int kProtonPDG = 2212;
+  constexpr int kOxygenPDG = 1000080160; // O-16 ion
+  constexpr double kEcms = 9620.;        // GeV, sqrt(s_NN) as set in the .optns file
+  constexpr double kRapcms = 0.346225;      // rapidity boost set via hepmc_rapcms
+  constexpr int kA = 16;                 // Oxygen mass number
+  const double kProtonEnergy = (kEcms / 2.0) * std::exp(kRapcms);            // boosted proton energy
+  const double kOxygenEnergy = kA * (kEcms / 2.0) * std::exp(-kRapcms);      // total energy of the O-16 ion
+
+  // Check if each event has one proton and one oxygen ion at expected energies
+  for (int i = 0; i < nEvents; i++)
+  {
+    tree->GetEntry(i);
+    int countProton = 0;
+    int countOxygen = 0;
+
+    for (int idxMCTrack = 0; idxMCTrack < tracks->size(); ++idxMCTrack)
+    {
+      auto track = tracks->at(idxMCTrack);
+      double energy = track.GetEnergy();
+
+      // 1 GeV tolerance (the rapcms boost is applied in single precision in EPOS4)
+      if (std::abs(energy - kProtonEnergy) < 1. &&
+          track.GetPdgCode() == kProtonPDG)
+      {
+        countProton++;
+      }
+      else if (std::abs(energy - kOxygenEnergy) < 1. &&
+               track.GetPdgCode() == kOxygenPDG)
+      {
+        countOxygen++;
+      }
+    }
+
+    if (countProton < 1)
+    {
+      std::cerr << "Event " << i
+                << " has no proton beam particle at "
+                << kProtonEnergy << " GeV\n";
+      return 1;
+    }
+
+    if (countOxygen < 1)
+    {
+      std::cerr << "Event " << i
+                << " has no oxygen ion at "
+                << kOxygenEnergy << " GeV\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/MC/config/common/ini/tests/GeneratorEPOS4pO962TeV_hydro.C
+++ b/MC/config/common/ini/tests/GeneratorEPOS4pO962TeV_hydro.C
@@ -1,0 +1,99 @@
+int External()
+{
+  std::string path{"o2sim_Kine.root"};
+
+  // Check that file exists, can be opened and has the correct tree
+  TFile file(path.c_str(), "READ");
+  if (file.IsZombie())
+  {
+    std::cerr << "Cannot open ROOT file " << path << "\n";
+    return 1;
+  }
+
+  auto tree = (TTree *)file.Get("o2sim");
+  if (!tree)
+  {
+    std::cerr << "Cannot find tree o2sim in file " << path << "\n";
+    return 1;
+  }
+
+  std::vector<o2::MCTrack> *tracks{};
+  tree->SetBranchAddress("MCTrack", &tracks);
+
+  // Check if all events are filled
+  auto nEvents = tree->GetEntries();
+  for (Long64_t i = 0; i < nEvents; ++i)
+  {
+    tree->GetEntry(i);
+    if (tracks->empty())
+    {
+      std::cerr << "Empty entry found at event " << i << "\n";
+      return 1;
+    }
+  }
+
+  // Check if there are 2 events, as customly set in the ini file (NEV_TEST)
+  if (nEvents != 2)
+  {
+    std::cerr << "Expected 2 events, got " << nEvents << "\n";
+    return 1;
+  }
+
+  // ---- proton-Oxygen parameters ----
+  // The .optns file boosts the output from the symmetric NN CM frame (where
+  // each nucleon carries ecms/2) to the real asymmetric p/O beam frame via
+  // "hepmc_rapcms <kRapcms>", so E_p = (ecms/2)*exp(+kRapcms) and
+  // E_O-nucleon = (ecms/2)*exp(-kRapcms). Keep kRapcms in sync with the value
+  // set in pO_962TeV_EPOS4.optns / pO_962TeV_EPOS4_hydro.optns.
+  constexpr int kProtonPDG = 2212;
+  constexpr int kOxygenPDG = 1000080160; // O-16 ion
+  constexpr double kEcms = 9620.;        // GeV, sqrt(s_NN) as set in the .optns file
+  constexpr double kRapcms = 0.346225;   // rapidity boost set via hepmc_rapcms
+  constexpr int kA = 16;                 // Oxygen mass number
+  const double kProtonEnergy = (kEcms / 2.0) * std::exp(kRapcms);            // boosted proton energy
+  const double kOxygenEnergy = kA * (kEcms / 2.0) * std::exp(-kRapcms);      // total energy of the O-16 ion
+
+  // Check if each event has one proton and one oxygen ion at expected energies
+  for (int i = 0; i < nEvents; i++)
+  {
+    tree->GetEntry(i);
+    int countProton = 0;
+    int countOxygen = 0;
+
+    for (int idxMCTrack = 0; idxMCTrack < tracks->size(); ++idxMCTrack)
+    {
+      auto track = tracks->at(idxMCTrack);
+      double energy = track.GetEnergy();
+
+      // 1 GeV tolerance (the rapcms boost is applied in single precision in EPOS4)
+      if (std::abs(energy - kProtonEnergy) < 1. &&
+          track.GetPdgCode() == kProtonPDG)
+      {
+        countProton++;
+      }
+      else if (std::abs(energy - kOxygenEnergy) < 1. &&
+               track.GetPdgCode() == kOxygenPDG)
+      {
+        countOxygen++;
+      }
+    }
+
+    if (countProton < 1)
+    {
+      std::cerr << "Event " << i
+                << " has no proton beam particle at "
+                << kProtonEnergy << " GeV\n";
+      return 1;
+    }
+
+    if (countOxygen < 1)
+    {
+      std::cerr << "Event " << i
+                << " has no oxygen ion at "
+                << kOxygenEnergy << " GeV\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
EPOS4 physics generation always happens internally in the symmetric nucleon-nucleon CM frame. hepmc_rapcms does not change that internal physics, but it applies a rigid rapidity boost (dy = -hepmc_rapcms, applied in src/KW/out.f → fillhepmc) to every particle written to output, which means re-expressing the same collision in the lab frame. This is here used for pO and should be used for p-Pb as well (the shift there is 0.465, from the same `Δy = 0.5·ln(E_p/E_target-per-nucleon` formula).