### PR TITLE
Fix reassignment of mother indices after pruning HF events in embedding

### DIFF
--- a/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
+++ b/MC/config/PWGHF/external/generator/generator_pythia8_embed_hf.C
@@ -280,7 +280,7 @@ Bool_t importParticles() override
 
         /// Establish if this particle comes from charm or beauty
         /// If not, ignore this particle and increase the number of discarded particles from the pp event
-        if(!isFromCharmOrBeauty(iPart, particlesHfEvent)) {
+        if(!(nEvsHF == 0 && iPart < 1) && !isFromCharmOrBeauty(iPart, particlesHfEvent)) {
             continue;
         }
         /// if we arrive here, then the current particle is from charm or beauty, keep it!
@@ -314,11 +314,13 @@ Bool_t importParticles() override
             idFirstMother = findKey(mapHfParticles, idFirstMother);
             /// If idFirstMother>=0, the 1st mother is from charm or beauty, i.e. is not a light-flavoured parton
             /// Instead, if idFirstMother==-1 from findKey this means that the first mother was a light-flavoured parton --> not stored in the map
-            if(idFirstMother >=0) {
+            if(idFirstMother >= 0) {
                 /// the 1st mother is from charm or beauty, i.e. is not a light-flavoured parton
                 if(idLastMother != idFirstMotherOrig) {
-                    if(idLastMother != -1) {
-                        /// idLastMother is >= 0
+                    idLastMother = findKey(mapHfParticles, idLastMother);
+                    if(idLastMother < 0) {
+                        // second mother not found, we set it to 0
+                        idLastMother = 0;
                     }
                 } else {
                     /// idLastMother is equal to idFirstMother
@@ -343,15 +345,17 @@ Bool_t importParticles() override
                 const int idMother = findKey(mapHfParticles, idMotherOrig);
                 if(idMother >= 0) {
                     /// this should mean that the mother is from HF, i.e. that we found the correct one
-                    idFirstMother = idMother;
-                    idLastMother = idFirstMother;
+                    if (idFirstMother < 0) {
+                        idFirstMother = idMother;
+                    }
+                    idLastMother = idMother;
                     foundAnyMother = true;
-                    break;
                 }
             }
-            // set last mother to -1 if no mother has been found so far
+            // set last mother to 0 if no mother has been found so far
             if (!foundAnyMother) {
-                idLastMother = -1;
+                idLastMother = 0;
+                idFirstMother = 0;
             }
         }
 
@@ -360,10 +364,10 @@ Bool_t importParticles() override
         idLastDaughter = findKey(mapHfParticles, idLastDaughter);
 
         /// adjust the particle mother and daughter indices
-        particle.SetFirstMother((idFirstMother >= 0) ? idFirstMother + offset : idFirstMother);
-        particle.SetLastMother((idLastMother >= 0) ? idLastMother + offset : idLastMother);
-	    particle.SetFirstDaughter((idFirstDaughter >= 0) ? idFirstDaughter + offset : idFirstDaughter);
-	    particle.SetLastDaughter((idLastDaughter >= 0) ? idLastDaughter + offset : idLastDaughter);
+        particle.SetFirstMother((idFirstMother > 0) ? idFirstMother + offset : idFirstMother);
+        particle.SetLastMother((idLastMother > 0) ? idLastMother + offset : idLastMother);
+	    particle.SetFirstDaughter((idFirstDaughter > 0) ? idFirstDaughter + offset : idFirstDaughter);
+	    particle.SetLastDaughter((idLastDaughter > 0) ? idLastDaughter + offset : idLastDaughter);
 
         /// copy inside this.mParticles from mGeneratorEvHF.mParticles, i.e. the particles generated in mGeneratorEvHF
         mParticles.push_back(particle);
@@ -371,10 +375,10 @@ Bool_t importParticles() override
       }
 
       // for debug
-      // LOG(info) << "-----------------------------------------------";
-      // LOG(info) << "============ After HF event " << nEvsHF;
-      // LOG(info) << "Full stack:";
-      // printParticleVector(mParticles);
+    //   LOG(info) << "-----------------------------------------------";
+    //   LOG(info) << "============ After HF event " << nEvsHF;
+    //   LOG(info) << "Full stack:";
+    //   printParticleVector(mParticles);
 
       /// one more event generated, let's update the counter and clear it, to allow the next generation
       nEvsHF++;


### PR DESCRIPTION
This PR fixes an issue observed by @fchinu, namely the fact that in embedded MCs we often have the second mother id that is wrong. An example of this behaviour can be seen in the following log:
```
[10:51:46][INFO]    id = 0, pdgCode = 5 --> idFirstMother=-1, idLastMother=-1, idFirstDaughter=2, idLastDaughter=2
[10:51:46][INFO]    id = 1, pdgCode = -5 --> idFirstMother=-1, idLastMother=-1, idFirstDaughter=3, idLastDaughter=3
[10:51:46][INFO]    id = 2, pdgCode = 5 --> idFirstMother=0, idLastMother=0, idFirstDaughter=4, idLastDaughter=4
[10:51:46][INFO]    id = 3, pdgCode = -5 --> idFirstMother=1, idLastMother=1, idFirstDaughter=5, idLastDaughter=5
[10:51:46][INFO]    id = 4, pdgCode = 5 --> idFirstMother=2, idLastMother=2, idFirstDaughter=6, idLastDaughter=6
[10:51:46][INFO]    id = 5, pdgCode = -5 --> idFirstMother=3, idLastMother=3, idFirstDaughter=8, idLastDaughter=8
[10:51:46][INFO]    id = 6, pdgCode = 5 --> idFirstMother=4, idLastMother=4, idFirstDaughter=7, idLastDaughter=7
[10:51:46][INFO]    id = 7, pdgCode = 5 --> idFirstMother=6, idLastMother=6, idFirstDaughter=10, idLastDaughter=10
[10:51:46][INFO]    id = 8, pdgCode = -5 --> idFirstMother=5, idLastMother=5, idFirstDaughter=9, idLastDaughter=-1
[10:51:46][INFO]    id = 9, pdgCode = -5 --> idFirstMother=-1, idLastMother=-1, idFirstDaughter=11, idLastDaughter=11
[10:51:46][INFO]    id = 10, pdgCode = 5 --> idFirstMother=7, idLastMother=7, idFirstDaughter=-1, idLastDaughter=-1
[10:51:46][INFO]    id = 11, pdgCode = -5 --> idFirstMother=9, idLastMother=9, idFirstDaughter=13, idLastDaughter=-1
[10:51:46][INFO]    id = 12, pdgCode = 5 --> idFirstMother=-1, idLastMother=-1, idFirstDaughter=15, idLastDaughter=-1
[10:51:46][INFO]    id = 13, pdgCode = -5201 --> idFirstMother=11, idLastMother=348, idFirstDaughter=22, idLastDaughter=22
[10:51:46][INFO]    id = 14, pdgCode = 2101 --> idFirstMother=12, idLastMother=12, idFirstDaughter=17, idLastDaughter=18
```
where you can see that particle `13` has mothers `11->348`, which makes no sense (since this includes the particle itself and many more particles that are not even in the stack, that has 89 particles in total).

It also fixes the issue of `motherId = -1`, that does not exist as case in PYTHIA (see https://pythia8.web.cern.ch/manuals/pythia8317/Welcome.html -> Study output -> Particle Properties)

The issue has been solved at the analysis level by @fchinu adding the possibility to look only at the first daughter in https://github.com/AliceO2Group/O2Physics/pull/17816 (enough for decay chains of hadrons, not to go up to the parton shower).
@gluparel @xinyepeng @stefanopolitano @zhangbiao-phy I would suggest that you include this change in new HF MC productions for PbPb (e.g. the one anchored to 2025), for the existing ones I believe that we can stay with the fix by Fabrizio C. at the analysis level.

Tagging @mfaggin for info